### PR TITLE
Fix integer overflow in IsIoReadWriteAllowed()

### DIFF
--- a/MmSupervisorPkg/Library/SmmPolicyGateLib/SmmPolicyGateLib.c
+++ b/MmSupervisorPkg/Library/SmmPolicyGateLib/SmmPolicyGateLib.c
@@ -15,6 +15,7 @@
 #include <Library/DebugLib.h>
 #include <Library/SmmPolicyGateLib.h>
 #include <Library/SysCallLib.h>
+#include <Library/SafeIntLib.h>
 
 /**
   Given an IO port address and size, determine if the request is allowed by
@@ -50,6 +51,7 @@ IsIoReadWriteAllowed (
   UINT32                                     IoSize        = 0;
   UINT32                                     i;
   BOOLEAN                                    FoundMatch = FALSE;
+  UINT16                                     Dummy;
 
   //
   // Check to ensure that only one of SECURE_POLICY_RESOURCE_ATTR_READ
@@ -74,6 +76,27 @@ IsIoReadWriteAllowed (
     IoSize = sizeof (UINT32);
   } else {
     DEBUG ((DEBUG_ERROR, "%a Invalid Access Mask specified.\n", __FUNCTION__));
+    Status = EFI_INVALID_PARAMETER;
+    goto Exit;
+  }
+
+  //
+  // Check to ensure the starting IO port number is within the range of 16bit value
+  //
+  Status = SafeUint32ToUint16 (IoAddress, &Dummy);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Invalid IO address supplied - port: 0x%x.\n", __FUNCTION__, IoAddress));
+    Status = EFI_INVALID_PARAMETER;
+    goto Exit;
+  }
+
+  //
+  // Check to ensure the ending IO port number is within the range of 16bit value
+  // The MAX_UINT16 + 1 is because access 1 byte at 0xFFFF is still legit, if needed
+  //
+  if (IoAddress + IoSize > MAX_UINT16 + 1) {
+    // IO port 0xFFFF with width of
+    DEBUG ((DEBUG_ERROR, "%a Invalid IO address range supplied - port: 0x%x, width: 0x%x.\n", __FUNCTION__, IoAddress, IoSize));
     Status = EFI_INVALID_PARAMETER;
     goto Exit;
   }

--- a/MmSupervisorPkg/Library/SmmPolicyGateLib/SmmPolicyGateLib.c
+++ b/MmSupervisorPkg/Library/SmmPolicyGateLib/SmmPolicyGateLib.c
@@ -95,7 +95,6 @@ IsIoReadWriteAllowed (
   // The MAX_UINT16 + 1 is because access 1 byte at 0xFFFF is still legit, if needed
   //
   if (IoAddress + IoSize > MAX_UINT16 + 1) {
-    // IO port 0xFFFF with width of
     DEBUG ((DEBUG_ERROR, "%a Invalid IO address range supplied - port: 0x%x, width: 0x%x.\n", __FUNCTION__, IoAddress, IoSize));
     Status = EFI_INVALID_PARAMETER;
     goto Exit;

--- a/MmSupervisorPkg/Library/SmmPolicyGateLib/SmmPolicyGateLib.inf
+++ b/MmSupervisorPkg/Library/SmmPolicyGateLib/SmmPolicyGateLib.inf
@@ -28,6 +28,7 @@
 
 [LibraryClasses]
   DebugLib
+  SafeIntLib
 
 [BuildOptions]
 #  DEBUG_*_*_CC_FLAGS  = /FAcs

--- a/MmSupervisorPkg/Library/SmmPolicyGateLib/UnitTest/SmmPolicyGateLibUnitTest.c
+++ b/MmSupervisorPkg/Library/SmmPolicyGateLib/UnitTest/SmmPolicyGateLibUnitTest.c
@@ -1,0 +1,579 @@
+/** @file
+  Unit tests of the instance in MmSupervisorPkg of the SmmPolicyGateLib class
+
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <Uefi.h>
+#include <SmmSecurePolicy.h>
+#include <Protocol/MmCpuIo.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+#include <Library/UnitTestLib.h>
+#include <Library/SmmPolicyGateLib.h>
+
+#define UNIT_TEST_APP_NAME     "SmmPolicyGateLib Unit Tests"
+#define UNIT_TEST_APP_VERSION  "1.0"
+
+typedef struct {
+  SMM_SUPV_SECURE_POLICY_DATA_V1_0    *Policy;
+} TEST_CONTEXT_POLICY;
+
+SMM_SUPV_SECURE_POLICY_DATA_V1_0  mTestPolicyTemplate = {
+  .VersionMinor     = 0x0000,
+  .VersionMajor     = 0x0001,
+  .PolicyRootOffset = sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0),
+};
+
+SMM_SUPV_POLICY_ROOT_V1  mTestPolicyRootTemplate = {
+  .Version        = 1,
+  .PolicyRootSize = sizeof (SMM_SUPV_POLICY_ROOT_V1),
+};
+
+/*
+  Helper function to create a test policy with single 8bit read-allow IO entry of port 0x72
+*/
+UNIT_TEST_STATUS
+EFIAPI
+CreateSingleIoPolicy (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  SMM_SUPV_SECURE_POLICY_DATA_V1_0           *TestPolicy;
+  SMM_SUPV_POLICY_ROOT_V1                    *TestPolicyRoot;
+  SMM_SUPV_SECURE_POLICY_IO_DESCRIPTOR_V1_0  *IoPolicy;
+  UINT32                                     PolicySize;
+
+  PolicySize = sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0) +
+               sizeof (SMM_SUPV_POLICY_ROOT_V1) +
+               sizeof (SMM_SUPV_SECURE_POLICY_IO_DESCRIPTOR_V1_0);
+
+  TestPolicy = AllocatePool (PolicySize);
+  CopyMem (TestPolicy, &mTestPolicyTemplate, sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0));
+  TestPolicy->PolicyRootCount = 1;
+  TestPolicy->Size            = PolicySize;
+
+  TestPolicyRoot = (SMM_SUPV_POLICY_ROOT_V1 *)(TestPolicy + 1);
+  CopyMem (TestPolicyRoot, &mTestPolicyRootTemplate, sizeof (SMM_SUPV_POLICY_ROOT_V1));
+  TestPolicyRoot->AccessAttr = SMM_SUPV_ACCESS_ATTR_ALLOW;
+  TestPolicyRoot->Count      = 1;
+  TestPolicyRoot->Type       = SMM_SUPV_SECURE_POLICY_DESCRIPTOR_TYPE_IO;
+  TestPolicyRoot->Offset     = sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0) + sizeof (SMM_SUPV_POLICY_ROOT_V1);
+
+  IoPolicy                = (SMM_SUPV_SECURE_POLICY_IO_DESCRIPTOR_V1_0 *)(TestPolicyRoot + 1);
+  IoPolicy->Attributes    = SECURE_POLICY_RESOURCE_ATTR_READ;
+  IoPolicy->IoAddress     = 0x72;
+  IoPolicy->LengthOrWidth = 1;
+
+  ((TEST_CONTEXT_POLICY *)Context)->Policy = TestPolicy;
+
+  return UNIT_TEST_PASSED;
+}
+
+/*
+  Helper function to create a test policy with one read-allow MSR entry of 2 contiguous registers starting at 0xC0000080
+*/
+UNIT_TEST_STATUS
+EFIAPI
+CreateSingleMsrPolicy (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  SMM_SUPV_SECURE_POLICY_DATA_V1_0            *TestPolicy;
+  SMM_SUPV_POLICY_ROOT_V1                     *TestPolicyRoot;
+  SMM_SUPV_SECURE_POLICY_MSR_DESCRIPTOR_V1_0  *MsrPolicy;
+  UINT32                                      PolicySize;
+
+  PolicySize = sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0) +
+               sizeof (SMM_SUPV_POLICY_ROOT_V1) +
+               sizeof (SMM_SUPV_SECURE_POLICY_MSR_DESCRIPTOR_V1_0);
+
+  TestPolicy = AllocatePool (PolicySize);
+  CopyMem (TestPolicy, &mTestPolicyTemplate, sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0));
+  TestPolicy->PolicyRootCount = 1;
+  TestPolicy->Size            = PolicySize;
+
+  TestPolicyRoot = (SMM_SUPV_POLICY_ROOT_V1 *)(TestPolicy + 1);
+  CopyMem (TestPolicyRoot, &mTestPolicyRootTemplate, sizeof (SMM_SUPV_POLICY_ROOT_V1));
+  TestPolicyRoot->AccessAttr = SMM_SUPV_ACCESS_ATTR_ALLOW;
+  TestPolicyRoot->Count      = 1;
+  TestPolicyRoot->Type       = SMM_SUPV_SECURE_POLICY_DESCRIPTOR_TYPE_MSR;
+  TestPolicyRoot->Offset     = sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0) + sizeof (SMM_SUPV_POLICY_ROOT_V1);
+
+  MsrPolicy             = (SMM_SUPV_SECURE_POLICY_MSR_DESCRIPTOR_V1_0 *)(TestPolicyRoot + 1);
+  MsrPolicy->Attributes = SECURE_POLICY_RESOURCE_ATTR_READ;
+  MsrPolicy->MsrAddress = 0xC0000080;
+  MsrPolicy->Length     = 2;
+
+  ((TEST_CONTEXT_POLICY *)Context)->Policy = TestPolicy;
+
+  return UNIT_TEST_PASSED;
+}
+
+/*
+  Helper function to create a test policy with one execution-allow instruction entry of CLI
+*/
+UNIT_TEST_STATUS
+EFIAPI
+CreateSingleInsPolicy (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  SMM_SUPV_SECURE_POLICY_DATA_V1_0                    *TestPolicy;
+  SMM_SUPV_POLICY_ROOT_V1                             *TestPolicyRoot;
+  SMM_SUPV_SECURE_POLICY_INSTRUCTION_DESCRIPTOR_V1_0  *InstructionPolicy;
+  UINT32                                              PolicySize;
+
+  PolicySize = sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0) +
+               sizeof (SMM_SUPV_POLICY_ROOT_V1) +
+               sizeof (SMM_SUPV_SECURE_POLICY_INSTRUCTION_DESCRIPTOR_V1_0);
+
+  TestPolicy = AllocatePool (PolicySize);
+  CopyMem (TestPolicy, &mTestPolicyTemplate, sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0));
+  TestPolicy->PolicyRootCount = 1;
+  TestPolicy->Size            = PolicySize;
+
+  TestPolicyRoot = (SMM_SUPV_POLICY_ROOT_V1 *)(TestPolicy + 1);
+  CopyMem (TestPolicyRoot, &mTestPolicyRootTemplate, sizeof (SMM_SUPV_POLICY_ROOT_V1));
+  TestPolicyRoot->AccessAttr = SMM_SUPV_ACCESS_ATTR_ALLOW;
+  TestPolicyRoot->Count      = 1;
+  TestPolicyRoot->Type       = SMM_SUPV_SECURE_POLICY_DESCRIPTOR_TYPE_INSTRUCTION;
+  TestPolicyRoot->Offset     = sizeof (SMM_SUPV_SECURE_POLICY_DATA_V1_0) + sizeof (SMM_SUPV_POLICY_ROOT_V1);
+
+  InstructionPolicy                   = (SMM_SUPV_SECURE_POLICY_INSTRUCTION_DESCRIPTOR_V1_0 *)(TestPolicyRoot + 1);
+  InstructionPolicy->Attributes       = SECURE_POLICY_RESOURCE_ATTR_EXECUTE;
+  InstructionPolicy->InstructionIndex = SECURE_POLICY_INSTRUCTION_CLI;
+
+  ((TEST_CONTEXT_POLICY *)Context)->Policy = TestPolicy;
+
+  return UNIT_TEST_PASSED;
+}
+
+/*
+  Helper function to clean up prepared policy, if needed.
+*/
+VOID
+EFIAPI
+ClearTestPolicy (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  TEST_CONTEXT_POLICY  *PolicyCntx;
+
+  PolicyCntx = (TEST_CONTEXT_POLICY *)Context;
+  if ((PolicyCntx != NULL) && (PolicyCntx->Policy != NULL)) {
+    FreePool (PolicyCntx->Policy);
+  }
+}
+
+/**
+  Unit test for IsIoReadWriteAllowed () API of the SmmPolicyGateLib against allow list.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+PolicyGateMatchEntryOnAllowIoList (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  TEST_CONTEXT_POLICY  *PolicyCntx;
+  EFI_STATUS           Status;
+
+  PolicyCntx = (TEST_CONTEXT_POLICY *)Context;
+
+  // Test IO read on test policy
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0x72, MM_IO_UINT8, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  // Test IO write on test policy
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0x72, MM_IO_UINT8, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  // Test IO read not on test policy, should fail
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0x71, MM_IO_UINT8, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  // Test IO read not on test policy, should fail
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0x71, MM_IO_UINT8, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Unit test for IsIoReadWriteAllowed () API of the SmmPolicyGateLib against deny list.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+PolicyGateMatchEntryOnDenyIoList (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  TEST_CONTEXT_POLICY  *PolicyCntx;
+  EFI_STATUS           Status;
+
+  PolicyCntx = (TEST_CONTEXT_POLICY *)Context;
+
+  // Change the root access attribute to deny list
+  ((SMM_SUPV_POLICY_ROOT_V1 *)(PolicyCntx->Policy + 1))->AccessAttr = SMM_SUPV_ACCESS_ATTR_DENY;
+
+  // Test IO read on test policy
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0x72, MM_IO_UINT8, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  // Test IO write on test policy
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0x72, MM_IO_UINT8, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  // Test IO read not on test policy, should pass
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0x71, MM_IO_UINT8, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  // Test IO read not on test policy, should pass
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0x71, MM_IO_UINT8, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Unit test for IsIoReadWriteAllowed () API of the SmmPolicyGateLib against overflow requests.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+PolicyGateOnOverflowIoRequests (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  TEST_CONTEXT_POLICY  *PolicyCntx;
+  EFI_STATUS           Status;
+
+  PolicyCntx = (TEST_CONTEXT_POLICY *)Context;
+
+  // Test uint32 IO overflow read on test policy
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0xFFFD, MM_IO_UINT32, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_INVALID_PARAMETER);
+
+  // Test uint16 IO overflow read on test policy
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0xFFFF, MM_IO_UINT16, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_INVALID_PARAMETER);
+
+  // Test uint8 on edge IO write on test policy
+  Status = IsIoReadWriteAllowed (PolicyCntx->Policy, 0xFFFF, MM_IO_UINT8, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Unit test for IsMsrReadWriteAllowed () API of the SmmPolicyGateLib against allow list.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+PolicyGateMatchEntryOnAllowMsrList (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  TEST_CONTEXT_POLICY  *PolicyCntx;
+  EFI_STATUS           Status;
+
+  PolicyCntx = (TEST_CONTEXT_POLICY *)Context;
+
+  // Test MSR read on test policy
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0xC0000080, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  // Test MSR read on test policy in entry range
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0xC0000081, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  // Test MSR write on test policy
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0xC0000080, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  // Test MSR read on test policy in entry range
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0xC0000081, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  // Test MSR read not on test policy, should fail
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0x00000071, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  // Test IO read not on test policy, should fail
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0x00000071, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Unit test for IsMsrReadWriteAllowed () API of the SmmPolicyGateLib against deny list.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+PolicyGateMatchEntryOnDenyMsrList (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  TEST_CONTEXT_POLICY  *PolicyCntx;
+  EFI_STATUS           Status;
+
+  PolicyCntx = (TEST_CONTEXT_POLICY *)Context;
+
+  // Change the root access attribute to deny list
+  ((SMM_SUPV_POLICY_ROOT_V1 *)(PolicyCntx->Policy + 1))->AccessAttr = SMM_SUPV_ACCESS_ATTR_DENY;
+
+  // Test MSR read on test policy
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0xC0000080, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  // Test MSR read on test policy in entry range
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0xC0000081, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  // Test MSR write on test policy
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0xC0000080, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  // Test MSR read on test policy in entry range
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0xC0000081, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  // Test MSR read not on test policy, should fail
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0x00000071, SECURE_POLICY_RESOURCE_ATTR_READ);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  // Test IO read not on test policy, should fail
+  Status = IsMsrReadWriteAllowed (PolicyCntx->Policy, 0x00000071, SECURE_POLICY_RESOURCE_ATTR_WRITE);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Unit test for IsInstructionExecutionAllowed () API of the SmmPolicyGateLib against allow list.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+PolicyGateMatchEntryOnAllowInsList (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  TEST_CONTEXT_POLICY  *PolicyCntx;
+  EFI_STATUS           Status;
+
+  PolicyCntx = (TEST_CONTEXT_POLICY *)Context;
+
+  // Test instruction execution on test policy
+  Status = IsInstructionExecutionAllowed (PolicyCntx->Policy, SECURE_POLICY_INSTRUCTION_CLI);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  // Test instruction execution not on test policy
+  Status = IsInstructionExecutionAllowed (PolicyCntx->Policy, SECURE_POLICY_INSTRUCTION_HLT);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Unit test for IsInstructionExecutionAllowed () API of the SmmPolicyGateLib against deny list.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+PolicyGateMatchEntryOnDenyInsList (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  TEST_CONTEXT_POLICY  *PolicyCntx;
+  EFI_STATUS           Status;
+
+  PolicyCntx = (TEST_CONTEXT_POLICY *)Context;
+
+  // Change the root access attribute to deny list
+  ((SMM_SUPV_POLICY_ROOT_V1 *)(PolicyCntx->Policy + 1))->AccessAttr = SMM_SUPV_ACCESS_ATTR_DENY;
+
+  // Test instruction execution on test policy
+  Status = IsInstructionExecutionAllowed (PolicyCntx->Policy, SECURE_POLICY_INSTRUCTION_CLI);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_ACCESS_DENIED);
+
+  // Test instruction execution not on test policy
+  Status = IsInstructionExecutionAllowed (PolicyCntx->Policy, SECURE_POLICY_INSTRUCTION_HLT);
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize the unit test framework, suite, and unit tests for the
+  SmmPolicyGateLib and run the SmmPolicyGateLib unit test.
+
+  @retval  EFI_SUCCESS           All test cases were dispatched.
+  @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                 initialize the unit tests.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+UnitTestingEntry (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      PolicyGateTests;
+  TEST_CONTEXT_POLICY         PolicyContext;
+
+  Framework            = NULL;
+  PolicyContext.Policy = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_APP_NAME, UNIT_TEST_APP_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_APP_NAME, gEfiCallerBaseName, UNIT_TEST_APP_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Populate the SmmPolicyGateLib Unit Test Suite.
+  //
+  Status = CreateUnitTestSuite (&PolicyGateTests, Framework, "SmmPolicyGateLib Request Tests", "SmmPolicyGateLib.Request", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for PolicyGateTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  //
+  // --------------Suite-----------Description--------------Name----------Function--------Pre---Post-------------------Context-----------
+  //
+  AddTestCase (PolicyGateTests, "Policy gate should catch requests listed on allow IO policy", "AllowIO", PolicyGateMatchEntryOnAllowIoList, CreateSingleIoPolicy, ClearTestPolicy, &PolicyContext);
+  AddTestCase (PolicyGateTests, "Policy gate should catch requests listed on deny IO policy", "DenyIO", PolicyGateMatchEntryOnDenyIoList, CreateSingleIoPolicy, ClearTestPolicy, &PolicyContext);
+  AddTestCase (PolicyGateTests, "Policy gate should catch potentially overflow IO request", "OverflowIO", PolicyGateOnOverflowIoRequests, CreateSingleIoPolicy, ClearTestPolicy, &PolicyContext);
+  AddTestCase (PolicyGateTests, "Policy gate should catch requests listed on allow MSR policy", "AllowMsr", PolicyGateMatchEntryOnAllowMsrList, CreateSingleMsrPolicy, ClearTestPolicy, &PolicyContext);
+  AddTestCase (PolicyGateTests, "Policy gate should catch requests listed on deny MSR policy", "DenyMsr", PolicyGateMatchEntryOnDenyMsrList, CreateSingleMsrPolicy, ClearTestPolicy, &PolicyContext);
+  AddTestCase (PolicyGateTests, "Policy gate should catch requests listed on allow Instruction policy", "AllowIns", PolicyGateMatchEntryOnAllowInsList, CreateSingleInsPolicy, ClearTestPolicy, &PolicyContext);
+  AddTestCase (PolicyGateTests, "Policy gate should catch requests listed on deny Instruction policy", "DenyIns", PolicyGateMatchEntryOnDenyInsList, CreateSingleInsPolicy, ClearTestPolicy, &PolicyContext);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UnitTestingEntry ();
+}

--- a/MmSupervisorPkg/Library/SmmPolicyGateLib/UnitTest/SmmPolicyGateLibUnitTest.inf
+++ b/MmSupervisorPkg/Library/SmmPolicyGateLib/UnitTest/SmmPolicyGateLibUnitTest.inf
@@ -1,0 +1,35 @@
+## @file
+# Unit tests of the instance in MmSupervisorPkg of the SmmPolicyGateLib class
+#
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = SmmPolicyGateLibUnitTest
+  FILE_GUID                      = F9A41C48-FEDD-4416-8605-40B9247BF048
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SmmPolicyGateLibUnitTest.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MmSupervisorPkg/MmSupervisorPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  SmmPolicyGateLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  UnitTestLib

--- a/MmSupervisorPkg/MmSupervisorPkg.ci.yaml
+++ b/MmSupervisorPkg/MmSupervisorPkg.ci.yaml
@@ -26,6 +26,7 @@
             "MmSupervisorPkg/MmSupervisorPkg.dec"
         ],
         "AcceptableDependencies-HOST_APPLICATION":[ # for host based unit tests
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
         ],
         "AcceptableDependencies-UEFI_APPLICATION": [
             "ShellPkg/ShellPkg.dec",
@@ -40,12 +41,23 @@
         "DscPath": "MmSupervisorPkg.dsc"
     },
 
+    ## options defined ci/Plugin/HostUnitTestCompilerPlugin
+    "HostUnitTestCompilerPlugin": {
+        "DscPath": "Test/MmSupervisorPkgHostTest.dsc"
+    },
+
     ## options defined ci/Plugin/GuidCheck
     "GuidCheck": {
         "IgnoreGuidName": [],
         "IgnoreGuidValue": [],
         "IgnoreFoldersAndFiles": [],
         "IgnoreDuplicates": []
+    },
+
+    ## options defined ci/Plugin/HostUnitTestDscCompleteCheck
+    "HostUnitTestDscCompleteCheck": {
+        "IgnoreInf": [""],
+        "DscPath": "Test/MmSupervisorPkgHostTest.dsc"
     },
 
     ## options defined ci/Plugin/LibraryClassCheck

--- a/MmSupervisorPkg/Test/MmSupervisorPkgHostTest.dsc
+++ b/MmSupervisorPkg/Test/MmSupervisorPkgHostTest.dsc
@@ -1,0 +1,33 @@
+# *******************************************************************************
+# Host Based Unit Test DSC file for MmSupervisorPkg.
+#
+# Copyright(C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) Microsoft Corporation.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# *******************************************************************************
+
+
+
+[Defines]
+  PLATFORM_NAME                  = MmSupervisor
+  PLATFORM_GUID                  = 364AEF2C-2051-4466-8DDB-4DC3600F3BA0
+  PLATFORM_VERSION               = 1.0
+  DSC_SPECIFICATION              = 0x0001001A
+  OUTPUT_DIRECTORY               = Build/MmSupervisorPkg/HostTest
+  SUPPORTED_ARCHITECTURES        = IA32|X64
+  BUILD_TARGETS                  = NOOPT
+  SKUID_IDENTIFIER               = DEFAULT
+
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+
+[LibraryClasses]
+  SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+
+[Components]
+  MmSupervisorPkg/Library/SmmPolicyGateLib/UnitTest/SmmPolicyGateLibUnitTest.inf {
+    <LibraryClasses>
+      SmmPolicyGateLib|MmSupervisorPkg/Library/SmmPolicyGateLib/SmmPolicyGateLib.inf
+  }


### PR DESCRIPTION
Bug Description:
The supervisor calls IsIoReadWriteAllowed() to see if a user can read or write to specific io ports. The code looks pretty decent; however, a few minor things seem wrong. There's some weirdness around casting and truncating when calling it (and when later using the ioports), which looks kinda bad, but ultimately it doesn't seem to cause many problems.

When validating the ioport and size, there is an integer overflow. It will overflow if the port is really big (0xfffffffd or larger). If there is a policy to allow writes to low ports (e.g., 0), then it could allow writing to a high port (e.g., 65535, 0xffffffff truncated to 16 bits). Ultimately this is a really specific set of circumstances and probably not that big of a deal, but it does look like a clear bug that should be addressed.

Fix:
A safe int function to convert port (IoAddress) to prevent any integer overflow from occurring. Also added an integer overflow check as a defense in depth mechanism.

fixes #6 