### PR TITLE
Fixed global length field updated even allocation in MmInstallConfigurationTable() failed

### DIFF
--- a/MmSupervisorPkg/Core/Misc/InstallConfigurationTable.c
+++ b/MmSupervisorPkg/Core/Misc/InstallConfigurationTable.c
@@ -40,6 +40,7 @@ MmInstallConfigurationTable (
   )
 {
   UINTN                    Index;
+  UINTN                    TempSize;
   EFI_CONFIGURATION_TABLE  *ConfigurationTable;
   EFI_CONFIGURATION_TABLE  *OldTable;
 
@@ -105,14 +106,19 @@ MmInstallConfigurationTable (
       //
       // Allocate a table with one additional entry.
       //
-      mMmSystemTableAllocateSize += (CONFIG_TABLE_SIZE_INCREASED * sizeof (EFI_CONFIGURATION_TABLE));
-      ConfigurationTable          = AllocatePool (mMmSystemTableAllocateSize);
+      TempSize           = mMmSystemTableAllocateSize + (CONFIG_TABLE_SIZE_INCREASED * sizeof (EFI_CONFIGURATION_TABLE));
+      ConfigurationTable = AllocatePool (TempSize);
       if (ConfigurationTable == NULL) {
         //
         // If a new table could not be allocated, then return an error.
         //
         return EFI_OUT_OF_RESOURCES;
       }
+
+      //
+      // Only update the global after confirming the allocation is successful
+      //
+      mMmSystemTableAllocateSize = TempSize;
 
       if (gMmCoreMmst.MmConfigurationTable != NULL) {
         //


### PR DESCRIPTION
Bug Description:
MmInstallConfigurationTable() is called by the supervisor to allow user space to install configuration tables. It looks up the guid, and if it can't find it in the current table, it adds an entry. If there is no room left in the tables, they get reallocated to account for extra space. This reallocation has an interesting logic error. It updates the global variable (mMmSystemTableAllocateSize) that holds the table's max size prior to allocation. If the allocation fails (and hence no reallocation occurs), the global size variable isn't reset. This means the next caller that wants to add an entry would trigger memory corruption.

This has the potential for a compromised SMM handler to break into the supervisor, assuming a full memory corruption exploit. One of the prerequisites would be getting AllocatePool() to fail; however, I suspect this could be done utilizing a memory leak.

Fix:
This is fixed by using a temporary size value before allocation and assigning it to mMmSystemTableAllocateSize after successful allocation.

fixes #7 