### PR TITLE
MmFreePages() doesn't properly check NumberOfPages

### DIFF
--- a/MmSupervisorPkg/Core/Mem/Page.c
+++ b/MmSupervisorPkg/Core/Mem/Page.c
@@ -1072,6 +1072,10 @@ MmFreePages (
   BOOLEAN     IsGuarded;
   BOOLEAN     IsSupervisorPage;
 
+  if (NumberOfPages > TRUNCATE_TO_PAGES ((UINTN)-1) + 1) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   if (!InMemMap (Memory, NumberOfPages, &IsSupervisorPage)) {
     return EFI_NOT_FOUND;
   }

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
@@ -496,7 +496,11 @@ SyscallDispatcher (
 
       break;
     case SMM_FREE_PAGE:
-      if (!EFI_ERROR (InspectTargetRangeOwnership (Arg1, EFI_PAGES_TO_SIZE (Arg2), &IsUserRange)) && IsUserRange) {
+      // Making sure Arg2 does not overflow when supplying into inspector
+      // Then also making sure this entire range is owned by user
+      if ((Arg2 <= EFI_SIZE_TO_PAGES ((UINTN)-1)) &&
+          !EFI_ERROR (InspectTargetRangeOwnership (Arg1, EFI_PAGES_TO_SIZE (Arg2), &IsUserRange)) && IsUserRange)
+      {
         Status = MmFreePages ((EFI_PHYSICAL_ADDRESS)Arg1, Arg2);
       } else {
         Status = EFI_SECURITY_VIOLATION;


### PR DESCRIPTION
Bug Description:
The supervisor calls MmFreePages() to free pages previously allocated with a call to SMM_ALOC_PAGE. In the SMM_ALOC_PAGE case, a call is made to MmAllocatePages(), which eventually lands inside of MmInternalAllocatePagesEx(), which makes sure the number of pages provided by user space can't be too large (no more than 48 bits essentially, as any more pages would require more memory than the 64-bit address space would logically allow for). This check makes a lot of sense.

Unfortunately, MmAllocatePages()'s counterpart, MmFreePages() has no such check. The number of pages provided by userland callers can be > 48 bits big. When converted to actual size (using the EFI_PAGES_TO_SIZE() macro), an integer overflow can lead the code to believe that fewer pages than required are being freed.

If the heap guard is enabled and the memory is guarded, in that case, ClearGuardedMemoryBits() loops over a bitmap based on the number of pages (without using the EFI_PAGES_TO_SIZE() macro). The worst-case scenario would be some kind of memory corruption.

Fix:
Added a check like MmInternalAllocatePagesEx() has. Also added an overflow check for user page free call in the syscall dispatcher.

fixes #8 