### PR TITLE
Syscall entry/exit register save / restore (general purpose and FPU/MMX/SSE/AVX)

### DIFF
--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SysCallEntry.nasm
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SysCallEntry.nasm
@@ -73,6 +73,15 @@ ASM_PFX(SyscallCenter):
     push    rdi
     push    rbx
     push    r11
+    push    r10
+    push    r13
+    push    r14
+    push    r15
+
+    ;; FX_SAVE_STATE_X64 FxSaveState;
+    sub rsp, 512
+    mov rdi, rsp
+    db 0xf, 0xae, 0x7 ;fxsave [rdi]
 
     ;Prepare for ds, es, fs, gs
     xor     rbx, rbx
@@ -100,7 +109,15 @@ ASM_PFX(SyscallCenter):
     mov     es, bx
     mov     fs, bx
 
+    mov rsi, rsp
+    db 0xf, 0xae, 0xE ; fxrstor [rsi]
+    add rsp, 512
+
     ;restore registers from CPL3 stack
+    pop     r15
+    pop     r14
+    pop     r13
+    pop     r10
     pop     r11
     pop     rbx
     pop     rdi


### PR DESCRIPTION
Bug Description:
SyscallCenter implemented in SysCallEntry.nasm is called as the supervisor entry point when user space issues a SYSCALL instruction. This function is responsible for proper setup, calling the dispatcher, and then returning to user space properly.

Except, it doesn't seem to restore all registers. It restores a subset of the general purpose registers (r11, rbx, rdi, r12, rsi, r9, r8, rdx, rbp rcx and rsp), clearly leaving out r10, r13, r14, and r15. If the dispatcher uses any of these registers, they would get returned to user space.

In addition to the general purpose registers, it doesn't seem to restore any of the FPU/MMX/SSE/AVX registers. Optimizing compilers tend to use the SIMD registers and instructions for things like memcpy().

Fix:
In the syscall interface:
- Adding saving/restoring all general purpose registers.
- Saving/restoring MMX/SSE/FPU registers with FXSAVE and FXSTOR.
- AVX operations are prohibited by not enabling OSXSAVE in CR4.

The instructions addition is measured to have <100ms slowdown for 1M syscall calls.

fixes #9 