### PR TITLE
Fixed unvalidated CpuIndex (Arg2) in SMM_START_AP_PROC can cause out of bound writes

### DIFF
--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
@@ -505,6 +505,7 @@ SyscallDispatcher (
       break;
     case SMM_START_AP_PROC:
       if ((!EFI_ERROR (InspectTargetRangeOwnership (Arg1, sizeof (Arg1), &IsUserRange)) && IsUserRange) &&
+          (Arg2 < gMmCoreMmst.NumberOfCpus) &&
           ((Arg3 == 0) || (!EFI_ERROR (InspectTargetRangeOwnership (Arg3, 1, &IsUserRange)) && IsUserRange)))
       {
         // We only make sure the procedure is demoted, then the arguments access protection will be natural


### PR DESCRIPTION
Bug Description:
The supervisor handles the SMM_START_AP_PROC call index. It calls the gMmCoreMmst.MmStartupThisAp() function pointer with 3 arguments provided by userspace. The exact function pointer points to SmmStartupThisAp().

The second argument (Arg2) is seen as a CpuIndex and is used as an index into an array that is being written too. There are no bounds checks to ensure the index is <= the number of CPUs present. In this case, user-space gets to provide an unvalidated index and write user-controlled values almost anywhere in memory.

Fix:
Add CpuIndex validation inside the dispatcher when handling SMM_START_AP_PROC.

fixes #10 