### PR TITLE
Fixed SMM_UNREG_HNDL can unregister any handler, including supervisor ones

### DIFF
--- a/MmSupervisorPkg/Core/Handler/Mmi.c
+++ b/MmSupervisorPkg/Core/Handler/Mmi.c
@@ -348,7 +348,8 @@ MmiUserHandlerRegister (
                                 supervisor handler.
 
   @retval EFI_SUCCESS           Handler function was successfully unregistered.
-  @retval EFI_INVALID_PARAMETER DispatchHandle does not refer to a valid handle.
+  @retval EFI_INVALID_PARAMETER DispatchHandle does not refer to a valid handle or the ownership
+                                of DispatchHandle mismatches with IsSupervisorHandler.
 
 **/
 EFI_STATUS

--- a/MmSupervisorPkg/Core/Handler/Mmi.c
+++ b/MmSupervisorPkg/Core/Handler/Mmi.c
@@ -341,9 +341,11 @@ MmiUserHandlerRegister (
 }
 
 /**
-  Unregister a handler in MM.
+  Unregister a handler in MM with specified ownership.
 
-  @param  DispatchHandle  The handle that was specified when the handler was registered.
+  @param  DispatchHandle        The handle that was specified when the handler was registered.
+  @param  IsSupervisorHandler   The flag to indicate this is intending to unregister user or
+                                supervisor handler.
 
   @retval EFI_SUCCESS           Handler function was successfully unregistered.
   @retval EFI_INVALID_PARAMETER DispatchHandle does not refer to a valid handle.
@@ -351,8 +353,9 @@ MmiUserHandlerRegister (
 **/
 EFI_STATUS
 EFIAPI
-MmiHandlerUnRegister (
-  IN EFI_HANDLE  DispatchHandle
+MmiHandlerUnRegisterEx (
+  IN EFI_HANDLE  DispatchHandle,
+  IN BOOLEAN     IsSupervisorHandler
   )
 {
   MMI_HANDLER  *MmiHandler;
@@ -394,7 +397,7 @@ MmiHandlerUnRegister (
     }
   }
 
-  if ((EFI_HANDLE)MmiHandler != DispatchHandle) {
+  if (((EFI_HANDLE)MmiHandler != DispatchHandle) || (MmiHandler->IsSupervisor != IsSupervisorHandler)) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -420,4 +423,40 @@ MmiHandlerUnRegister (
   }
 
   return EFI_SUCCESS;
+}
+
+/**
+  Unregister a handler in MM owned by supervisor.
+
+  @param  DispatchHandle  The handle that was specified when the handler was registered.
+
+  @retval EFI_SUCCESS           Handler function was successfully unregistered.
+  @retval EFI_INVALID_PARAMETER DispatchHandle does not refer to a valid handle.
+
+**/
+EFI_STATUS
+EFIAPI
+MmiHandlerSupvUnRegister (
+  IN  EFI_HANDLE  DispatchHandle
+  )
+{
+  return MmiHandlerUnRegisterEx (DispatchHandle, TRUE);
+}
+
+/**
+  Unregister a handler in MM owned by users.
+
+  @param  DispatchHandle  The handle that was specified when the handler was registered.
+
+  @retval EFI_SUCCESS           Handler function was successfully unregistered.
+  @retval EFI_INVALID_PARAMETER DispatchHandle does not refer to a valid handle.
+
+**/
+EFI_STATUS
+EFIAPI
+MmiHandlerUserUnRegister (
+  IN  EFI_HANDLE  DispatchHandle
+  )
+{
+  return MmiHandlerUnRegisterEx (DispatchHandle, FALSE);
 }

--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -97,7 +97,7 @@ EFI_MM_SYSTEM_TABLE  gMmCoreMmst = {
   MmLocateProtocol,
   MmiManage,
   MmiSupvHandlerRegister,
-  MmiHandlerUnRegister
+  MmiHandlerSupvUnRegister
 };
 
 EFI_MEMORY_DESCRIPTOR  mMmSupervisorAccessBuffer[MM_OPEN_BUFFER_CNT];
@@ -329,7 +329,7 @@ MmReadyToLockHandler (
   //
   for (Index = 0; mMmCoreMmiHandlers[Index].HandlerType != NULL; Index++) {
     if (mMmCoreMmiHandlers[Index].UnRegister) {
-      Status = MmiHandlerUnRegister (mMmCoreMmiHandlers[Index].DispatchHandle);
+      Status = MmiHandlerSupvUnRegister (mMmCoreMmiHandlers[Index].DispatchHandle);
       if (EFI_ERROR (Status)) {
         DEBUG ((
           DEBUG_ERROR,

--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -685,7 +685,7 @@ MmiUserHandlerRegister (
   );
 
 /**
-  Unregister a handler in MM.
+  Unregister a handler in MM owned by supervisor.
 
   @param  DispatchHandle  The handle that was specified when the handler was registered.
 
@@ -695,7 +695,22 @@ MmiUserHandlerRegister (
 **/
 EFI_STATUS
 EFIAPI
-MmiHandlerUnRegister (
+MmiHandlerSupvUnRegister (
+  IN  EFI_HANDLE  DispatchHandle
+  );
+
+/**
+  Unregister a handler in MM owned by users.
+
+  @param  DispatchHandle  The handle that was specified when the handler was registered.
+
+  @retval EFI_SUCCESS           Handler function was successfully unregistered.
+  @retval EFI_INVALID_PARAMETER DispatchHandle does not refer to a valid handle.
+
+**/
+EFI_STATUS
+EFIAPI
+MmiHandlerUserUnRegister (
   IN  EFI_HANDLE  DispatchHandle
   );
 

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
@@ -533,7 +533,7 @@ SyscallDispatcher (
 
       break;
     case SMM_UNREG_HNDL:
-      Status = MmiHandlerUnRegister ((EFI_HANDLE)Arg1);
+      Status = MmiHandlerUserUnRegister ((EFI_HANDLE)Arg1);
       break;
     case SMM_SET_CPL3_TBL:
       if (EFI_ERROR (InspectTargetRangeOwnership (Arg1, sizeof (EFI_MM_SYSTEM_TABLE), &IsUserRange)) || !IsUserRange) {


### PR DESCRIPTION
Bug Description:
The supervisor handles syscalls to register and unregister handlers on user space's behalf by exposing a SMM_REG_HNDL and SMM_UNREG_HNDL syscall. for registration it calls MmiUserHandlerRegister() to do this work, which calls CoreMmiHandlerRegister() with IsSupervisorHandler set to FALSE. For unregistering, it calls MmiHandlerUnRegister() with a user-provided handle. It performs a handle lookup and, if found, unregisters the handler. MmiHandlerUnRegister() makes no effort to see whether the handler's IsSupervisor BOOLEAN is set or not. In order words, a user-space caller can unregister a supervisor-created handler.

The impact of unregistering supervisor handler could potentially miss some events and potentially lose capability of reporting secure policy. However, security critical events will be enforced by the time external entities fetch the policy, or the OS will indicate system guard is off.

Fix:
Added a MmiUserHandlerUnRegister() function that makes sure only handlers with their IsSupervisor field set to FALSE can be unregistered through the SMM_UNREG_HNDL syscall.

fixes #11 