### PR TITLE
Fixed missing length check in ConvertSmiHandlerSwContext()

### DIFF
--- a/MmSupervisorPkg/Core/Handler/SmiHandlerProfile.c
+++ b/MmSupervisorPkg/Core/Handler/SmiHandlerProfile.c
@@ -1304,7 +1304,8 @@ ConvertSmiHandlerUsbContext (
   @param SwContextSize                The size of EFI_SMM_SW_REGISTER_CONTEXT in bytes
   @param SmiHandlerSwContextSize      The size of SMI_HANDLER_PROFILE_SW_REGISTER_CONTEXT in bytes
 
-  @return SmiHandlerSwContext   A pointer to SMI_HANDLER_PROFILE_SW_REGISTER_CONTEXT
+  @return SmiHandlerSwContext   A pointer to SMI_HANDLER_PROFILE_SW_REGISTER_CONTEXT,
+                                or NULL if any of the inputs are null pointers.
 **/
 SMI_HANDLER_PROFILE_SW_REGISTER_CONTEXT *
 ConvertSmiHandlerSwContext (
@@ -1315,7 +1316,18 @@ ConvertSmiHandlerSwContext (
 {
   SMI_HANDLER_PROFILE_SW_REGISTER_CONTEXT  *SmiHandlerSwContext;
 
-  ASSERT (SwContextSize == sizeof (EFI_SMM_SW_REGISTER_CONTEXT));
+  if ((SmiHandlerSwContextSize == NULL) ||
+      (SwContext == NULL))
+  {
+    // Should not happen...
+    return NULL;
+  }
+
+  if (SwContextSize != sizeof (EFI_SMM_SW_REGISTER_CONTEXT)) {
+    // Invalid parameter
+    *SmiHandlerSwContextSize = 0;
+    return NULL;
+  }
 
   SmiHandlerSwContext = AllocatePool (sizeof (SMI_HANDLER_PROFILE_SW_REGISTER_CONTEXT));
   if (SmiHandlerSwContext == NULL) {


### PR DESCRIPTION
ConvertSmiHandlerSwContext() is called by SmiHandlerProfileRegisterHandler() which is called by ProcessUserHandlerReg() when the supervisor dispatcher handles a SMM_MM_HDL_REG_1/SMM_MM_HDL_REG_2 request to register a child SMI handler with a gEfiSmmSwDispatch2ProtocolGuid handler guid. ConvertSmiHandlerSwContext() is handed a user space provided context and context size, and it will convert an EFI_SMM_SW_REGISTER_CONTEXT structure to a SMI_HANDLER_PROFILE_SW_REGISTER_CONTEXT structure. It doesn't check the context size and simply assumes it's large enough to hold the data it needs (it only does an assert). This could lead to user space inducing the supervisor to touch supervisor pages and possibly info leak some supervisor page data (a couple of bytes).

However, this is a debug feature for testing and development purposes only and should not be enabled in release products. Thus the security impact should be minor.

Fix:
- Turning the ASSERT length check into a proper length check (so that it would also trigger in release builds).

fixes #12