### PR TITLE
Fixed GUID comparison that could lead to arbitrary write from FreePool()

### DIFF
--- a/MmSupervisorPkg/Core/Handler/SmiHandlerProfile.c
+++ b/MmSupervisorPkg/Core/Handler/SmiHandlerProfile.c
@@ -1582,6 +1582,8 @@ SmiHandlerProfileUnregisterHandler (
   if (SearchContext != NULL) {
     if (CompareGuid (HandlerGuid, &gEfiSmmUsbDispatch2ProtocolGuid)) {
       FreePool (SearchContext);
+    } else if (CompareGuid (HandlerGuid, &gEfiSmmSwDispatch2ProtocolGuid)) {
+      FreePool (SearchContext);
     }
   }
 
@@ -1643,6 +1645,7 @@ ProcessUserHandlerUnreg (
 {
   EFI_STATUS  Status = EFI_SUCCESS;
   BOOLEAN     IsUserRange;
+  EFI_GUID    TempGuid;
 
   if ((PcdGet8 (PcdSmiHandlerProfilePropertyMask) & 0x1) == 0) {
     Status = EFI_UNSUPPORTED;
@@ -1664,7 +1667,8 @@ ProcessUserHandlerUnreg (
         goto Exit;
       }
 
-      UserHandlerRegHolder.HandlerGuid      = HandlerGuid;
+      // Cache this GUID internally
+      CopyMem (&TempGuid, HandlerGuid, sizeof (EFI_GUID));
       UserHandlerRegHolder.Context          = (VOID *)Arg2;
       UserHandlerRegHolder.ContextSize      = Arg3;
       UserHandlerRegHolder.CompletedSyscall = SyscallIndex;
@@ -1686,7 +1690,7 @@ ProcessUserHandlerUnreg (
 
       Status = SmiHandlerProfileUnregisterHandler (
                  &mSmiHandlerProfile,
-                 UserHandlerRegHolder.HandlerGuid,
+                 &TempGuid,
                  UserHandlerRegHolder.Handler,
                  UserHandlerRegHolder.Context,
                  UserHandlerRegHolder.ContextSize


### PR DESCRIPTION
Bug Description:
SmiHandlerProfileUnregisterHandler() is called by ProcessUserHandlerUnreg() which is called by the supervisor when handling SMM_MM_HDL_UNREG_1/SMM_MM_HDL_UNREG_2 syscalls. It takes a guid pointer (as well as a context and context size) provided by user space. It has been inspected with a call to InspectTargetRangeOwnership() to ensure it belongs to user space. SmiHandlerProfileUnregisterHandler() uses the guid pointer twice. Once to look up the handler (and its associated context) and a second time to free memory if the guid content is the same as gEfiSmmUsbDispatch2ProtocolGuid.

Given that the guid points to user space controlled data, it is possible that this content could have changed between the first time it was used and the second time it was used. I'm not sure if user space gets access to more than one core (in which case they could instruct the 2nd core to modify the data asynchronously). If the guid content is not equal to gEfiSmmUsbDispatch2ProtocolGuid during the first use but is equal during the second use, user space can induce the supervisor to FreePool() data that user space controls instead of supervisor allocated pool memory.

In addition, MmInstallProtocolInterfaceNotify() only has an assert (this is reachable through the SMM_INST_PROT syscall with a similar user-provided guid pointer) that could be triggered with a similar guid race where multiple entries in a list could have the same guid. But this is benign because it occurs after initial MM launching and does not impact supervisor behavior.

One last note, SmiHandlerProfileUnregisterHandler() has a second case that compares against a specific guid (gEfiSmmSwDispatch2ProtocolGuid) and returns a supervisor pool allocated piece of memory. However, in this case, there is no logic to free this memory at the end of the function, leading to a memory leak. In and on itself, memory leaks aren't great, but (certainly in the context of UEFI/SMM) I wouldn't call them out as a security issue. However, exploitation of the "MmInstallConfigurationTable()" issue described above would likely benefit from a reliable memory leak, and as such, this might have some security consequences.

The impact of handler profile related bugs are trivial because this is a test/development feature, which should not be enabled in the release firmware.

Fix:
- Capturing the user-provided GUID before using it.
- Fixed the memory leak.

fixes #13 