### PR TITLE
Updated the version number since we moved to console build to support NX

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -30,14 +30,14 @@
   #Major: major version is one or two digits from 0 to 99
   #Minor: minor version is four digits, the first 3 digits are the minor number, the last digit is the flag
   #flag=9 represents RELEASE version, flag=8 represents DEBUG version, flag=0~7 represents test version
-  RELEASE_DRIVER_VERSION   = 1.0019
-  DEBUG_DRIVER_VERSION     = 1.0018
+  RELEASE_DRIVER_VERSION   = 6.0029
+  DEBUG_DRIVER_VERSION     = 6.0028
   #SPL value definition: SPL version = Major.Minor, SPL value = (Major << 16 | Minor)
   #Major: major value is an UINT16 number in decimal from 0 to 65535
   #Minor: minor value is an UINT16 number in decimal from 0 to 65535
   #for example: Major=0 Minor=10, SPL=0x0000000A
-  MAJOR_PATCH_LEVEL              = 0
-  MINOR_PATCH_LEVEL              = 0
+  MAJOR_PATCH_LEVEL              = 1
+  MINOR_PATCH_LEVEL              = 1
 
 #  VALID_ARCHITECTURES           = X64
 

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -22,7 +22,7 @@
   BASE_NAME                      = MmSupervisorCore
   FILE_GUID                      = 4E4C89DC-A452-4B6B-B183-F16A2A223733
   MODULE_TYPE                    = MM_CORE_STANDALONE
-  VERSION_STRING                 = 1.001
+  VERSION_STRING                 = 6.002
   PI_SPECIFICATION_VERSION       = 0x00010032
   ENTRY_POINT                    = MmSupervisorMain
 

--- a/MmSupervisorPkg/MmSupervisorPkg.dec
+++ b/MmSupervisorPkg/MmSupervisorPkg.dec
@@ -13,7 +13,7 @@
   DEC_SPECIFICATION              = 0x0001001A
   PACKAGE_NAME                   = MmSupervisorPkg
   PACKAGE_GUID                   = 2DCA2E5C-4696-4613-943F-DFE5F6941C34
-  PACKAGE_VERSION                = 1.001
+  PACKAGE_VERSION                = 6.002
 
 [Includes]
   Include


### PR DESCRIPTION
BASECORE recently moved to `CONSOLE` as subsystem during linking process, in order to support NX flag.

However, the side effect of this change is enforcing the subsystem level to be 5.0* at minimum, according to this document:
https://docs.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-170#remarks

This change updated the subsystem level to be 6.02* to be higher than the default value.

Patch level is also updated to reflect that the security patches applied from last refresh.