### PR TITLE
Fixing an edge case of incoming parameter check

### DIFF
--- a/MmSupervisorPkg/Core/Mem/Page.c
+++ b/MmSupervisorPkg/Core/Mem/Page.c
@@ -625,7 +625,7 @@ MmInternalAllocatePagesEx (
     return EFI_INVALID_PARAMETER;
   }
 
-  if (NumberOfPages > TRUNCATE_TO_PAGES ((UINTN)-1) + 1) {
+  if (NumberOfPages >= TRUNCATE_TO_PAGES ((UINTN)-1) + 1) {
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1072,7 +1072,7 @@ MmFreePages (
   BOOLEAN     IsGuarded;
   BOOLEAN     IsSupervisorPage;
 
-  if (NumberOfPages > TRUNCATE_TO_PAGES ((UINTN)-1) + 1) {
+  if (NumberOfPages >= TRUNCATE_TO_PAGES ((UINTN)-1) + 1) {
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/MmSupervisorPkg/Core/Mem/Page.c
+++ b/MmSupervisorPkg/Core/Mem/Page.c
@@ -552,9 +552,10 @@ InternalAllocMaxAddress (
 
   @param  FreePageList           The free page node.
   @param  NumberOfPages          Number of pages to be allocated.
-  @param  MaxAddress             Request to allocate memory below this address.
+  @param  Address                Request to allocate new memory at this address.
 
-  @return Memory address of allocated pages.
+  @return Memory address of allocated pages. Any returned value that differs from
+          Address should be treated as EFI_NOT_FOUND.
 
 **/
 UINTN


### PR DESCRIPTION
This change fixed a potential overflow where if the maximal allowed number of pages being passed in (0x10000), the return will be an address of 0 pages.

The security impact is minimal as on allocation, the returned address will be either pointing to a free page that is marked with supervisor privilege or guarded page with read prevention protection. On the freeing, the input address will fail the internal attribute look up and bail early.