### PR TITLE
.azurepipelines: Opt out of PR Evaluation

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -33,6 +33,7 @@ jobs:
     arch_list: IA32,X64
     do_ci_build: true
     do_ci_setup: false
+    do_pr_eval: false
     packages: MmSupervisorPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT
     tool_chain_tag: GCC5

--- a/.azurepipelines/Windows-VS.yml
+++ b/.azurepipelines/Windows-VS.yml
@@ -33,6 +33,7 @@ jobs:
     arch_list: IA32,X64
     do_ci_build: true
     do_ci_setup: false
+    do_pr_eval: false
     packages: MmSupervisorPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT
     tool_chain_tag: VS2022


### PR DESCRIPTION
Prior to using Mu DevOps, this repo did not use Stuart PR Evaluation.

.pytool/CISettings.py does not implement a PrEvalSettingsManager.

To maintain this configuration, this change opts the YAML files in
the repo out of PR evaluation in the templates used for build in
Mu DevOps.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>