### PR TITLE
basecore_ext_dep.yaml: Update to latest mu_basecore (4d60e12)

### DIFF
--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.inf
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.inf
@@ -18,11 +18,11 @@
   ENTRY_POINT                    = MmIplPeiEntry
 
 # Secure:
-#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | 363e254ecb2e8334d7efdbe363172897 | 2022-05-13T05-08-11 | 1fe56ccdeb39aa2fb6b85a37f4fb3225f4fa2e2a
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | 363e254ecb2e8334d7efdbe363172897 | 2022-09-02T01-34-33 | 078e685aa7aa900ea15cdf41ffe4e42bc97474d2
 # Non-Secure:
-#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | c552f7d1889413df958c1a3faa1ed16b | 2022-05-18T19-34-40 | 8b96b84846f46f16f96a44ac838c6a1c50f2d0b3
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | c552f7d1889413df958c1a3faa1ed16b | 2022-09-02T01-35-35 | 4d60e12bfa108cd4b20796dd3f6f859417223408
 
-#Override : 00000002 | MdeModulePkg/Universal/CapsulePei/CapsulePei.inf | e7e3c4b486d8a74981a9d7ee313f942a | 2022-03-17T00-31-33 | dcf8b1b78a3fa0317c396c950a00ee30ea42d43e
+#Override : 00000002 | MdeModulePkg/Universal/CapsulePei/CapsulePei.inf | 6ccb347bc8933623a7b1b6144379b4bb | 2022-09-02T01-33-52 | 4d60e12bfa108cd4b20796dd3f6f859417223408
 
 #
 # The following information is for reference only and not required by the build tools.

--- a/MmSupervisorPkg/Test/MmiHandlerProfileInfo/MmiHandlerProfileInfo.inf
+++ b/MmSupervisorPkg/Test/MmiHandlerProfileInfo/MmiHandlerProfileInfo.inf
@@ -10,7 +10,7 @@
 #
 ##
 
-#Override : 00000002 | MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.inf | 6c2a904f34fb982b919d1d1999eb5c6b | 2022-07-15T23-43-10 | 58112c3f45a59892c2c3bdd15c6f1599358aaf2e
+#Override : 00000002 | MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf | 6c2a904f34fb982b919d1d1999eb5c6b | 2022-09-02T02-30-27 | 4d60e12bfa108cd4b20796dd3f6f859417223408
 
 [Defines]
   INF_VERSION                    = 0x00010005

--- a/basecore_ext_dep.yaml
+++ b/basecore_ext_dep.yaml
@@ -9,6 +9,6 @@
   "name": "MU_BASECORE",
   "var_name": "BASECORE_PATH",
   "source": "https://github.com/microsoft/mu_basecore.git",
-  "version": "baa0eb6aafe7dc8930822f6dd6f71eba411970be", # release/202202
+  "version": "4d60e12bfa108cd4b20796dd3f6f859417223408", # release/202202
   "flags": ["set_build_var"]
 }

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -16,3 +16,4 @@ edk2-pytool-library~=0.11.2
 edk2-pytool-extensions~=0.17.1
 edk2-basetools==0.1.13
 antlr4-python3-runtime==4.7.1
+regex


### PR DESCRIPTION
Updates mu_basecore to the latest commit so consuming packages that
need to move to latest can get the latest override validation track
tags needed.

Adds "regex" to pip-requirements.txt as it is needed by the DebugMacroCheck
plugin picked up in this mu_basecore update.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>