### PR TITLE
codeql-analysis.yml: Use Mu Devops CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,12 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
+## @file
+# Mu MM Supervisor CodeQL file.
 #
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
+# Triggers the CodeQL GitHub action flow on the main branch.
 #
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
 name: "CodeQL"
 
 on:
@@ -21,45 +19,8 @@ on:
     - cron: '20 23 * * 4'
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'cpp' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-        
-    - name: 'Install/Upgrade pip modules' 
-      run: pip install -r pip-requirements.txt --upgrade
-      
-    - name: 'update'
-      run: stuart_update -c .pytool/CISettings.py -p MmSupervisorPkg -t DEBUG -a IA32,X64 TOOL_CHAIN_TAG=GCC5
-      
-    - name: 'build'
-      run: stuart_ci_build -c .pytool/CISettings.py -p MmSupervisorPkg -t DEBUG -a IA32,X64 TOOL_CHAIN_TAG=GCC5
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+  codeql-analysis:
+    uses: microsoft/mu_devops/.github/workflows/CodeQl.yml@main
+    with:
+      update_command: stuart_update -c .pytool/CISettings.py -p MmSupervisorPkg -t DEBUG -a IA32,X64 TOOL_CHAIN_TAG=GCC5
+      build_command: stuart_ci_build -c .pytool/CISettings.py -p MmSupervisorPkg -t DEBUG -a IA32,X64 TOOL_CHAIN_TAG=GCC5


### PR DESCRIPTION
Updates codeql-analysis.yml to use a common reusable workflow from
mu_devops for CodeQL analysis.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>