### PR TITLE
CodeQL Fixes - Second Pass

### DIFF
--- a/MmSupervisorPkg/Core/Mem/PageTbl.c
+++ b/MmSupervisorPkg/Core/Mem/PageTbl.c
@@ -265,6 +265,11 @@ SetStaticPageTable (
 
   EFI_STATUS  Status;
 
+  PageMapLevel4Entry        = NULL;
+  PageMapLevel5Entry        = NULL;
+  PageDirectoryPointerEntry = NULL;
+  PageDirectoryEntry        = NULL;
+
   //
   // IA-32e paging translates 48-bit linear addresses to 52-bit physical addresses
   //  when 5-Level Paging is disabled.
@@ -305,10 +310,7 @@ SetStaticPageTable (
   //
   PageMap = (VOID *)PageTable;
 
-  PageMapLevel4Entry        = PageMap;
-  PageMapLevel5Entry        = NULL;
-  PageDirectoryPointerEntry = NULL;
-  PageDirectoryEntry        = NULL;
+  PageMapLevel4Entry = PageMap;
   if (m5LevelPagingNeeded) {
     //
     // By architecture only one PageMapLevel5 exists - so lets allocate storage for it.

--- a/MmSupervisorPkg/Drivers/MmCommunicationBuffer/MmCommunicationBufferDxe.c
+++ b/MmSupervisorPkg/Drivers/MmCommunicationBuffer/MmCommunicationBufferDxe.c
@@ -43,6 +43,8 @@ MmCommunicationBufferDxeEntry (
   EFI_PEI_HOB_POINTERS  GuidHob;
   MM_COMM_REGION_HOB    *CommRegionHob;
 
+  PiSmmCommunicationRegionTable = NULL;
+
   GuidHob.Guid = GetFirstGuidHob (&gMmCommonRegionHobGuid);
   if (GuidHob.Guid == NULL) {
     DEBUG ((DEBUG_ERROR, "%a Did not locate any published hob under %g to create communication buffer table!!!\n", __FUNCTION__, &gMmCommonRegionHobGuid));

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.c
@@ -1057,6 +1057,9 @@ GetFullMmramRanges (
   UINTN                         MaxCount;
   BOOLEAN                       Rescan;
 
+  MmramRanges     = NULL;
+  TempMmramRanges = NULL;
+
   // MU_CHANGE: Changed to use MM PPI instead of protocol
   //
   // Get MM Configuration PPI if it is present.

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.c
@@ -247,7 +247,7 @@ GetMmramCacheRange (
 
   do {
     FoundAdjacentRange = FALSE;
-    for (Index = 0; Index < gMmCorePrivate->MmramRangeCount; Index++) {
+    for (Index = 0; (UINT64)Index < gMmCorePrivate->MmramRangeCount; Index++) {
       RangeCpuStart     = MmramRanges[Index].CpuStart;
       RangePhysicalSize = MmramRanges[Index].PhysicalSize;
       if ((RangeCpuStart < *MmramCacheBase) && (*MmramCacheBase == (RangeCpuStart + RangePhysicalSize))) {

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.c
@@ -1403,7 +1403,7 @@ MmIplPeiEntry (
   // Find the largest SMRAM range between 1MB and 4GB that is at least 256KB - 4K in size
   //
   mCurrentMmramRange = NULL;
-  for (Index = 0, MaxSize = SIZE_256KB - EFI_PAGE_SIZE; Index < gMmCorePrivate->MmramRangeCount; Index++) {
+  for (Index = 0, MaxSize = SIZE_256KB - EFI_PAGE_SIZE; (UINT64)Index < gMmCorePrivate->MmramRangeCount; Index++) {
     //
     // Skip any SMRAM region that is already allocated, needs testing, or needs ECC initialization
     //


### PR DESCRIPTION
## Description

Makes changes to comply with alerts raised by CodeQL.

A prior pass with a subset of queries used here was already done so this is mostly addressing
issues discovered by enabling a few new queries.

Most of the issues here fall into the following two categories:

1. Potential use of uninitialized pointer
2. Inconsistent integer width used in loop comparison

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No** - Should just be refactoring to address alerts

## How This Was Tested

1. Verified CI build

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>