### PR TITLE
[Rebase & FF] Add stack cookie

### DIFF
--- a/MmSupervisorPkg/Core/Dispatcher/Dispatcher.c
+++ b/MmSupervisorPkg/Core/Dispatcher/Dispatcher.c
@@ -292,8 +292,10 @@ MmLoadImage (
 {
   UINTN                         PageCount;
   EFI_STATUS                    Status;
+  EFI_STATUS                    StackCookieStatus;
   EFI_PHYSICAL_ADDRESS          DstBuffer;
   PE_COFF_LOADER_IMAGE_CONTEXT  ImageContext;
+  UINT64                        *SecurityCookieAddress;
 
   DEBUG ((DEBUG_INFO, "MmLoadImage - %g\n", &DriverEntry->FileName));
 
@@ -478,6 +480,12 @@ MmLoadImage (
   DEBUG ((DEBUG_INFO | DEBUG_LOAD, "\n"));
 
   DEBUG_CODE_END ();
+
+  StackCookieStatus = PeCoffLoaderGetSecurityCookieAddress (&ImageContext, &SecurityCookieAddress);
+  if (!EFI_ERROR (StackCookieStatus)) {
+    InitializeSecurityCookieAddress (SecurityCookieAddress);
+    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Standalone MM SecurityCookie set to %lld\n", (*SecurityCookieAddress)));
+  }
 
   return Status;
 }

--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -50,6 +50,7 @@
 #include <Library/UefiLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/ResetSystemLib.h>
+#include <Library/BaseBinSecurityLib.h>
 
 //
 // Used to build a table of MMI Handlers that the MM Core registers

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -140,6 +140,7 @@
   SortLib
   HwResetSystemLib
   SmmPolicyGateLib
+  BaseBinSecurityLib
   MmMemoryProtectionHobLib ## MU_CHANGE
   IhvSmmSaveStateSupervisionLib
   SafeIntLib

--- a/MmSupervisorPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
+++ b/MmSupervisorPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
@@ -231,6 +231,10 @@ flash drivers, SW MMI dispatcher drivers, etc.
 ``` bash
 [PcdsFixedAtBuild]
   gEfiSecurityPkgTokenSpaceGuid.PcdUserPhysicalPresence               | FALSE
+  # MM environment only set up the exception handler for the upper 32 entries.
+  # The platform should set this to a non-conflicting exception number, otherwise
+  # it will be treated as one of the normal types of CPU faults.
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector              | 0x0F
 
 [LibraryClasses.IA32]
   MmSupervisorUnblockMemoryLib|MmSupervisorPkg/Library/MmSupervisorUnblockMemoryLib/MmSupervisorUnblockMemoryLibPei.inf

--- a/MmSupervisorPkg/MmSupervisorPkg.ci.yaml
+++ b/MmSupervisorPkg/MmSupervisorPkg.ci.yaml
@@ -30,7 +30,8 @@
         ],
         "AcceptableDependencies-UEFI_APPLICATION": [
             "ShellPkg/ShellPkg.dec",
-            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec",
+            "UefiTestingPkg/UefiTestingPkg.dec"
         ],
         "IgnoreInf": []
     },

--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -51,7 +51,6 @@
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
   RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
 
-!if $(TARGET) == DEBUG
 !if $(TOOL_CHAIN_TAG) == VS2017 or $(TOOL_CHAIN_TAG) == VS2015 or $(TOOL_CHAIN_TAG) == VS2019 or $(TOOL_CHAIN_TAG) == VS2022
   #if debug is enabled provide StackCookie support lib so that we can link to /GS exports
   NULL|MdePkg/Library/BaseBinSecurityLibRng/BaseBinSecurityLibRng.inf
@@ -60,7 +59,6 @@
 !else
   # otherwise use the null version for GCC and CLANG
   BaseBinSecurityLib|MdePkg/Library/BaseBinSecurityLibNull/BaseBinSecurityLibNull.inf
-!endif
 !endif
 
 [LibraryClasses.IA32]

--- a/MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
+++ b/MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
@@ -29,6 +29,7 @@
   ShellPkg/ShellPkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
   MmSupervisorPkg/MmSupervisorPkg.dec
+  UefiTestingPkg/UefiTestingPkg.dec
 
 [LibraryClasses]
   ShellLib
@@ -53,3 +54,6 @@
   gEfiMemoryAttributesTableGuid
   gMmSupervisorCommunicationRegionTableGuid
   gMmPagingAuditMmiHandlerGuid
+
+[FixedPcd]
+  gUefiTestingPkgTokenSpaceGuid.PcdPlatformSmrrUnsupported  ## SOMETIMES_CONSUMES

--- a/MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/X64/PagingAuditProcessor.c
+++ b/MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/X64/PagingAuditProcessor.c
@@ -149,6 +149,15 @@ LookupSmrrIntel (
     }
   }
 
+  //
+  // The above check is great...
+  // However, there are some virtual platforms that does not really support them. This PCD check
+  // is to allow these virtual platforms to skip the SMRR check.
+  //
+  if (FixedPcdGetBool (PcdPlatformSmrrUnsupported)) {
+    Status = EFI_UNSUPPORTED;
+  }
+
   return Status;
 }
 
@@ -200,9 +209,15 @@ LookupSmrrAMD (
   DEBUG ((DEBUG_INFO, "%a - FamilyId 0x%02x, ModelId 0x%02x\n", __FUNCTION__, FamilyId, ModelId));
 
   //
-  // In processors implementing the AMD64 architecture, SMBASE relocation is always supported
+  // In processors implementing the AMD64 architecture, SMBASE relocation is always supported.
+  // However, there are some virtual platforms that does not really support them. This PCD check
+  // is to allow these virtual platforms to skip the SMRR check.
   //
-  Status = EFI_SUCCESS;
+  if (FixedPcdGetBool (PcdPlatformSmrrUnsupported)) {
+    Status = EFI_UNSUPPORTED;
+  } else {
+    Status = EFI_SUCCESS;
+  }
 
   return Status;
 }

--- a/basecore_ext_dep.yaml
+++ b/basecore_ext_dep.yaml
@@ -9,6 +9,6 @@
   "name": "MU_BASECORE",
   "var_name": "BASECORE_PATH",
   "source": "https://github.com/microsoft/mu_basecore.git",
-  "version": "405c0d211acd1341f851c2c554eb0c66bc907170", # release/202208
+  "version": "f34e20c5d9162cb06a9f7d921a5268452e1ea5b8", # release/202208
   "flags": ["set_build_var"]
 }

--- a/mu_plus_ext_dep.yaml
+++ b/mu_plus_ext_dep.yaml
@@ -9,6 +9,6 @@
   "name": "MU_PLUS",
   "var_name": "MU_PLUS_PATH",
   "source": "https://github.com/microsoft/mu_plus.git",
-  "version": "b0c55cdc00923f25a3199631742adce058b0747b", # release/202208
+  "version": "8ebc6f05268efda3bf48894b3c07e56de90d6eef", # release/202208
   "flags": ["set_build_var"]
 }

--- a/mu_tiano_ext_dep.yaml
+++ b/mu_tiano_ext_dep.yaml
@@ -9,6 +9,6 @@
   "name": "MU_TIANO_PLUS",
   "var_name": "MU_TIANO_PATH",
   "source": "https://github.com/microsoft/mu_tiano_plus.git",
-  "version": "d9f3cb694602f20c40c4cf774f63b7ad42be36f4", # release/202208
+  "version": "fd5086f39cd0a730c428c1f9a5a0807e14100bac", # release/202208
   "flags": ["set_build_var"]
 }


### PR DESCRIPTION
## Description

This change added the support for stack cookie in standalone MM core and user modules:
- Added assembly function to write to `ICC_SGI1R` from non-secure EL1/EL2
- Extended current `ArmGicSendSgiTo` interface to also support sending SGI on GIC v3 and v4
- Added a new PSCI command index to query PSCI suspend features.

The assembly support is intentionally left out as the common solution for MSVC and GCC
support is still under development.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on both GCC and MSVC compiled Q35 platform.

## Integration Instructions

Need to include the appropriate instance of `BaseBinSecurityLib` in the platform dsc file to pass the build.