### PR TITLE
Remove broken link in PlatformIntegrationSteps.md

### DIFF
--- a/MmSupervisorPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
+++ b/MmSupervisorPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
@@ -21,8 +21,6 @@ defined data structures in addition to supervisor-specific data structures to be
 1. [MM Supervisor Code Integration](#mm-supervisor-code-integration) - How to best integrate the `MmSupervisorPkg`
 collateral into a platform firmware.
 
-1. [Known Issues](#known-issues) - Known issues that need to be taken into account.
-
 1. [Platform Security Goals](TODO/SUPERVISOR_SECURITY_OVERVIEW.md) - The MM Supervisor aims to improve security. It is
 important to understand the goals of the supervisor and how that aligns with the platform security goals.
 


### PR DESCRIPTION
## Description

Removes a link in markdown that is causing a markdown lint failure. Required to complete containerized build. https://github.com/microsoft/mu_feature_mm_supv/pull/49

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
