### PR TITLE
Fixing override failure

### DIFF
--- a/MmSupervisorPkg/Library/BaseLibSysCall/BaseLib.inf
+++ b/MmSupervisorPkg/Library/BaseLibSysCall/BaseLib.inf
@@ -12,7 +12,7 @@
 #
 ##
 
-#Override : 00000002 | MdePkg/Library/BaseLib/BaseLib.inf | dd377290e5da05e363eadfe0ebaa4b1c | 2022-10-07T19-25-54 | 0d04a5e280c55eb742deaabcfa97da85a0afe7b2
+#Override : 00000002 | MdePkg/Library/BaseLib/BaseLib.inf | 0b10a03fb8c421c246d850068d4b2b5e | 2023-01-10T00-35-23 | 8d5e7c09a6a140e012d9f3eb0ce92bca823c981f
 
 [Defines]
   INF_VERSION                    = 0x00010005

--- a/MmSupervisorPkg/Library/BaseLibSysCall/String.c
+++ b/MmSupervisorPkg/Library/BaseLibSysCall/String.c
@@ -274,8 +274,8 @@ StrStr (
 
   @param  Char  The character to check against.
 
-  @retval TRUE  If the Char is a decimal character.
-  @retval FALSE If the Char is not a decimal character.
+  @retval TRUE  If the Char is a decmial character.
+  @retval FALSE If the Char is not a decmial character.
 
 **/
 BOOLEAN
@@ -351,8 +351,8 @@ InternalHexCharToUintn (
 
   @param  Char  The character to check against.
 
-  @retval TRUE  If the Char is a hexadecimal character.
-  @retval FALSE If the Char is not a hexadecimal character.
+  @retval TRUE  If the Char is a hexadecmial character.
+  @retval FALSE If the Char is not a hexadecmial character.
 
 **/
 BOOLEAN
@@ -410,7 +410,10 @@ StrDecimalToUintn (
   RETURN_STATUS  Status;
 
   Status = StrDecimalToUintnS (String, (CHAR16 **)NULL, &Result);
-  ASSERT_RETURN_ERROR (Status);
+  if (Status == RETURN_INVALID_PARAMETER) {
+    Result = 0;
+  }
+
   return Result;
 }
 
@@ -458,7 +461,10 @@ StrDecimalToUint64 (
   RETURN_STATUS  Status;
 
   Status = StrDecimalToUint64S (String, (CHAR16 **)NULL, &Result);
-  ASSERT_RETURN_ERROR (Status);
+  if (Status == RETURN_INVALID_PARAMETER) {
+    Result = 0;
+  }
+
   return Result;
 }
 
@@ -507,7 +513,10 @@ StrHexToUintn (
   RETURN_STATUS  Status;
 
   Status = StrHexToUintnS (String, (CHAR16 **)NULL, &Result);
-  ASSERT_RETURN_ERROR (Status);
+  if (Status == RETURN_INVALID_PARAMETER) {
+    Result = 0;
+  }
+
   return Result;
 }
 
@@ -556,7 +565,10 @@ StrHexToUint64 (
   RETURN_STATUS  Status;
 
   Status = StrHexToUint64S (String, (CHAR16 **)NULL, &Result);
-  ASSERT_RETURN_ERROR (Status);
+  if (Status == RETURN_INVALID_PARAMETER) {
+    Result = 0;
+  }
+
   return Result;
 }
 
@@ -569,8 +581,8 @@ StrHexToUint64 (
 
   @param  Char  The character to check against.
 
-  @retval TRUE  If the Char is a decimal character.
-  @retval FALSE If the Char is not a decimal character.
+  @retval TRUE  If the Char is a decmial character.
+  @retval FALSE If the Char is not a decmial character.
 
 **/
 BOOLEAN
@@ -592,8 +604,8 @@ InternalAsciiIsDecimalDigitCharacter (
 
   @param  Char  The character to check against.
 
-  @retval TRUE  If the Char is a hexadecimal character.
-  @retval FALSE If the Char is not a hexadecimal character.
+  @retval TRUE  If the Char is a hexadecmial character.
+  @retval FALSE If the Char is not a hexadecmial character.
 
 **/
 BOOLEAN
@@ -999,7 +1011,10 @@ AsciiStrDecimalToUintn (
   RETURN_STATUS  Status;
 
   Status = AsciiStrDecimalToUintnS (String, (CHAR8 **)NULL, &Result);
-  ASSERT_RETURN_ERROR (Status);
+  if (Status == RETURN_INVALID_PARAMETER) {
+    Result = 0;
+  }
+
   return Result;
 }
 
@@ -1043,7 +1058,10 @@ AsciiStrDecimalToUint64 (
   RETURN_STATUS  Status;
 
   Status = AsciiStrDecimalToUint64S (String, (CHAR8 **)NULL, &Result);
-  ASSERT_RETURN_ERROR (Status);
+  if (Status == RETURN_INVALID_PARAMETER) {
+    Result = 0;
+  }
+
   return Result;
 }
 
@@ -1091,7 +1109,10 @@ AsciiStrHexToUintn (
   RETURN_STATUS  Status;
 
   Status = AsciiStrHexToUintnS (String, (CHAR8 **)NULL, &Result);
-  ASSERT_RETURN_ERROR (Status);
+  if (Status == RETURN_INVALID_PARAMETER) {
+    Result = 0;
+  }
+
   return Result;
 }
 
@@ -1139,7 +1160,10 @@ AsciiStrHexToUint64 (
   RETURN_STATUS  Status;
 
   Status = AsciiStrHexToUint64S (String, (CHAR8 **)NULL, &Result);
-  ASSERT_RETURN_ERROR (Status);
+  if (Status == RETURN_INVALID_PARAMETER) {
+    Result = 0;
+  }
+
   return Result;
 }
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The CodeQL PR from basecore (https://github.com/microsoft/mu_basecore/commit/8d8f808384a5c3d545857fdcaada61c347e0562d) introduced a few changes  into the `BaseLib`, which breaks the override validation process. This change is to sync with the upstream change.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [x] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Q35 Qemu can build with the latest supervisor commit.

## Integration Instructions

N/A
