### PR TITLE
Converge demotion routines in assembly into one and update the stack alignments

### DIFF
--- a/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
@@ -66,7 +66,6 @@ extern ASM_PFX(RegErrorReportJumpPointer)
 global ASM_PFX(InvokeDemotedRoutine)
 ASM_PFX(InvokeDemotedRoutine):
     ;Preserve input parameters onto stack for later usage
-    jmp     $
     push    r9
     push    r8
     push    rdx
@@ -76,7 +75,7 @@ ASM_PFX(InvokeDemotedRoutine):
     push    rbp
     mov     rbp, rsp
     ;Clear the lowest 16 bit after saving rsp, to make sure the stack pointer 16byte aligned
-    and     rsp, -65536
+    and     rsp, -16
 
     push    rbx
     push    rdi
@@ -89,12 +88,12 @@ ASM_PFX(InvokeDemotedRoutine):
     ;Add place holder on stack
     mov     rbx, r8
     cmp     rbx, 2
-    jg      .0
+    jge     .0
     mov     rbx, 2      ; make sure rbx is at least 2, to accomodate the space needed for C functions called below
 .0:
     bt      rbx, 0
-    jc      .1
-    inc     rbx         ; make sure rbx is an odd number
+    jnc     .1
+    inc     rbx         ; make sure rbx is an odd number to "even" the registers pushed above
 .1:
     shl     rbx, 3      ; multiply by 8, so that we have stack holder we wanted to reserve
 

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
@@ -39,13 +39,11 @@ extern ASM_PFX(RestoreCpl0MsrStar)
 extern ASM_PFX(GetBspCpl3Stack)
 extern ASM_PFX(GetThisCpl3Stack)
 
-extern ASM_PFX(RegisteredRing3JumpPointer)
-extern ASM_PFX(RegApRing3JumpPointer)
 extern ASM_PFX(RegErrorReportJumpPointer)
 
 %macro CHECK_RAX    0
     cmp     rax, 0
-    jz      .3
+    jz      .4
 %endmacro
 
 ;------------------------------------------------------------------------------
@@ -70,6 +68,8 @@ ASM_PFX(InvokeDemotedRoutine):
     mov     [rsp + 0x10], rdx
     mov     [rsp + 0x08], rcx
 
+    ; jmp     $
+
     ;Preserve nonvolatile registers, in case demoted routines mess with them
     push    rbp
     mov     rbp, rsp
@@ -84,26 +84,14 @@ ASM_PFX(InvokeDemotedRoutine):
     push    r14
     push    r15
 
-    ;Add place holder on stack
-    mov     rbx, r8
-    cmp     rbx, 4
-    jge     .0
-    mov     rbx, 4      ; make sure rbx is at least 4, to accomodate the space needed for C functions called below
-.0:
-    bt      rbx, 0
-    jnc     .1
-    inc     rbx         ; make sure rbx is an odd number to "even" the registers pushed above
-.1:
-    shl     rbx, 3      ; multiply by 8, so that we have stack holder we want to reserve
-
-    ;Preserve the updated rbp and rbx as we need them on return
+    ;Preserve the updated rbp as we need them on return
     push    rbp
-    push    rbx
 
     sub     rsp, 0x18
     push    rcx
     call    GetThisCpl3Stack
     mov     r15, rax
+    and     r15, -16
     pop     rcx
     add     rsp, 0x18
 
@@ -113,7 +101,7 @@ ASM_PFX(InvokeDemotedRoutine):
     add     rsp, 0x20
 
     ;Setup call gate for return
-    lea     rcx, [.4]
+    lea     rcx, [.5]
     mov     rdx, 1
     sub     rsp, 0x20
     call    SetupCallGate
@@ -158,11 +146,25 @@ ASM_PFX(InvokeDemotedRoutine):
     mov     r9, [rbp + 0x40]            ;Forth input argument for demoted routine
     dec     rax
     CHECK_RAX
-    int     3                           ;Although we can, we do not support demoted function with more than 4 input args...
-
+    ;For further input arguments, they will be put on the stack
+    xor     rbx, rbx                    ;rbx=0
+    mov     r14, rax
+    shl     r14, 3                      ;r14=8*rax
+    sub     r15, r14                    ;r15-=r14, offset the stack for remainder of input arguments
+    sub     r15, 0x20                   ;r15-=0x20, 4 stack parameters
+    and     r15, -16                    ;finally we worry about the stack alignment in CPL3
 .3:
+    mov     r14, [rbp + 0x48 + rbx]     ;r14=*(rbp+0x48+rbx)
+    mov     [r15 + 0x20 + rbx], r14     ;*(r15+0x20+rbx)=r14
+    add     rbx, 0x08                   ;rbx+=0x08
+    dec     rax
+    CHECK_RAX
+    jmp     .3
+
+.4:
     ;Demote to CPL3 by far return, it will take care of cs and ss
     ;Note: we did more pushes on the way, so need to compensate the calculation when grabbing earlier pushed values
+    sub     r15, 0x08                   ;dummy r15 displacement, to mimic the return pointer on the stack
     push    LONG_DS_R3                  ;prepare ss on the stack
     mov     rax, r15                    ;grab Cpl3StackPtr from r15
     push    rax                         ;prepare CPL3 stack pointer on the stack
@@ -176,7 +178,7 @@ ASM_PFX(InvokeDemotedRoutine):
 
     ;2000 years later...
 
-.4:
+.5:
     ;First offset the return far related 4 pushes (we have 0 count of arguments):
     ;PUSH.v old_SS // #SS on this or next pushes use SS.sel as error code
     ;PUSH.v old_RSP
@@ -184,19 +186,19 @@ ASM_PFX(InvokeDemotedRoutine):
     ;PUSH.v next_RIP
     add     rsp, 0x20
 
-    ;Driver entry point is responsible for returning to this point by invoking call gate
-    pop     rbx
-    pop     rbp
+    ;Demoted routine is responsible for returning to this point by invoking call gate
+    ;rbp should be at the top of this stack we set up in the TS
+    mov     rbp, [rsp]
 
     ;Populate the rcx for usage below
     mov     rcx, [rbp + 0x10]
 
     ;Return status should still be in rax, save it before calling other functions
-    sub     rsp, 8
+    sub     rsp, 0x18
     push    rax
     call    RestoreCpl0MsrStar
     pop     rax
-    add     rsp, 8
+    add     rsp, 0x18
 
     xor     rcx, rcx
     mov     cx, LONG_DS_R0
@@ -205,9 +207,8 @@ ASM_PFX(InvokeDemotedRoutine):
     mov     fs, cx
     mov     gs, cx
 
-    ;Then offset the stack place holder for function entry
-    add     rsp, rbx
-
+    add     rsp, 0x08       ;Unwind the rbp from the last net-push
+    ;Unwind the rest of the pushes
     pop     r15
     pop     r14
     pop     r13
@@ -218,402 +219,6 @@ ASM_PFX(InvokeDemotedRoutine):
     mov     rsp, rbp
     pop     rbp
 
-    ret
-
-;------------------------------------------------------------------------------
-; EFI_STATUS
-; EFIAPI
-; InvokeDemotedMmHandler (
-;   IN MMI_HANDLER *DispatchHandle,
-;   IN CONST VOID  *Context         OPTIONAL,
-;   IN OUT VOID    *CommBuffer      OPTIONAL,
-;   IN OUT UINTN   *CommBufferSize  OPTIONAL
-;   );
-; Calling convention: Arg0 in RCX, Arg1 in RDX, Arg2 in R8, Arg3 in R9, more on the stack
-;------------------------------------------------------------------------------
-global ASM_PFX(InvokeDemotedMmHandler)
-ASM_PFX(InvokeDemotedMmHandler):
-    ;Preserve all input parameters onto stack
-    push    rbx
-    push    rbp
-    push    rdi
-    push    rsi
-    push    r12
-    push    r13
-    push    r14
-    push    rcx
-    push    rdx
-    push    r8
-    push    r9
-    push    r15
-
-    ;Place holder on stack
-    sub     rsp, 0x30
-
-    call    GetBspCpl3Stack
-    mov     r15, rax
-
-    call    SetupBspCpl0MsrStar
-
-    ;Setup call gate for return
-    lea     rcx, [MmHandlerReturnPointer]
-    mov     rdx, 1
-    call    SetupCallGate
-
-    ;Setup SetupTssDescriptor for return
-    mov     rcx, rsp
-    mov     rdx, 1
-    call    SetupTssDescriptor
-
-    ;Same level far return to apply GDT change
-    xor     rcx, rcx
-    mov     rcx, cs
-    push    rcx                 ;prepare cs on the stack
-    lea     rax, [.0]
-    push    rax                 ;prepare return rip on the stack
-    retfq
-
-.0:
-    ;Prepare for ds, es, fs, gs
-    xor     rax, rax
-    mov     ax, LONG_DS_R3
-    mov     ds, ax
-    mov     es, ax
-    mov     fs, ax
-    mov     gs, ax
-
-    ;Prepare input arguments
-    mov     rcx, [rsp + 0x30 + 0x20]    ;DispatchHandle from input argument
-    mov     rdx, [rsp + 0x30 + 0x18]    ;Context from input argument
-    mov     r8, [rsp + 0x30 + 0x10]     ;CommBuffer from input argument
-    mov     r9, [rsp + 0x30 + 0x08]     ;CommBufferSize from input argument
-
-    ;Demote to CPL3 by far return, it will take care of cs and ss
-    ;Note: we did more pushes on the way, so need to compensate the calculation when grabbing earlier pushed values
-    push    LONG_DS_R3                  ;prepare ss on the stack
-    mov     rax, r15                    ;grab Cpl3StackPtr from r15
-    sub     rax, 0x08                   ;mimic a push
-    mov     r15, [rcx + 0x18]           ;TODO: This is DispatchHandle->Handler operation
-    mov     [rax], r15                  ;store real handler to stack
-    push    rax                         ;prepare CPL3 stack pointer on the stack
-    push    LONG_CS_R3                  ;prepare cs on the stack
-    mov     rax, strict qword 0         ;mov     rax, ASM_PFX(RegisteredRing3JumpPointer); from ring 3 shim driver
-RegisteredRing3JumpPointerAddr:
-    mov     rax, [rax]                  ;dereference the content of RegisteredRing3JumpPointer
-    push    rax                         ;prepare EntryPoint on the stack
-
-    mov     r15, CALL_GATE_OFFSET       ;This is our way to come back, do not mess it up
-    shl     r15, 32                     ;Call gate on call far stack should be CS:rIP
-    retfq
-
-    ;2000 years later...
-
-MmHandlerReturnPointer:
-    ;Driver entry point is responsible for returning to this point by invoking call gate
-
-    ;First offset the return far related 4 pushes
-    ;PUSH.v old_SS // #SS on this or next pushes use SS.sel as error code
-    ;PUSH.v old_RSP
-    ;PUSH.v old_CS
-    ;PUSH.v next_RIP
-    add     rsp, 0x20
-
-    ;Return status should still be in rax, save it before calling other functions
-    push    rax
-    call    RestoreBspCpl0MsrStar
-    pop     rax
-
-    ;Then offset the stack place holder for function entry
-    add     rsp, 0x30
-
-    xor     rcx, rcx
-    mov     cx, LONG_DS_R0
-    mov     ds, cx
-    mov     es, cx
-    mov     fs, cx
-    mov     gs, cx
-
-    pop     r15
-    pop     r9
-    pop     r8
-    pop     rdx
-    pop     rcx
-    pop     r14
-    pop     r13
-    pop     r12
-    pop     rsi
-    pop     rdi
-    pop     rbp
-    pop     rbx
+    ; jmp     $
 
     ret
-
-;------------------------------------------------------------------------------
-; EFI_STATUS
-; EFIAPI
-; InvokeDemotedApProcedure (
-;   IN UINTN                    CpuIndex,
-;   IN EFI_AP_PROCEDURE2        *Procedure,
-;   IN VOID                     *ProcedureArgument
-;   );
-; Calling convention: Arg0 in RCX, Arg1 in RDX, Arg2 in R8, Arg3 in R9, more on the stack
-;------------------------------------------------------------------------------
-global ASM_PFX(InvokeDemotedApProcedure)
-global ASM_PFX(ApHandlerReturnPointer)
-
-ASM_PFX(InvokeDemotedApProcedure):
-    ;Preserve all input parameters onto stack
-    push    rbx
-    push    rbp
-    push    rdi
-    push    rsi
-    push    r12
-    push    r13
-    push    r14
-    push    rcx
-    push    rdx
-    push    r8
-    push    r9
-    push    r15
-
-    ;Place holder on stack
-    sub     rsp, 0x20
-
-    push    rcx
-    call    GetThisCpl3Stack
-    mov     r15, rax
-    pop     rcx
-
-    ;rcx is CpuIndex, so no worries for this call
-    call    SetupCpl0MsrStar
-
-    ;Setup call gate for return
-    lea     rcx, [ApHandlerReturnPointer]
-    mov     rdx, 1
-    call    SetupCallGate
-
-    ;Setup SetupTssDescriptor for return
-    mov     rcx, rsp
-    mov     rdx, 1
-    call    SetupTssDescriptor
-
-    ;Same level far return to apply GDT change
-    xor     rcx, rcx
-    mov     rcx, cs
-    push    rcx                 ;prepare cs on the stack
-    lea     rax, [.0]
-    push    rax                 ;prepare return rip on the stack
-    retfq
-
-.0:
-    ;Prepare for ds, es, fs, gs
-    xor     rax, rax
-    mov     ax, LONG_DS_R3
-    mov     ds, ax
-    mov     es, ax
-    mov     fs, ax
-    mov     gs, ax
-
-    ;Prepare input arguments
-    mov     rcx, [rsp + 0x20 + 0x18]    ;Procedure from input argument
-    mov     rdx, [rsp + 0x20 + 0x10]    ;ProcedureArgument from input argument
-
-    ;Demote to CPL3 by far return, it will take care of cs and ss
-    ;Note: we did more pushes on the way, so need to compensate the calculation when grabbing earlier pushed values
-    push    LONG_DS_R3                  ;prepare ss on the stack
-    mov     rax, r15                    ;grab Cpl3StackPtr from r15
-    push    rax                         ;prepare CPL3 stack pointer on the stack
-    push    LONG_CS_R3                  ;prepare cs on the stack
-    mov     rax, strict qword 0         ;mov     rax, ASM_PFX(RegApRing3JumpPointer); from ring 3 shim driver
-RegApRing3JumpPointerAddr:
-    mov     rax, [rax]                  ;dereference the content of RegApRing3JumpPointer
-    push    rax                         ;prepare EntryPoint on the stack
-
-    mov     r15, CALL_GATE_OFFSET       ;This is our way to come back, do not mess it up
-    shl     r15, 32                     ;Call gate on call far stack should be CS:rIP
-    retfq
-
-    ;2000 years later...
-
-ASM_PFX(ApHandlerReturnPointer):
-    ;First offset the return far related 4 pushes (we have 0 count of arguments):
-    ;PUSH.v old_SS // #SS on this or next pushes use SS.sel as error code
-    ;PUSH.v old_RSP
-    ;PUSH.v old_CS
-    ;PUSH.v next_RIP
-    add     rsp, 0x20
-
-    ;Driver entry point is responsible for returning to this point by invoking call gate
-    mov     rcx, [rsp + 0x20 + 0x20]
-
-    ;Return status should still be in rax, save it before calling other functions
-    push    rax
-    call    RestoreCpl0MsrStar
-    pop     rax
-
-    ;Then offset the stack place holder for function entry
-    add     rsp, 0x20
-
-    xor     rcx, rcx
-    mov     cx, LONG_DS_R0
-    mov     ds, cx
-    mov     es, cx
-    mov     fs, cx
-    mov     gs, cx
-
-    pop     r15
-    pop     r9
-    pop     r8
-    pop     rdx
-    pop     rcx
-    pop     r14
-    pop     r13
-    pop     r12
-    pop     rsi
-    pop     rdi
-    pop     rbp
-    pop     rbx
-
-    ret
-
-;------------------------------------------------------------------------------
-; EFI_STATUS
-; EFIAPI
-; InvokeDemotedErrorReport (
-;   IN UINTN                    CpuIndex,
-;   IN VOID                     *ErrorInfoBuffer
-;   );
-; Calling convention: Arg0 in RCX, Arg1 in RDX, Arg2 in R8, Arg3 in R9, more on the stack
-;------------------------------------------------------------------------------
-global ASM_PFX(InvokeDemotedErrorReport)
-ASM_PFX(InvokeDemotedErrorReport):
-    ;Preserve all input parameters onto stack
-    push    rbx
-    push    rbp
-    push    rdi
-    push    rsi
-    push    r12
-    push    r13
-    push    r14
-    push    rcx
-    push    rdx
-    push    r8
-    push    r9
-    push    r15
-
-    ;Place holder on stack
-    sub     rsp, 0x30
-
-    push    rcx
-    call    GetThisCpl3Stack
-    mov     r15, rax
-    pop     rcx
-
-    ;rcx is CpuIndex, so no worries for this call
-    call    SetupCpl0MsrStar
-
-    ;Setup call gate for return
-    lea     rcx, [ErrorReportReturnPointer]
-    mov     rdx, 1
-    call    SetupCallGate
-
-    ;Setup SetupTssDescriptor for return
-    mov     rcx, rsp
-    mov     rdx, 1
-    call    SetupTssDescriptor
-
-    ;Same level far return to apply GDT change
-    xor     rcx, rcx
-    mov     rcx, cs
-    push    rcx                 ;prepare cs on the stack
-    lea     rax, [.0]
-    push    rax                 ;prepare return rip on the stack
-    retfq
-
-.0:
-    ;Prepare for ds, es, fs, gs
-    xor     rax, rax
-    mov     ax, LONG_DS_R3
-    mov     ds, ax
-    mov     es, ax
-    mov     fs, ax
-    mov     gs, ax
-
-    ;Prepare input arguments
-    mov     rcx, [rsp + 0x30 + 0x20]    ;CpuIndex from input argument
-    mov     rdx, [rsp + 0x30 + 0x18]    ;ErrorInfoBuffer from input argument
-
-    ;Demote to CPL3 by far return, it will take care of cs and ss
-    ;Note: we did more pushes on the way, so need to compensate the calculation when grabbing earlier pushed values
-    push    LONG_DS_R3                  ;prepare ss on the stack
-    mov     rax, r15                    ;grab Cpl3StackPtr from r15
-    push    rax                         ;prepare CPL3 stack pointer on the stack
-    push    LONG_CS_R3                  ;prepare cs on the stack
-    mov     rax, strict qword 0         ;mov     rax, ASM_PFX(RegErrorReportJumpPointer); from ring 3 shim driver
-RegErrorReportJumpPointerAddr:
-    mov     rax, [rax]                  ;dereference the content of RegErrorReportJumpPointer
-    push    rax                         ;prepare EntryPoint on the stack
-
-    mov     r15, CALL_GATE_OFFSET       ;This is our way to come back, do not mess it up
-    shl     r15, 32                     ;Call gate on call far stack should be CS:rIP
-    retfq
-
-    ;2000 years later...
-
-ErrorReportReturnPointer:
-    ;First offset the return far related 4 pushes (we have 0 count of arguments):
-    ;PUSH.v old_SS // #SS on this or next pushes use SS.sel as error code
-    ;PUSH.v old_RSP
-    ;PUSH.v old_CS
-    ;PUSH.v next_RIP
-    add     rsp, 0x20
-
-    ;Error report function is responsible for returning to this point by invoking call gate
-    mov     rcx, [rsp + 0x30 + 0x20]
-
-    ;Return status should still be in rax, save it before calling other functions
-    push    rax
-    call    RestoreCpl0MsrStar
-    pop     rax
-
-    ;Then offset the stack place holder for function entry
-    add     rsp, 0x30
-
-    xor     rcx, rcx
-    mov     cx, LONG_DS_R0
-    mov     ds, cx
-    mov     es, cx
-    mov     fs, cx
-    mov     gs, cx
-
-    pop     r15
-    pop     r9
-    pop     r8
-    pop     rdx
-    pop     rcx
-    pop     r14
-    pop     r13
-    pop     r12
-    pop     rsi
-    pop     rdi
-    pop     rbp
-    pop     rbx
-
-    ret
-
-global ASM_PFX(PrivilegeMgmtFixupAddress)
-ASM_PFX(PrivilegeMgmtFixupAddress):
-    lea    rax, [ASM_PFX(RegisteredRing3JumpPointer)]
-    lea    rcx, [RegisteredRing3JumpPointerAddr]
-    mov    qword [rcx - 8], rax
-
-    lea    rax, [ASM_PFX(RegApRing3JumpPointer)]
-    lea    rcx, [RegApRing3JumpPointerAddr]
-    mov    qword [rcx - 8], rax
-
-    lea    rax, [ASM_PFX(RegErrorReportJumpPointer)]
-    lea    rcx, [RegErrorReportJumpPointerAddr]
-    mov    qword [rcx - 8], rax
-
-    ret
-

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
@@ -49,6 +49,19 @@ extern ASM_PFX(RegErrorReportJumpPointer)
 ;------------------------------------------------------------------------------
 ; /**
 ;   Invoke specified routine on specified core in CPL 3.
+;
+;   @param[in]      CpuIndex            CpuIndex value of intended core, cannot be
+;                                       greater than mNumberOfCpus.
+;   @param[in]      Cpl3Routine         Function pointer to demoted routine.
+;   @param[in]      ArgCount            Number of arguments needed by Cpl3Routine.
+;   @param          ...                 The variable argument list whose count is defined by
+;                                       ArgCount. Its contented will be accessed and populated
+;                                       to the registers and/or CPL3 stack areas per EFIAPI
+;                                       calling convention.
+;
+;   @retval EFI_SUCCESS                 The demoted routine returns successfully.
+;   @retval Others                      Errors caught by subroutines during ring transitioning
+;                                       or error code returned from demoted routine.
 ; **/
 ; EFI_STATUS
 ; EFIAPI

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
@@ -68,8 +68,6 @@ ASM_PFX(InvokeDemotedRoutine):
     mov     [rsp + 0x10], rdx
     mov     [rsp + 0x08], rcx
 
-    ; jmp     $
-
     ;Preserve nonvolatile registers, in case demoted routines mess with them
     push    rbp
     mov     rbp, rsp
@@ -218,7 +216,5 @@ ASM_PFX(InvokeDemotedRoutine):
     pop     rbx
     mov     rsp, rbp
     pop     rbp
-
-    ; jmp     $
 
     ret

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/CallGateTransfer.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/CallGateTransfer.c
@@ -213,3 +213,23 @@ CallgateInit (
       );
   }
 }
+
+/**
+  Invoke MM driver in CPL 3.
+**/
+EFI_STATUS
+EFIAPI
+InvokeDemotedDriverEntryPoint (
+  IN MM_IMAGE_ENTRY_POINT  *EntryPoint,
+  IN EFI_HANDLE            ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE   *MmSystemTable
+  )
+{
+  return InvokeDemotedRoutine (
+          mSmmMpSyncData->BspIndex,
+          (EFI_PHYSICAL_ADDRESS)(UINTN)EntryPoint,
+          2,
+          ImageHandle,
+          MmSystemTable
+        );
+}

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/CallGateTransfer.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/CallGateTransfer.c
@@ -228,12 +228,12 @@ InvokeDemotedDriverEntryPoint (
   }
 
   return InvokeDemotedRoutine (
-          mSmmMpSyncData->BspIndex,
-          (EFI_PHYSICAL_ADDRESS)(UINTN)EntryPoint,
-          2,
-          ImageHandle,
-          MmSystemTable
-        );
+           mSmmMpSyncData->BspIndex,
+           (EFI_PHYSICAL_ADDRESS)(UINTN)EntryPoint,
+           2,
+           ImageHandle,
+           MmSystemTable
+           );
 }
 
 /**
@@ -252,20 +252,20 @@ InvokeDemotedMmHandler (
     return EFI_INVALID_PARAMETER;
   }
 
-  if ((VOID*)RegisteredRing3JumpPointer == NULL) {
+  if ((VOID *)RegisteredRing3JumpPointer == NULL) {
     return EFI_NOT_READY;
   }
 
   return InvokeDemotedRoutine (
-          mSmmMpSyncData->BspIndex,
-          (EFI_PHYSICAL_ADDRESS)RegisteredRing3JumpPointer,
-          5,
-          DispatchHandle,
-          Context,
-          CommBuffer,
-          CommBufferSize,
-          DispatchHandle->Handler
-        );
+           mSmmMpSyncData->BspIndex,
+           (EFI_PHYSICAL_ADDRESS)RegisteredRing3JumpPointer,
+           5,
+           DispatchHandle,
+           Context,
+           CommBuffer,
+           CommBufferSize,
+           DispatchHandle->Handler
+           );
 }
 
 /**
@@ -279,21 +279,21 @@ InvokeDemotedApProcedure (
   IN VOID               *ProcedureArgument
   )
 {
-  if (Procedure == NULL || ProcedureArgument == NULL) {
+  if ((Procedure == NULL) || (ProcedureArgument == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 
-  if ((VOID*)RegApRing3JumpPointer == NULL) {
+  if ((VOID *)RegApRing3JumpPointer == NULL) {
     return EFI_NOT_READY;
   }
 
   return InvokeDemotedRoutine (
-          CpuIndex,
-          (EFI_PHYSICAL_ADDRESS)RegApRing3JumpPointer,
-          2,
-          Procedure,
-          ProcedureArgument
-        );
+           CpuIndex,
+           (EFI_PHYSICAL_ADDRESS)RegApRing3JumpPointer,
+           2,
+           Procedure,
+           ProcedureArgument
+           );
 }
 
 /**
@@ -312,15 +312,15 @@ InvokeDemotedErrorReport (
     return EFI_INVALID_PARAMETER;
   }
 
-  if ((VOID*)RegErrorReportJumpPointer == NULL) {
+  if ((VOID *)RegErrorReportJumpPointer == NULL) {
     return EFI_NOT_READY;
   }
 
   return InvokeDemotedRoutine (
-          CpuIndex,
-          (EFI_PHYSICAL_ADDRESS)RegErrorReportJumpPointer,
-          2,
-          CpuIndex,
-          ErrorInfoBuffer
-        );
+           CpuIndex,
+           (EFI_PHYSICAL_ADDRESS)RegErrorReportJumpPointer,
+           2,
+           CpuIndex,
+           ErrorInfoBuffer
+           );
 }

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/CallGateTransfer.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/CallGateTransfer.c
@@ -195,17 +195,15 @@ CallgateInit (
   UINTN                 CpuIndex;
   EFI_PHYSICAL_ADDRESS  GdtrBaseAddr;
 
-  PrivilegeMgmtFixupAddress ();
-
   for (CpuIndex = 0; CpuIndex < NumberOfCpus; CpuIndex++) {
     if (CpuIndex == mSmmMpSyncData->BspIndex) {
       // BSP call gate will change, patch at runtime
       continue;
     }
 
-    // Patch AP handlers call gate and stack here as they are static after init
+    // Patch AP handlers call gate here, they can still change during later usage
     GdtrBaseAddr = mGdtBuffer + mGdtStepSize * CpuIndex;
-    PatchCallGatePtr ((IA32_IDT_GATE_DESCRIPTOR *)(UINTN)(GdtrBaseAddr + CALL_GATE_OFFSET), (VOID *)ApHandlerReturnPointer);
+    PatchCallGatePtr ((IA32_IDT_GATE_DESCRIPTOR *)(UINTN)(GdtrBaseAddr + CALL_GATE_OFFSET), (VOID *)NULL);
     PatchTssDescriptor (
       (IA32_TSS_DESCRIPTOR *)(UINTN)(GdtrBaseAddr + TSS_SEL_OFFSET),
       (IA32_TASK_STATE_SEGMENT *)(UINTN)(GdtrBaseAddr + TSS_DESC_OFFSET),
@@ -225,11 +223,104 @@ InvokeDemotedDriverEntryPoint (
   IN EFI_MM_SYSTEM_TABLE   *MmSystemTable
   )
 {
+  if (EntryPoint == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   return InvokeDemotedRoutine (
           mSmmMpSyncData->BspIndex,
           (EFI_PHYSICAL_ADDRESS)(UINTN)EntryPoint,
           2,
           ImageHandle,
           MmSystemTable
+        );
+}
+
+/**
+  Invoke MM handler in CPL 3.
+**/
+EFI_STATUS
+EFIAPI
+InvokeDemotedMmHandler (
+  IN MMI_HANDLER  *DispatchHandle,
+  IN CONST VOID   *Context         OPTIONAL,
+  IN OUT VOID     *CommBuffer      OPTIONAL,
+  IN OUT UINTN    *CommBufferSize  OPTIONAL
+  )
+{
+  if (DispatchHandle == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((VOID*)RegisteredRing3JumpPointer == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  return InvokeDemotedRoutine (
+          mSmmMpSyncData->BspIndex,
+          (EFI_PHYSICAL_ADDRESS)RegisteredRing3JumpPointer,
+          5,
+          DispatchHandle,
+          Context,
+          CommBuffer,
+          CommBufferSize,
+          DispatchHandle->Handler
+        );
+}
+
+/**
+  Invoke AP Procedure in CPL 3.
+**/
+EFI_STATUS
+EFIAPI
+InvokeDemotedApProcedure (
+  IN UINTN              CpuIndex,
+  IN EFI_AP_PROCEDURE2  Procedure,
+  IN VOID               *ProcedureArgument
+  )
+{
+  if (Procedure == NULL || ProcedureArgument == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((VOID*)RegApRing3JumpPointer == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  return InvokeDemotedRoutine (
+          CpuIndex,
+          (EFI_PHYSICAL_ADDRESS)RegApRing3JumpPointer,
+          2,
+          Procedure,
+          ProcedureArgument
+        );
+}
+
+/**
+  Invoke Error Report function in CPL 3, if registered.
+
+  Note: Never call this from the syscall dispatcher.
+**/
+EFI_STATUS
+EFIAPI
+InvokeDemotedErrorReport (
+  IN UINTN  CpuIndex,
+  IN VOID   *ErrorInfoBuffer
+  )
+{
+  if (ErrorInfoBuffer == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((VOID*)RegErrorReportJumpPointer == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  return InvokeDemotedRoutine (
+          CpuIndex,
+          (EFI_PHYSICAL_ADDRESS)RegErrorReportJumpPointer,
+          2,
+          CpuIndex,
+          ErrorInfoBuffer
         );
 }

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/PrivilegeMgmt.h
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/PrivilegeMgmt.h
@@ -119,6 +119,18 @@ SyncMmEntryContextToCpl3 (
   );
 
 /**
+  Invoke specified routine on specified core in CPL 3.
+**/
+EFI_STATUS
+EFIAPI
+InvokeDemotedRoutine (
+  IN UINTN                 CpuIndex,
+  IN EFI_PHYSICAL_ADDRESS  Cpl3Routine,
+  IN UINTN                 ArgCount,
+  ...
+  );
+
+/**
   Invoke MM driver in CPL 3.
 **/
 EFI_STATUS

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/PrivilegeMgmt.h
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/PrivilegeMgmt.h
@@ -108,6 +108,19 @@ SyncMmEntryContextToCpl3 (
 
 /**
   Invoke specified routine on specified core in CPL 3.
+
+  @param[in]      CpuIndex            CpuIndex value of intended core, cannot be
+                                      greater than mNumberOfCpus.
+  @param[in]      Cpl3Routine         Function pointer to demoted routine.
+  @param[in]      ArgCount            Number of arguments needed by Cpl3Routine.
+  @param          ...                 The variable argument list whose count is defined by
+                                      ArgCount. Its contented will be accessed and populated
+                                      to the registers and/or CPL3 stack areas per EFIAPI
+                                      calling convention.
+
+  @retval EFI_SUCCESS                 The demoted routine returns successfully.
+  @retval Others                      Errors caught by subroutines during ring transitioning
+                                      or error code returned from demoted routine.
 **/
 EFI_STATUS
 EFIAPI

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/PrivilegeMgmt.h
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/PrivilegeMgmt.h
@@ -93,18 +93,6 @@ SyscallCenter (
   UINTN  CallerAddr
   );
 
-VOID
-EFIAPI
-PrivilegeMgmtFixupAddress (
-  VOID
-  );
-
-VOID
-EFIAPI
-ApHandlerReturnPointer (
-  VOID
-  );
-
 // Setup ring transition for AP procedure
 VOID
 EFIAPI

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SysCallEntry.nasm
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SysCallEntry.nasm
@@ -78,6 +78,9 @@ ASM_PFX(SyscallCenter):
     push    r14
     push    r15
 
+    mov     rbp, rsp
+    and     rsp, -16
+
     ;; FX_SAVE_STATE_X64 FxSaveState;
     sub rsp, 512
     mov rdi, rsp
@@ -112,6 +115,8 @@ ASM_PFX(SyscallCenter):
     mov rsi, rsp
     db 0xf, 0xae, 0xE ; fxrstor [rsi]
     add rsp, 512
+
+    mov     rsp, rbp
 
     ;restore registers from CPL3 stack
     pop     r15

--- a/MmSupervisorPkg/Drivers/MmSupervisorErrorReport/AsmErrorReportRing3JumpPointer.nasm
+++ b/MmSupervisorPkg/Drivers/MmSupervisorErrorReport/AsmErrorReportRing3JumpPointer.nasm
@@ -15,21 +15,20 @@ extern ASM_PFX(MmSupvErrorReportWorker)
 ; EFIAPI
 ; RegErrorReportJumpPointer (
 ;   IN UINTN                    CpuIndex,
-;   IN VOID                     *ErrorInfoBuffer,
-;   IN UINTN                    ErrorInfoSize
+;   IN MM_SUPV_TELEMETRY_DATA   *ErrorInfoBuffer
 ;   )
 ; Calling convention: Arg0 in RCX, Arg1 in RDX, Arg2 in R8, Arg3 in R9, more on the stack
 ;------------------------------------------------------------------------------
 global ASM_PFX(RegErrorReportJumpPointer)
 ASM_PFX(RegErrorReportJumpPointer):
     ;By the time we are here, it should be everything CPL3 already
-    sub     rsp, 0x18
+    sub     rsp, 0x28
 
     ;To boot strap this procedure, we directly call the registered procedure worker
     call    MmSupvErrorReportWorker
 
     ;Restore the stack pointer
-    add     rsp, 0x18
+    add     rsp, 0x28
 
     ;Once returned, we will get returned status in rax, don't touch it, if you can help
     ;r15 contains call gate selector that was planned ahead

--- a/MmSupervisorPkg/Library/StandaloneMmDriverEntryPoint/AsmStandaloneMmDriverEntryPoint.nasm
+++ b/MmSupervisorPkg/Library/StandaloneMmDriverEntryPoint/AsmStandaloneMmDriverEntryPoint.nasm
@@ -22,13 +22,13 @@ extern ASM_PFX(_ModuleEntryPointWorker)
 global ASM_PFX(_ModuleEntryPoint)
 ASM_PFX(_ModuleEntryPoint):
     ;By the time we are here, it should be everything CPL3 already
-    sub     rsp, 0x18
+    sub     rsp, 0x28
 
     ;To boot strap this driver, we directly call the entry point worker
     call    _ModuleEntryPointWorker
 
     ;Restore the stack pointer
-    add     rsp, 0x18
+    add     rsp, 0x28
 
     ;Once returned, we will get returned status in rax, don't touch it, if you can help
     ;r15 contains call gate selector that was planned ahead


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

In the original implementation, each operation privilege transitioning has its own function, which is mostly alike, causing the same change having to be replicated four times each change involving these routines..

This change mainly converges the 4 routines into a general-purpose assembly routine `InvokeDemotedRoutine`, which accepts variable input arguments and transition them into desired function, for both BSP and AP procedures.

In the meantime, this change also fixes stack alignment discrepancy when the program is built on GCC vs. VC by caching the input stack in RBP. This should fix the issue reported: https://github.com/microsoft/mu_tiano_platforms/issues/111.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change was tested on QEMU Q35 platform built with both GCC and VC, as well as on proprietary hardware. All binaries can boot to Windows OS.

## Integration Instructions

N/A
