### PR TITLE
Fixed stack corruption issues with assembly routine

### DIFF
--- a/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
@@ -98,13 +98,13 @@ ASM_PFX(InvokeDemotedRoutine):
     ;Preserve the updated rbp as we need them on return
     push    rbp
 
-    sub     rsp, 0x18
     push    rcx
+    sub     rsp, 0x28
     call    GetThisCpl3Stack
+    add     rsp, 0x28
     mov     r15, rax
     and     r15, -16
     pop     rcx
-    add     rsp, 0x18
 
     ;rcx is CpuIndex, so no worries for this call
     sub     rsp, 0x20
@@ -205,11 +205,11 @@ ASM_PFX(InvokeDemotedRoutine):
     mov     rcx, [rbp + 0x10]
 
     ;Return status should still be in rax, save it before calling other functions
-    sub     rsp, 0x18
     push    rax
+    sub     rsp, 0x28
     call    RestoreCpl0MsrStar
+    add     rsp, 0x28
     pop     rax
-    add     rsp, 0x18
 
     xor     rcx, rcx
     mov     cx, LONG_DS_R0

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/AsmCallGateTransfer.nasm
@@ -102,9 +102,9 @@ ASM_PFX(InvokeDemotedRoutine):
     sub     rsp, 0x28
     call    GetThisCpl3Stack
     add     rsp, 0x28
+    pop     rcx
     mov     r15, rax
     and     r15, -16
-    pop     rcx
 
     ;rcx is CpuIndex, so no worries for this call
     sub     rsp, 0x20


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The existing routine does not reserve enough number of stack segment before calling into other C functions (more information can be seen [here](https://learn.microsoft.com/en-us/cpp/build/stack-usage?view=msvc-170#stack-allocation)), which could cause the reserved memory on the stack to be corrupted and consumed.

This change allocated enough parameter space on the stack before calling into other functions and unwind the displacement after returning.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 virtual platform.

## Integration Instructions

N/A
