### PR TITLE
Untangle syscall entry logging using feature PCD

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -179,6 +179,7 @@
   gUefiCpuPkgTokenSpaceGuid.PcdSmmExceptionTestModeSupport         ## CONSUMES ## MS_CHANGE
   gMmSupervisorPkgTokenSpaceGuid.PcdMmSupervisorTestEnable         ## CONSUMES
   gMmSupervisorPkgTokenSpaceGuid.PcdMmSupervisorPrintPortsEnable   ## CONSUMES
+  gMmSupervisorPkgTokenSpaceGuid.PcdEnableSyscallLogs              ## CONSUMES
 
 [FixedPcd]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber        ## SOMETIMES_CONSUMES

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
@@ -633,5 +633,6 @@ Exit:
   if (FeaturePcdGet (PcdEnableSyscallLogs)) {
     DEBUG ((DEBUG_INFO, "%a Exit...\n", __FUNCTION__));
   }
+
   return Ret;
 }

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
@@ -238,7 +238,7 @@ SyscallDispatcher (
     mPcdCheck     = FALSE;
   }
 
-  if (FixedPcdGetBool (PcdEnableSyscallLogs)) {
+  if (FeaturePcdGet (PcdEnableSyscallLogs)) {
     while (!AcquireSpinLockOrFail (mCpuToken)) {
       CpuPause ();
     }
@@ -630,7 +630,7 @@ Exit:
     CpuDeadLoop ();
   }
 
-  if (FixedPcdGetBool (PcdEnableSyscallLogs)) {
+  if (FeaturePcdGet (PcdEnableSyscallLogs)) {
     DEBUG ((DEBUG_VERBOSE, "%a Exit...\n", __FUNCTION__));
   }
   return Ret;

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
@@ -244,7 +244,7 @@ SyscallDispatcher (
     }
 
     DEBUG ((
-      DEBUG_VERBOSE,
+      DEBUG_INFO,
       "%a Enter... CallIndex: %lx, Arg1: %lx, Arg2: %lx, Arg3: %lx, CallerAddr: %p, Ring3Stack %p\n",
       __FUNCTION__,
       CallIndex,
@@ -631,7 +631,7 @@ Exit:
   }
 
   if (FeaturePcdGet (PcdEnableSyscallLogs)) {
-    DEBUG ((DEBUG_VERBOSE, "%a Exit...\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a Exit...\n", __FUNCTION__));
   }
   return Ret;
 }

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
@@ -238,23 +238,25 @@ SyscallDispatcher (
     mPcdCheck     = FALSE;
   }
 
-  while (!AcquireSpinLockOrFail (mCpuToken)) {
-    CpuPause ();
+  if (FixedPcdGetBool (PcdEnableSyscallLogs)) {
+    while (!AcquireSpinLockOrFail (mCpuToken)) {
+      CpuPause ();
+    }
+
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "%a Enter... CallIndex: %lx, Arg1: %lx, Arg2: %lx, Arg3: %lx, CallerAddr: %p, Ring3Stack %p\n",
+      __FUNCTION__,
+      CallIndex,
+      Arg1,
+      Arg2,
+      Arg3,
+      CallerAddr,
+      Ring3StackPointer
+      ));
+
+    ReleaseSpinLock (mCpuToken);
   }
-
-  DEBUG ((
-    DEBUG_VERBOSE,
-    "%a Enter... CallIndex: %lx, Arg1: %lx, Arg2: %lx, Arg3: %lx, CallerAddr: %p, Ring3Stack %p\n",
-    __FUNCTION__,
-    CallIndex,
-    Arg1,
-    Arg2,
-    Arg3,
-    CallerAddr,
-    Ring3StackPointer
-    ));
-
-  ReleaseSpinLock (mCpuToken);
 
   // The real policy come from DRTM event is copied over to FirmwarePolicy
   switch (CallIndex) {
@@ -628,6 +630,8 @@ Exit:
     CpuDeadLoop ();
   }
 
-  DEBUG ((DEBUG_VERBOSE, "%a Exit...\n", __FUNCTION__));
+  if (FixedPcdGetBool (PcdEnableSyscallLogs)) {
+    DEBUG ((DEBUG_VERBOSE, "%a Exit...\n", __FUNCTION__));
+  }
   return Ret;
 }

--- a/MmSupervisorPkg/MmSupervisorPkg.dec
+++ b/MmSupervisorPkg/MmSupervisorPkg.dec
@@ -65,6 +65,14 @@
   #    FALSE - Don't print out the MSR and IO ports as normal.
   gMmSupervisorPkgTokenSpaceGuid.PcdMmSupervisorPrintPortsEnable|FALSE|BOOLEAN|0x00010002
 
+  ## Indicates if syscall entry logs should be printed out.<BR>
+  #  Enabling this will extensively slow down the boot process and bloated the boot log output.<BR>
+  #  It is suggested to enable this logging exclusively for syscall usage/distribution analysis.<BR>
+  #
+  #    TRUE  - Print out each syscall requests through out this boot.
+  #    FALSE - Don't print out any syscall request entries.
+  gMmSupervisorPkgTokenSpaceGuid.PcdEnableSyscallLogs|FALSE|BOOLEAN|0x00010003
+
 [PcdsFixedAtBuild]
   ## Size of supervisor communication buffer in number of pages
   gMmSupervisorPkgTokenSpaceGuid.PcdSupervisorCommBufferPages|16|UINT64|0x00000001


### PR DESCRIPTION
## Description

Resolves #99 

This change will introduce a new PCD to untangle the syscall entry logging from verbose level. Per feedback from this issue: https://github.com/microsoft/mu_feature_mm_supv/issues/99, the logging is too intrusive to allow the system booting reasonably.

The newly introduced PCD will disable the logging by default to allow system to continue using verbose without further negatively impacting the booting process.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This change was tested on QEMU Q35 virtual platform.

## Integration Instructions

Platform should leave the newly introduced PCD as is to use the default disable setting. Should the platform want to enable syscall usage analysis, one can enable it by setting `gMmSupervisorPkgTokenSpaceGuid.PcdEnableSyscallLogs|TRUE` for analysis purposes.