### PR TITLE
Fix shell-based unit test for supervisor requests

### DIFF
--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
@@ -262,7 +262,7 @@ MmSupvRequestDxeToMmCommunicate (
     DEBUG ((DEBUG_VERBOSE, "[%a] - Communicate() = %r\n", __FUNCTION__, Status));
   }
 
-  return ((MM_SUPERVISOR_REQUEST_HEADER *)CommHeader->Data)->Result;
+  return Status;
 }
 
 /*
@@ -294,13 +294,22 @@ FetchSecurityPolicyFromSupv (
   Status = MmSupvRequestDxeToMmCommunicate ();
 
   if (EFI_ERROR (Status)) {
-    // We encountered some errors on our way fetching policy.
-    UT_LOG_ERROR ("Supervisor did not successfully returned policy %r.", Status);
-  } else {
-    SecurityPolicy = (SMM_SUPV_SECURE_POLICY_DATA_V1_0 *)(CommBuffer + 1);
-    DUMP_HEX (DEBUG_INFO, 0, SecurityPolicy, SecurityPolicy->Size, "");
+    // We encountered some MM systematic errors on our way unblocking memory.
+    UT_LOG_ERROR ("Supervisor is not successfully communicated %r.", Status);
+    goto Done;
   }
 
+  // Get the real handler status code
+  if ((UINTN)CommBuffer->Result != 0) {
+    Status = ENCODE_ERROR ((UINTN)CommBuffer->Result);
+    UT_LOG_ERROR ("Supervisor did not successfully return policy %r.", Status);
+    goto Done;
+  }
+
+  SecurityPolicy = (SMM_SUPV_SECURE_POLICY_DATA_V1_0 *)(CommBuffer + 1);
+  DUMP_HEX (DEBUG_INFO, 0, SecurityPolicy, SecurityPolicy->Size, "");
+
+Done:
   return SecurityPolicy;
 }
 
@@ -635,8 +644,7 @@ RequestVersionInfo (
 
   if (EFI_ERROR (Status)) {
     // We encountered some errors on our way fetching version information.
-    UT_LOG_ERROR ("Supervisor did not successfully returned version info %r.", Status);
-    return UNIT_TEST_ERROR_TEST_FAILED;
+    UT_ASSERT_NOT_EFI_ERROR (Status);
   }
 
   // Get the real handler status code
@@ -670,8 +678,7 @@ RequestUnblockRegion (
 
   TargetPage = AllocatePages (1);
   if (TargetPage == NULL) {
-    UT_LOG_ERROR ("Target memory allocation failed.");
-    return UNIT_TEST_ERROR_TEST_FAILED;
+    UT_ASSERT_NOT_NULL (TargetPage);
   }
 
   // Grab the CommBuffer and fill it in for this test
@@ -692,8 +699,7 @@ RequestUnblockRegion (
 
   if (EFI_ERROR (Status)) {
     // We encountered some MM systematic errors on our way unblocking memory.
-    UT_LOG_ERROR ("Supervisor did not successfully returned policy %r.", Status);
-    return UNIT_TEST_ERROR_TEST_FAILED;
+    UT_ASSERT_NOT_EFI_ERROR (Status);
   }
 
   // This unit test runs in shell, which is past unblock window (ready to lock)
@@ -873,9 +879,8 @@ RequestUpdateCommBuffer (
   Status = MmSupvRequestDxeToMmCommunicate ();
 
   if (EFI_ERROR (Status)) {
-    // We encountered some errors on our way fetching version information.
-    UT_LOG_ERROR ("Supervisor did not successfully return from communication %r.", Status);
-    return UNIT_TEST_ERROR_TEST_FAILED;
+    // We encountered some errors on our way updating communication buffer.
+    UT_ASSERT_NOT_EFI_ERROR (Status);
   }
 
   // Get the real handler status code


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

There has been 2 false negative noticed during QEMU unit test runs. These were caused by 2-fold of mistakes:
1. The usage of unit test functions. It turned out that only the UT_ASSERT* macros are capable of logging errors to the XML.
2. The returned status of the service request was already extracted by `MmSupvRequestDxeToMmCommunicate`, but the caller thought this was the return status of MM communication.

This change updated the macro usage and fixed the logic of returning MM communication status.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU virtual platforms.

## Integration Instructions

N/A
