### PR TITLE
MmSupvervisorPkg/MmSupvRequestUnitTestApp: Add debug info

### DIFF
--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvMemPolicyUnitTest.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvMemPolicyUnitTest.c
@@ -285,8 +285,25 @@ VerifyIommuMemoryWithPolicy (
     goto Done;
   }
 
+  DEBUG ((DEBUG_INFO, "[%a] - Discovered %Ld IOMMU regions.\n", __FUNCTION__, Count));
+
   for (Index1 = 0; Index1 < Count; Index1++) {
+    DEBUG ((DEBUG_INFO, "[%a] - Checking the following IOMMU region:\n", __FUNCTION__));
+    DEBUG ((
+      DEBUG_INFO,
+      "[%a] -   IOMMU Region: Base = 0x%016Lx. Size = 0x%016Lx.\n",
+      __FUNCTION__,
+      IommuBases[Index1],
+      IommuSizes[Index1]
+      ));
     for (Index2 = 0; Index2 < MemPolicyCount; Index2++) {
+      DEBUG ((
+        DEBUG_INFO,
+        "[%a] -     Against Memory Descriptor: Base = 0x%016Lx. Size = 0x%016Lx.\n",
+        __FUNCTION__,
+        MemDesc[Index2].BaseAddress,
+        MemDesc[Index2].Size
+        ));
       if ((((IommuBases[Index1] <= MemDesc[Index2].BaseAddress) &&
             (IommuBases[Index1] + IommuSizes[Index1] > MemDesc[Index2].BaseAddress))) ||
           ((IommuBases[Index1] < (MemDesc[Index2].BaseAddress + MemDesc[Index2].Size)) &&

--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
@@ -295,14 +295,14 @@ FetchSecurityPolicyFromSupv (
 
   if (EFI_ERROR (Status)) {
     // We encountered some MM systematic errors on our way unblocking memory.
-    UT_LOG_ERROR ("Supervisor is not successfully communicated %r.", Status);
+    UT_LOG_ERROR ("Supervisor is not successfully communicated %r.\n", Status);
     goto Done;
   }
 
   // Get the real handler status code
   if ((UINTN)CommBuffer->Result != 0) {
     Status = ENCODE_ERROR ((UINTN)CommBuffer->Result);
-    UT_LOG_ERROR ("Supervisor did not successfully return policy %r.", Status);
+    UT_LOG_ERROR ("Supervisor did not successfully return policy %r.\n", Status);
     goto Done;
   }
 
@@ -656,7 +656,7 @@ RequestVersionInfo (
 
   if (EFI_ERROR (Status)) {
     // We encountered some errors on our way fetching version information.
-    UT_LOG_ERROR ("Supervisor did not successfully process version info request %r.", Status);
+    UT_LOG_ERROR ("Supervisor did not successfully process version info request %r.\n", Status);
     UT_ASSERT_NOT_EFI_ERROR (Status);
   }
 
@@ -670,7 +670,7 @@ RequestVersionInfo (
   VersionInfo = (MM_SUPERVISOR_VERSION_INFO_BUFFER *)(CommBuffer + 1);
   UT_ASSERT_EQUAL (VersionInfo->MaxSupervisorRequestLevel, MM_SUPERVISOR_REQUEST_MAX_SUPPORTED);
 
-  UT_LOG_INFO ("Supervisor version %x, patch level %x.", VersionInfo->Version, VersionInfo->PatchLevel);
+  UT_LOG_INFO ("Supervisor version %x, patch level %x.\n", VersionInfo->Version, VersionInfo->PatchLevel);
 
   return UNIT_TEST_PASSED;
 }
@@ -691,7 +691,7 @@ RequestUnblockRegion (
 
   TargetPage = AllocatePages (1);
   if (TargetPage == NULL) {
-    UT_LOG_ERROR ("Target memory allocation failed.");
+    UT_LOG_ERROR ("Target memory allocation failed.\n");
     UT_ASSERT_NOT_NULL (TargetPage);
   }
 
@@ -713,7 +713,7 @@ RequestUnblockRegion (
 
   if (EFI_ERROR (Status)) {
     // We encountered some MM systematic errors on our way unblocking memory.
-    UT_LOG_ERROR ("Supervisor did not successfully process unblock request %r.", Status);
+    UT_LOG_ERROR ("Supervisor did not successfully process unblock request %r.\n", Status);
     UT_ASSERT_NOT_EFI_ERROR (Status);
   }
 
@@ -862,7 +862,7 @@ InspectSecurityPolicy (
 
 Done:
   DEBUG ((DEBUG_INFO, "The fetch policy is at level %d\n", FinalLevel));
-  UT_LOG_INFO ("The fetch policy is at level %d", FinalLevel);
+  UT_LOG_INFO ("The fetch policy is at level %d\n", FinalLevel);
 
   // If we can get policy but still get 0 mm measurement level, something is messed up...
   UT_ASSERT_TRUE (FinalLevel > 0);
@@ -904,7 +904,7 @@ RequestUpdateCommBuffer (
 
   if (EFI_ERROR (Status)) {
     // We encountered some errors on our way updating communication buffer.
-    UT_LOG_ERROR ("Supervisor did not successfully process communication buffer update request %r.", Status);
+    UT_LOG_ERROR ("Supervisor did not successfully process communication buffer update request %r.\n", Status);
     UT_ASSERT_NOT_EFI_ERROR (Status);
   }
 


### PR DESCRIPTION
## Description

Updates the `UT_LOG_*` messages to print a new line so the prints
do not run into the individual test section dividers.

Prints additional information when examining IOMMU regions to show
what regions are being considered and specific details about
potential range overlaps.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Ran test on a physical Intel platform and reviewed debug output.

## Integration Instructions

N/A