### PR TITLE
MmSupervisorPkg/Test/MmSupvRequestUnitTestApp: Update Request Comm Buffer test logic

### DIFF
--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
@@ -902,12 +902,6 @@ RequestUpdateCommBuffer (
 
   Status = MmSupvRequestDxeToMmCommunicate ();
 
-  if (EFI_ERROR (Status)) {
-    // We encountered some errors on our way updating communication buffer.
-    UT_LOG_ERROR ("Supervisor did not successfully process communication buffer update request %r.", Status);
-    UT_ASSERT_NOT_EFI_ERROR (Status);
-  }
-
   // Get the real handler status code
   if ((UINTN)CommBuffer->Result != 0) {
     Status = ENCODE_ERROR ((UINTN)CommBuffer->Result);


### PR DESCRIPTION
## Description

The test currently calls `MmSupvRequestDxeToMmCommunicate()` and
checks if the return status code (the result from the comm buffer
request - `MM_SUPERVISOR_REQUEST_HEADER *)CommHeader->Data)->Result`)
is an `EFI_ERROR`.

Because the value is read from the comm buffer result, it will be
`EFI_ACCESS_DENIED` which is expected for the test to pass.

This change removes that check (to not impact other
`MmSupvRequestDxeToMmCommunicate()` callers) and continues to check
if the status code is `EFI_ACCESS_DENIED`.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Executed change on a physical platform to check results.

## Integration Instructions

N/A