### PR TITLE
Evaluate protected regions with proper memory attribute checks

### DIFF
--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvMemPolicyUnitTest.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvMemPolicyUnitTest.c
@@ -498,15 +498,15 @@ VerifyMemPolicy (
   // So level 10 passed, set it to at least level 10
   *Level = SMM_POLICY_LEVEL_10;
 
-  // // Level 20:
-  // // Write access must be denied to any MMIO or other system registers which allow configuration of any of the system IOMMUs
-  // Status = VerifyIommuMemoryWithPolicy (MemPolicy, MemPolicyCount, AccessAttr);
-  // if (EFI_ERROR (Status)) {
-  //   DEBUG ((DEBUG_WARN, "%a Failed to validate memory policy against IOMMU regions - %r\n", __FUNCTION__, Status));
-  //   // This is not an error anymore, since it should at least get level 10 report
-  //   Status = EFI_SUCCESS;
-  //   goto Done;
-  // }
+  // Level 20:
+  // Write access must be denied to any MMIO or other system registers which allow configuration of any of the system IOMMUs
+  Status = VerifyIommuMemoryWithPolicy (MemPolicy, MemPolicyCount, AccessAttr);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "%a Failed to validate memory policy against IOMMU regions - %r\n", __FUNCTION__, Status));
+    // This is not an error anymore, since it should at least get level 10 report
+    Status = EFI_SUCCESS;
+    goto Done;
+  }
 
   // So level 20 passed, set it to at least level 20
   *Level = SMM_POLICY_LEVEL_20;

--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvMemPolicyUnitTest.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvMemPolicyUnitTest.c
@@ -373,6 +373,12 @@ VerifyTxtMemoryWithPolicy (
       TxtBases[Index1],
       TxtSizes[Index1]
       ));
+
+    if (TxtBases[Index1] == 0) {
+      // This is region is probably not initialized, finding a hit with NULL does not make much sense, skip it
+      continue;
+    }
+
     for (Index2 = 0; Index2 < MemPolicyCount; Index2++) {
       DEBUG ((
         DEBUG_INFO,


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change updated the unit test to inspect retrieved MM policy attribute against protected regions, such as TXT and IOMMU regions as defined by WHCP specification.

Although the specification only mentions that the regions should have no write access, this implementation will flag attributes on executable protected regions.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is tested on QemuQ35Pkg.

## Integration Instructions

N/A
