### PR TITLE
MmSupervisorPkg: Remove bare excepts

### DIFF
--- a/MmSupervisorPkg/SupervisorPolicyTools/policy_entry.py
+++ b/MmSupervisorPkg/SupervisorPolicyTools/policy_entry.py
@@ -525,7 +525,7 @@ class InstructionPolicyEntry(PolicyEntry):
         self.Header = PolicyEntryHeader(POLICY_TYPE.INSTRUCTION, self._StructSizeLegacy)
         try:
             self.InstructionIndex = int(SUPPORTED_INSTRUCTION[InstructionName.upper()]) # UINT16
-        except:
+        except Exception:
             self.InstructionIndex = -1
         self.Attributes = AccessType(Attributes)  # UINT16
 
@@ -589,11 +589,11 @@ class SaveStatePolicyEntry(PolicyEntry):
         self.Header = PolicyEntryHeader(POLICY_TYPE.SAVESTATE, self._StructSize)
         try:
             self.SaveStateIndex = int(ALLOWED_SAVE_STATE_FIELD[SaveStateFieldName.upper()]) # UINT32
-        except:
+        except Exception:
             self.SaveStateIndex = -1
         try:
             self.AccessCondition = int(ALLOWED_SAVE_STATE_ACCESS_CONDITION[AccessCondition.upper()]) # UINT32
-        except:
+        except Exception:
             self.AccessCondition = 0
         self.Attributes = AccessType(Attributes)  # UINT32
 

--- a/MmSupervisorPkg/Test/MmPagingAuditTest/Windows/MemoryRangeObjects.py
+++ b/MmSupervisorPkg/Test/MmPagingAuditTest/Windows/MemoryRangeObjects.py
@@ -111,14 +111,14 @@ class MemoryRange(object):
             return "None"
         else:
             try: return MemoryRange.MemoryMapTypes[self.MemoryType]
-            except: raise Exception("Memory type is invalid")
+            except Exception: raise Exception("Memory type is invalid")
 
     def GetSystemMemoryType(self):
         if self.SystemMemoryType is None:
             return "None"
         try:
             return MemoryRange.SystemMemoryTypes[self.SystemMemoryType]
-        except:
+        except Exception:
             raise Exception("System Memory Type is invalid %d" % self.SystemMemoryType)
 
 


### PR DESCRIPTION
## Description

Catching a bare exception is considered bad practice.  Catching bare exceptions can make it impossible to interrupt the program (e.g., with Ctrl-C) and can disguise other problems.  This removes all bare excepts and instead catches `Exception` which is the base class for all code-generated exceptions.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
