### PR TITLE
MmSupervisorPkg.dec: Use 16 pages for user mode comm buffer by default

### DIFF
--- a/MmSupervisorPkg/MmSupervisorPkg.dec
+++ b/MmSupervisorPkg/MmSupervisorPkg.dec
@@ -78,7 +78,7 @@
   gMmSupervisorPkgTokenSpaceGuid.PcdSupervisorCommBufferPages|16|UINT64|0x00000001
 
   ## Size of user communication buffer in number of pages
-  gMmSupervisorPkgTokenSpaceGuid.PcdUserCommBufferPages|4|UINT64|0x00000002
+  gMmSupervisorPkgTokenSpaceGuid.PcdUserCommBufferPages|16|UINT64|0x00000002
 
   ## FILE_GUID of MmIplPeiX64Relay module
   #  This will be used by MmIplPei to look up driver location before switching to long mode.


### PR DESCRIPTION
## Description

`PcdUserCommBufferPages` is currently set to `4`. This buffer is
used for UEFI variable transactions where includes larger data like Intel
memory training and Secure Boot related UEFI variables.

16 pages provides 64KB by default which allows these common scenarios
to succeed in most cases without platform intervention.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified on Qemu Q35 and a physical Intel platform.

## Integration Instructions

If the default value was previously unmodified on a platform, expect that the
user mode communicate buffer will now be 48KB larger. If that's an issue, set
`gMmSupervisorPkgTokenSpaceGuid.PcdUserCommBufferPages` to `4` in the platform
DSC file to restore previous behavior.