### PR TITLE
MmSupervisorPkg: Integrate UefiCpuLib breaking change

### DIFF
--- a/MmSupervisorPkg/Core/Mem/SmmProfileInternal.h
+++ b/MmSupervisorPkg/Core/Mem/SmmProfileInternal.h
@@ -12,7 +12,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/SmmReadyToLock.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/CpuLib.h>
-#include <Library/UefiCpuLib.h>
 #include <IndustryStandard/Acpi.h>
 #include <Library/MmMemoryProtectionHobLib.h>         // MU_CHANGE
 

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -11,7 +11,7 @@
 ##
 
 #Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | afc905240e20c3c2205b0699c28e78d8 | 2023-02-14T23-02-36 | 45b2886c1f0d56d32b0b048494e4e9c2b4f88671
-#Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | dceb5d7aaa3a51aefdbbd0ba9ede8a47 | 2023-07-17T14-51-51 | 3f022dad7ac0035cfe3ed49a12403a7314445383
+#Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 32523fbea769a9c594fb5f7254907c3f | 2023-08-30T19-58-00 | c8cdc60a6e689681f0c81209aeb71e26fd023416
 #Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | c6af8bbe5339bdf045cc9e36064b0ea2 | 2023-05-19T23-00-30 | dc6c1f99c459dc4107bf51d307d3484f101a95fa
 
 [Defines]

--- a/MmSupervisorPkg/Core/Relocate/Relocate.h
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.h
@@ -47,7 +47,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/HobLib.h>
 #include <Library/LocalApicLib.h>
 #include <Library/CpuLib.h>
-#include <Library/UefiCpuLib.h>
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/SmmCpuFeaturesLib.h>

--- a/MmSupervisorPkg/Core/Test/PagingAudit.c
+++ b/MmSupervisorPkg/Core/Test/PagingAudit.c
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PeCoffGetEntryPointLib.h>
 #include <Library/BaseLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/UefiCpuLib.h>
+#include <Library/CpuLib.h>
 
 #include <Protocol/SmmCommunication.h>
 #include <Guid/DebugImageInfoTable.h>

--- a/MmSupervisorPkg/Library/BaseCpuLibSysCall/BaseCpuLib.inf
+++ b/MmSupervisorPkg/Library/BaseCpuLibSysCall/BaseCpuLib.inf
@@ -15,7 +15,7 @@
 #
 ##
 
-#Override : 00000002 | MdePkg/Library/BaseCpuLib/BaseCpuLib.inf | d0c8e15f448b76a4d613430cfb45320d | 2023-05-19T22-07-15 | dc6c1f99c459dc4107bf51d307d3484f101a95fa
+#Override : 00000002 | MdePkg/Library/BaseCpuLib/BaseCpuLib.inf | 9d03031b3ee982c16eab0ebe7d9fec98 | 2023-08-30T19-56-53 | c8cdc60a6e689681f0c81209aeb71e26fd023416
 
 [Defines]
   INF_VERSION                    = 0x00010005

--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -36,7 +36,6 @@
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
   PeCoffExtraActionLib|MdePkg/Library/BasePeCoffExtraActionLibNull/BasePeCoffExtraActionLibNull.inf
   PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
-  UefiCpuLib|UefiCpuPkg/Library/BaseUefiCpuLib/BaseUefiCpuLib.inf
   MuTelemetryHelperLib|MsWheaPkg/Library/MuTelemetryHelperLib/MuTelemetryHelperLib.inf
   MsWheaEarlyStorageLib|MsWheaPkg/Library/MsWheaEarlyStorageLibNull/MsWheaEarlyStorageLibNull.inf
   MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLibNull/MmMemoryProtectionHobLibNull.inf

--- a/MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
+++ b/MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
@@ -38,7 +38,7 @@
   DebugLib
   UefiBootServicesTableLib
   UefiLib
-  UefiCpuLib
+  CpuLib
   DxeServicesTableLib
   DevicePathLib
   PeCoffGetEntryPointLib

--- a/MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/X64/PagingAuditProcessor.c
+++ b/MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/X64/PagingAuditProcessor.c
@@ -20,7 +20,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Register/Cpuid.h>
 
 #include <Library/BaseLib.h>
-#include <Library/UefiCpuLib.h>
+#include <Library/CpuLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PrintLib.h>

--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvMemPolicyUnitTest.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvMemPolicyUnitTest.c
@@ -26,7 +26,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UnitTestLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/UefiCpuLib.h>
+#include <Library/CpuLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/IoLib.h>
 

--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
@@ -25,7 +25,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UnitTestLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/UefiCpuLib.h>
+#include <Library/CpuLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 
 #include "MmPolicyMeasurementLevels.h"

--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.inf
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.inf
@@ -43,10 +43,10 @@
   PrintLib
   MemoryAllocationLib
   BaseLib
+  CpuLib
   ShellLib
   PcdLib
   UefiLib
-  UefiCpuLib
   IoLib
 
 [Protocols]


### PR DESCRIPTION
## Description

Updates the repo for a change that merged UefiCpuLib with CpuLib.

UefiCpuLib will be removed entirely soon so all references are updated to CpuLib.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- MmSupervisorPkg CI build
- Feature integration build (in QemuQ35Pkg)

## Integration Instructions

N/A