### PR TITLE
MmSupervisorPkg/Core: Remove redundant null check (CodeQL)

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -1040,8 +1040,8 @@ EFIAPI
 MmSupvRequestHandler (
   IN     EFI_HANDLE  DispatchHandle,
   IN     CONST VOID  *Context         OPTIONAL,
-  IN OUT VOID        *CommBuffer      OPTIONAL,
-  IN OUT UINTN       *CommBufferSize  OPTIONAL
+  IN OUT VOID        *CommBuffer,
+  IN OUT UINTN       *CommBufferSize
   );
 
 /**

--- a/MmSupervisorPkg/Core/Request/RequestDispatcher.c
+++ b/MmSupervisorPkg/Core/Request/RequestDispatcher.c
@@ -40,8 +40,8 @@ EFIAPI
 MmSupvRequestHandler (
   IN     EFI_HANDLE  DispatchHandle,
   IN     CONST VOID  *Context         OPTIONAL,
-  IN OUT VOID        *CommBuffer      OPTIONAL,
-  IN OUT UINTN       *CommBufferSize  OPTIONAL
+  IN OUT VOID        *CommBuffer,
+  IN OUT UINTN       *CommBufferSize
   )
 {
   EFI_STATUS                    Status = EFI_SUCCESS;
@@ -106,7 +106,7 @@ MmSupvRequestHandler (
       // Use the common buffer to host policy data, and indicate the maximal data allowed
       ExpectedSize                = *CommBufferSize - ExpectedSize;
       MmSupvRequestHeader->Result = FetchNUpdateSecurityPolicy ((SMM_SUPV_SECURE_POLICY_DATA_V1_0 *)(MmSupvRequestHeader + 1), ExpectedSize);
-      if (!EFI_ERROR (MmSupvRequestHeader->Result) && (CommBufferSize != NULL)) {
+      if (!EFI_ERROR (MmSupvRequestHeader->Result)) {
         *CommBufferSize = sizeof (MM_SUPERVISOR_REQUEST_HEADER) + ((SMM_SUPV_SECURE_POLICY_DATA_V1_0 *)(MmSupvRequestHeader + 1))->Size;
       }
 


### PR DESCRIPTION
## Description

Fixes #182 

The main change is to remove a NULL check for the CommBufferSize
parameter value in the MM_SUPERVISOR_REQUEST_FETCH_POLICY switch
case since it triggers a CodeQL alert as a redundant NULL check
operation. The actual parameter value is checked for NULL at the
beginning of the function and not modified until that line of code.

However, the function API and implementation is confusing so that's
cleaned up as well.

1. The Context parameter is not used at all. Since it is marked
   optional, it is left so the function prototype can remain
   consistent in case the parameter is needed in the future.
2. The CommBuffer and CommBufferSize parameters are also marked
   optional, but they're not. The function immediately returns
   EFI_INVALID_PARAMETER if they are not provided (null).

For (2), the optional modifier is simply removed from the arguments
to indicate the function expects valid pointers are passed.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- MmSupervisorPkg build and CI checks

## Integration Instructions

N/A