### PR TITLE
Use New Stack Cookie Library

### DIFF
--- a/MmSupervisorPkg/Core/Dispatcher/Dispatcher.c
+++ b/MmSupervisorPkg/Core/Dispatcher/Dispatcher.c
@@ -292,10 +292,8 @@ MmLoadImage (
 {
   UINTN                         PageCount;
   EFI_STATUS                    Status;
-  EFI_STATUS                    StackCookieStatus;
   EFI_PHYSICAL_ADDRESS          DstBuffer;
   PE_COFF_LOADER_IMAGE_CONTEXT  ImageContext;
-  UINT64                        *SecurityCookieAddress;
 
   DEBUG ((DEBUG_INFO, "MmLoadImage - %g\n", &DriverEntry->FileName));
 
@@ -480,12 +478,6 @@ MmLoadImage (
   DEBUG ((DEBUG_INFO | DEBUG_LOAD, "\n"));
 
   DEBUG_CODE_END ();
-
-  StackCookieStatus = PeCoffLoaderGetSecurityCookieAddress (&ImageContext, &SecurityCookieAddress);
-  if (!EFI_ERROR (StackCookieStatus)) {
-    InitializeSecurityCookieAddress (SecurityCookieAddress);
-    DEBUG ((DEBUG_VERBOSE | DEBUG_LOAD, "Standalone MM SecurityCookie set to %lld\n", (*SecurityCookieAddress)));
-  }
 
   return Status;
 }

--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -50,7 +50,6 @@
 #include <Library/UefiLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/ResetSystemLib.h>
-#include <Library/BaseBinSecurityLib.h>
 
 //
 // Used to build a table of MMI Handlers that the MM Core registers

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -10,9 +10,9 @@
 #
 ##
 
-#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | afc905240e20c3c2205b0699c28e78d8 | 2023-02-14T23-02-36 | 45b2886c1f0d56d32b0b048494e4e9c2b4f88671
+#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | afc905240e20c3c2205b0699c28e78d8 | 2023-11-22T00-10-02 | 8a980c0465feec3e2096995006fa984fe4d7e238
 #Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 32523fbea769a9c594fb5f7254907c3f | 2023-08-30T19-58-00 | c8cdc60a6e689681f0c81209aeb71e26fd023416
-#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | c6af8bbe5339bdf045cc9e36064b0ea2 | 2023-05-19T23-00-30 | dc6c1f99c459dc4107bf51d307d3484f101a95fa
+#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 82ced358be9755dd8c3768cb01837d09 | 2023-11-22T00-11-19 | 8a980c0465feec3e2096995006fa984fe4d7e238
 
 [Defines]
   INF_VERSION                    = 0x0001001A

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -138,7 +138,6 @@
   SortLib
   HwResetSystemLib
   SmmPolicyGateLib
-  BaseBinSecurityLib
   MmMemoryProtectionHobLib ## MU_CHANGE
   IhvSmmSaveStateSupervisionLib
   SafeIntLib

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
@@ -9,8 +9,8 @@
 #**/
 
 # This module contains an instance of protocol/handle from StandaloneMmCore and pool memory + guard management from PiSmmCore.
-#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | afc905240e20c3c2205b0699c28e78d8 | 2023-02-14T23-02-36 | 45b2886c1f0d56d32b0b048494e4e9c2b4f88671
-#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | c6af8bbe5339bdf045cc9e36064b0ea2 | 2023-05-19T23-00-30 | dc6c1f99c459dc4107bf51d307d3484f101a95fa
+#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | afc905240e20c3c2205b0699c28e78d8 | 2023-11-22T00-10-02 | 8a980c0465feec3e2096995006fa984fe4d7e238
+#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 82ced358be9755dd8c3768cb01837d09 | 2023-11-22T00-11-19 | 8a980c0465feec3e2096995006fa984fe4d7e238
 
 [Defines]
   INF_VERSION                    = 0x0001001A

--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -52,6 +52,7 @@
 
 # MU_CHANGE [BEGIN] - Add Stack Cookie Support
 [LibraryClasses.X64]
+  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
   NULL|MdePkg/Library/StackCheckLib/StackCheckLib.inf
   StackCheckFailureLib|MdePkg/Library/StackCheckFailureLibNull/StackCheckFailureLibNull.inf
 # MU_CHANGE [END] - Add Stack Cookie Support

--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -50,15 +50,11 @@
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
   RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
 
-!if $(TOOL_CHAIN_TAG) == VS2017 or $(TOOL_CHAIN_TAG) == VS2015 or $(TOOL_CHAIN_TAG) == VS2019 or $(TOOL_CHAIN_TAG) == VS2022
-  #if debug is enabled provide StackCookie support lib so that we can link to /GS exports
-  NULL|MdePkg/Library/BaseBinSecurityLibRng/BaseBinSecurityLibRng.inf
-  BaseBinSecurityLib|MdePkg/Library/BaseBinSecurityLibRng/BaseBinSecurityLibRng.inf
-  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
-!else
-  # otherwise use the null version for GCC and CLANG
-  BaseBinSecurityLib|MdePkg/Library/BaseBinSecurityLibNull/BaseBinSecurityLibNull.inf
-!endif
+# MU_CHANGE [BEGIN] - Add Stack Cookie Support
+[LibraryClasses.X64]
+  NULL|MdePkg/Library/StackCheckLib/StackCheckLib.inf
+  StackCheckFailureLib|MdePkg/Library/StackCheckFailureLibNull/StackCheckFailureLibNull.inf
+# MU_CHANGE [END] - Add Stack Cookie Support
 
 [LibraryClasses.IA32]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf


### PR DESCRIPTION
## Description

This series transitions the core to use the new stack cookie libraries.
The stack cookie value no longer needs to be initialized before
image execution and can instead be initialized in the library
constructor. 

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A