### PR TITLE
CVE-2022-36765 - StandaloneMmHobLibSysCall: Prevent integer overflow in CreateHob() [Rebase & FF]

### DIFF
--- a/MmSupervisorPkg/Library/BaseLibSysCall/BaseLib.inf
+++ b/MmSupervisorPkg/Library/BaseLibSysCall/BaseLib.inf
@@ -12,7 +12,7 @@
 #
 ##
 
-#Override : 00000002 | MdePkg/Library/BaseLib/BaseLib.inf | 1f5cab6a914fb872e77c1298f36644e4 | 2023-05-19T21-53-39 | dc6c1f99c459dc4107bf51d307d3484f101a95fa
+#Override : 00000002 | MdePkg/Library/BaseLib/BaseLib.inf | a90a6e1cd43def11ce3c03dbc054f5c0 | 2024-02-02T14-22-14 | a4121d4aec36b5923ca7546c27f7d109a50fd870
 
 [Defines]
   INF_VERSION                    = 0x00010005

--- a/MmSupervisorPkg/Library/StandaloneMmHobLibSyscall/StandaloneMmHobLibSyscall.c
+++ b/MmSupervisorPkg/Library/StandaloneMmHobLibSyscall/StandaloneMmHobLibSyscall.c
@@ -248,6 +248,13 @@ CreateHob (
 
   HandOffHob = GetHobList ();
 
+  //
+  // Check Length to avoid data overflow.
+  //
+  if (HobLength > MAX_UINT16 - 0x7) {
+    return NULL;
+  }
+
   HobLength = (UINT16)((HobLength + 0x7) & (~0x7));
 
   FreeMemory = HandOffHob->EfiFreeMemoryTop - HandOffHob->EfiFreeMemoryBottom;


### PR DESCRIPTION
## Description

Contains the primary commit for the HOB calculation overflow and
a separate commit to build with the tip of mu_basecore release/202302.

---

**CVE-2022-36765 - StandaloneMmHobLibSysCall: Prevent integer overflow in CreateHob()**

Based on commit `9a75b030cf27d2530444e9a2f9f11867f79bf679` in edk2.

>  REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4166

>  Fix integer overflow in various CreateHob instances.
>  Fixes: CVE-2022-36765

>  The CreateHob() function aligns the requested size to 8
>  performing the following operation:
>  ```
>  HobLength = (UINT16)((HobLength + 0x7) & (~0x7));
>  ```

>  No checks are performed to ensure this value doesn't
>  overflow, and could lead to CreateHob() returning a smaller
>  HOB than requested, which could lead to OOB HOB accesses.

---

**MmSupervisorPkg/BaseLibSysCall/BaseLib: Update override**

The change that occurred in MdePkg/Library/BaseLib only affected
AARCH64 which does not exist in the instance in MmSupervisorPkg.

So, this change simply updates the override hash to the new value.

---

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- MmSupervisorPkg CI.
- Upstream validation.
- Boot on QEMU.

## Integration Instructions

N/A