### PR TITLE
Bump version value to v9 to match the release version

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -19,7 +19,7 @@
   BASE_NAME                      = MmSupervisorCore
   FILE_GUID                      = 4E4C89DC-A452-4B6B-B183-F16A2A223733
   MODULE_TYPE                    = MM_CORE_STANDALONE
-  VERSION_STRING                 = 8.001
+  VERSION_STRING                 = 9.001
   PI_SPECIFICATION_VERSION       = 0x00010032
   ENTRY_POINT                    = MmSupervisorMain
 
@@ -27,8 +27,8 @@
   #Major: major version is one or two digits from 0 to 99
   #Minor: minor version is four digits, the first 3 digits are the minor number, the last digit is the flag
   #flag=9 represents RELEASE version, flag=8 represents DEBUG version, flag=0~7 represents test version
-  RELEASE_DRIVER_VERSION   = 8.0019
-  DEBUG_DRIVER_VERSION     = 8.0018
+  RELEASE_DRIVER_VERSION   = 9.0019
+  DEBUG_DRIVER_VERSION     = 9.0018
   #SPL value definition: SPL version = Major.Minor, SPL value = (Major << 16 | Minor)
   #Major: major value is an UINT16 number in decimal from 0 to 65535
   #Minor: minor value is an UINT16 number in decimal from 0 to 65535

--- a/MmSupervisorPkg/MmSupervisorPkg.dec
+++ b/MmSupervisorPkg/MmSupervisorPkg.dec
@@ -13,7 +13,7 @@
   DEC_SPECIFICATION              = 0x0001001A
   PACKAGE_NAME                   = MmSupervisorPkg
   PACKAGE_GUID                   = 2DCA2E5C-4696-4613-943F-DFE5F6941C34
-  PACKAGE_VERSION                = 8.001
+  PACKAGE_VERSION                = 9.001
 
 [Includes]
   Include


### PR DESCRIPTION
## Description

This change updated the release version to v9 to reflect the new value from release template.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A