### PR TITLE
This should fix the constructor not calling the real stm constructor

### DIFF
--- a/SpamPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
@@ -18,6 +18,18 @@
 #include <Library/HobLib.h>
 
 /**
+  The constructor function for the common MM library instance with STM.
+
+  @retval EFI_SUCCESS      The constructor always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmCpuFeaturesLibStmConstructor (
+  VOID
+  );
+
+/**
   Performs library initialization.
 
   This initialization function contains common functionality shared betwen all

--- a/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -325,10 +325,7 @@ Done:
 }
 
 /**
-  The constructor function for the Traditional MM library instance with STM.
-
-  @param[in]  ImageHandle  The firmware allocated handle for the EFI image.
-  @param[in]  SystemTable  A pointer to the EFI System Table.
+  The constructor function for the common MM library instance with STM.
 
   @retval EFI_SUCCESS      The constructor always returns EFI_SUCCESS.
 
@@ -336,8 +333,7 @@ Done:
 EFI_STATUS
 EFIAPI
 SmmCpuFeaturesLibStmConstructor (
-  IN EFI_HANDLE        ImageHandle,
-  IN EFI_SYSTEM_TABLE  *SystemTable
+  VOID
   )
 {
   EFI_STATUS              Status;

--- a/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -261,7 +261,7 @@ DiscoverSmiEntryInFvHobs (
       //
       FileHeader = NULL;
       Status     =  FfsFindNextFile (
-                      EFI_FV_FILETYPE_RAW,
+                      EFI_FV_FILETYPE_FREEFORM,
                       FwVolHeader,
                       &FileHeader
                       );

--- a/SpamPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.c
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.c
@@ -44,7 +44,5 @@ StandaloneMmCpuFeaturesLibConstructor (
   IN EFI_MM_SYSTEM_TABLE  *SystemTable
   )
 {
-  CpuFeaturesLibInitialization ();
-
-  return EFI_SUCCESS;
+  return SmmCpuFeaturesLibStmConstructor ();
 }


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change should fix the constructor not invoking the proper STM based constructor.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
