### PR TITLE
Remove temporary fix for the size mismatch

### DIFF
--- a/SpamPkg/Plugins/TestPlugin/GenAux.py
+++ b/SpamPkg/Plugins/TestPlugin/GenAux.py
@@ -110,7 +110,7 @@ class ImageValidationDataHeader(ctypes.Structure):
     ]
     def __init__(self):
         self.header_signature = 0x444C4156
-        self.size = 20 + 4 # Bug in FvLib, It adds 4 bytes to the true size of the file
+        self.size = 20
         self.entry_count = 0
         self.offset_to_first_entry = 0
         self.offset_to_first_default = 0


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change removes the size of 4 bytes manipulation. from the aux file generation script.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested with the fixed version of FvLib.

## Integration Instructions

N/A
