### PR TITLE
Fix unload size not matching the original efi file

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -45,6 +45,9 @@ EFI_HANDLE  mMmCpuHandle = NULL;
 MM_CORE_PRIVATE_DATA  *gMmCorePrivate = NULL;
 MM_CORE_PRIVATE_DATA  *gMmCoreMailbox = NULL;
 
+EFI_PHYSICAL_ADDRESS  MmSupvEfiFileBase;
+UINT64                MmSupvEfiFileSize;
+
 //
 // Ring 3 Hob pointer
 //
@@ -396,16 +399,22 @@ MmReadyToLockHandler (
   }
 
   // Now prepare a new buffer to revert loading operations.
-  VOID *NewBuffer = AllocatePages (EFI_SIZE_TO_PAGES (gMmCorePrivate->MmCoreImageSize));
+  UINTN NewBufferSize = gMmCorePrivate->MmCoreImageSize;
+  VOID *NewBuffer = AllocatePages (EFI_SIZE_TO_PAGES (NewBufferSize));
+  ZeroMem (NewBuffer, NewBufferSize);
 
   DEBUG ((DEBUG_INFO, "%p %p %p\n", gMmCorePrivate->MmCoreImageBase, Buffer, NewBuffer));
 
   // At this point we dealt with the relocation, some data are still off.
   // Next we unload the image in the copy.
-  Status = PeCoffLoaderRevertLoadImage (&ImageContext, NewBuffer);
+  Status = PeCoffLoaderRevertLoadImage (&ImageContext, NewBuffer, &NewBufferSize);
   if (EFI_ERROR (Status)) {
     goto Done;
   }
+
+  DEBUG ((DEBUG_INFO, "%a Reverted image at %p of size %x\n", __func__, NewBuffer, NewBufferSize));
+  ASSERT (MmSupvEfiFileSize == NewBufferSize);
+  ASSERT (CompareMem (NewBuffer, (VOID*)(UINTN)MmSupvEfiFileBase, MmSupvEfiFileSize) == 0);
 
 Done:
   PERF_CALLBACK_END (&gEfiDxeMmReadyToLockProtocolGuid);
@@ -814,6 +823,19 @@ DiscoverStandaloneMmDriversInFvHobs (
             __FUNCTION__,
             &gEfiCallerIdGuid,
             (UINTN)FwVolHeader
+            ));
+
+          VOID *MmCoreImageBase = NULL;
+          Status = FfsFindSectionData (EFI_SECTION_PE32, FileHeader, &MmCoreImageBase, &MmSupvEfiFileSize);
+          ASSERT_EFI_ERROR (Status);
+          MmSupvEfiFileBase = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateCopyPool (MmSupvEfiFileSize, MmCoreImageBase);
+          ASSERT (MmSupvEfiFileBase != 0);
+          DEBUG ((
+            DEBUG_INFO,
+            "[%a]   reserved MmSupvEfiFileBase at %p for %x bytes.\n",
+            __FUNCTION__,
+            MmSupvEfiFileBase,
+            MmSupvEfiFileSize
             ));
         }
       } else {

--- a/SpamPkg/Include/Library/PeCoffLibNegative.h
+++ b/SpamPkg/Include/Library/PeCoffLibNegative.h
@@ -126,6 +126,9 @@ PeCoffLoaderRevertRelocateImage (
 
   @param  ImageContext              The pointer to the image context structure that describes the PE/COFF
                                     image that is being loaded.
+  @param  Buffer                    The pointer to the buffer used to host unloaded PE/COFF image.
+  @param  BufferSizePtr             On input, this holds the size of Buffer. On output, it holds the size
+                                    of the image that was actually unloaded into Buffer.
 
   @retval RETURN_SUCCESS            The PE/COFF image was loaded into the buffer specified by
                                     the ImageAddress and ImageSize fields of ImageContext.
@@ -141,8 +144,9 @@ PeCoffLoaderRevertRelocateImage (
 RETURN_STATUS
 EFIAPI
 PeCoffLoaderRevertLoadImage (
-  IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext,
-  OUT    VOID                          *Buffer
+  IN OUT  PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext,
+  OUT     UINTN                         *Buffer,
+  IN OUT  UINTN                         *BufferSizePtr
   );
 
 /**

--- a/SpamPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf
+++ b/SpamPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf
@@ -29,6 +29,7 @@
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = PeCoffLibNegative
 
+#Override : 00000002 | MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf | 401f7e82e499c011b2ebef8e30db4949 | 2024-02-28T21-39-40 | a880ead29bce709ecba1c047604ebffc16ff3e07
 
 #
 #  VALID_ARCHITECTURES           = IA32 X64 EBC ARM AARCH64


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change added a size calculator to make sure the unloaded sections are adding up to the same size of its original efi file.

This change also finalized a routine to perform derelocate, validate and unload after ready to lock, making sure all steps are adding up. This routine will live in the SPAM core evantually.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU Q35 platform.

## Integration Instructions

N/A
