### PR TITLE
Fixing the MMI entry size updated incorrectly

### DIFF
--- a/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -282,8 +282,7 @@ DiscoverSmiEntryInFvHobs (
               DEBUG ((DEBUG_ERROR, "[%a]   Failed to load MmiEntry [%g] in FV at 0x%p of %x bytes - %r.\n", __FUNCTION__, &gMmiEntrySpamFileGuid, FileHeader, FileHeader->Size, Status));
               break;
             }
-            // Moving the buffer like size field to our global variable
-            CopyMem (&mMmiEntrySize, FileHeader->Size, sizeof (FileHeader->Size));
+
             DEBUG ((
               DEBUG_INFO,
               "[%a]   Discovered MMI Entry for SPAM [%g] in FV at 0x%p of %x bytes.\n",
@@ -344,9 +343,11 @@ DiscoverSmiEntryInFvHobs (
     }
   } while (Hob.Raw != NULL);
 
-  if (!MmiEntryFound) {
-    DEBUG ((DEBUG_ERROR, "[%a]   MMI Entry for SPAM not found in any FV.\n", __FUNCTION__));
+  if (!MmiEntryFound || !SpamResponderFound || !AuxBinFound) {
+    DEBUG ((DEBUG_ERROR, "[%a]   Required entries for SPAM not found in any FV.\n", __FUNCTION__));
     Status = EFI_NOT_FOUND;
+  } else {
+    Status = EFI_SUCCESS;
   }
 
 Done:


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The MMI entry size is updated incorrectly after the section size is populated, causing the patching offset calculation pointing to the middle of nowhere.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35.

## Integration Instructions

N/A
