### PR TITLE
Add key symbols to the auxillary file

### DIFF
--- a/SpamPkg/Include/Library/PeCoffLibNegative.h
+++ b/SpamPkg/Include/Library/PeCoffLibNegative.h
@@ -48,8 +48,8 @@ typedef struct {
   UINT32  EntryCount;
   UINT32  OffsetToFirstEntry;
   UINT32  OffsetToFirstDefault;
-  UINT32  SymbolListCount;
-  KEY_SYMBOL SymbolList[];
+  UINT32  KeySymbolCount;
+  UINT32  OffsetToFirstKeySymbol;
 } IMAGE_VALIDATION_DATA_HEADER;
 
 typedef struct {

--- a/SpamPkg/Include/Library/PeCoffLibNegative.h
+++ b/SpamPkg/Include/Library/PeCoffLibNegative.h
@@ -38,11 +38,18 @@
 #pragma pack(1)
 
 typedef struct {
+  UINT32 Signature;
+  UINT32 Offset;
+} KEY_SYMBOL
+
+typedef struct {
   UINT32  HeaderSignature;
   UINT32  Size;
   UINT32  EntryCount;
   UINT32  OffsetToFirstEntry;
   UINT32  OffsetToFirstDefault;
+  UINT32  SymbolListCount;
+  KEY_SYMBOL SymbolList[];
 } IMAGE_VALIDATION_DATA_HEADER;
 
 typedef struct {

--- a/SpamPkg/Tools/gen_aux/readme.md
+++ b/SpamPkg/Tools/gen_aux/readme.md
@@ -10,6 +10,21 @@ Check the tool's help information by using the command `cargo run -- -h` or if t
 
 The configuration file, passed to the executable via the `-c` command, is used to specify which symbols should be reverted to their original value and/or tested using one of the supported testing methods. The config file uses the [toml](https://toml.io/en/) format for setting config options in the file. Currently, there are two configuration options: `rule` and `autogen`
 
+### key
+
+the key command (`[[key]]`) is a configuration option to tell the tool to generate signature / offset pairs for a specific symbol and add them to the the header (`IMAGE_VALIDATION_DATA_HEADER`).
+
+``` toml
+[[key]]
+signature = 'Required[u32]'
+symbol = 'Optional[String]'
+offset = 'Optional[u32]'
+```
+
+- `signature`: The 4 byte signature used by the firmware to determine how to use the offset
+- `symbol`: Used to calculate the offset value. Mutually exclusive to `offset`
+- `offset`: The offset used by the firmware. Mutually exclusive to `symbol`
+
 ### rule
 
 The rule command (`[[rule]]`) is a configuration option to tell the tool to generate an entry header for the specific symbol. The rule comes with the following standard options:

--- a/SpamPkg/Tools/gen_aux/readme.md
+++ b/SpamPkg/Tools/gen_aux/readme.md
@@ -12,7 +12,7 @@ This tool generates the binary file used to verify the state of a module after e
 +--------------------------------------------+
 +  IMAGE_VALIDATION_ENTRY_HEADER[]
 +--------------------------------------------+
-+  Raw Data
++  Defaults
 +--------------------------------------------+
 ```
 

--- a/SpamPkg/Tools/gen_aux/readme.md
+++ b/SpamPkg/Tools/gen_aux/readme.md
@@ -2,7 +2,21 @@
 
 This tool generates the binary file used to verify the state of a module after execution and revert it to it's original state. Any rule specified in the configuration file will be 1. Reverted and 2. Verified (depending on the verification type).
 
-# Usability
+## Auxillary File Format
+
+```
++--------------------------------------------+
++  IMAGE_VALIDATION_DATA_HEADER
++--------------------------------------------+
++  KEY_SYMBOL[]
++--------------------------------------------+
++  IMAGE_VALIDATION_ENTRY_HEADER[]
++--------------------------------------------+
++  Raw Data
++--------------------------------------------+
+```
+
+## Usability
 
 Check the tool's help information by using the command `cargo run -- -h` or if the tool is already compiled, `gen_aux -h`. It will provide you a list of options and a brief description of each option
 

--- a/SpamPkg/Tools/gen_aux/src/auxgen.rs
+++ b/SpamPkg/Tools/gen_aux/src/auxgen.rs
@@ -1,6 +1,6 @@
 //! A module that contains the C-equivalent structs and final functions to
 //! generate the aux file.
-use std::{fmt, io::Write};
+use std::{fmt, io::Write, mem::size_of};
 use pdb::{TypeIndex, TypeInformation};
 use scroll::{self, ctx, Endian, Pread, Pwrite, LE};
 use serde::Deserialize;
@@ -27,7 +27,7 @@ impl std::fmt::Debug for Symbol {
 
 /// A struct that represents an signature/address pair to be added to the
 /// auxillary file header.
-#[derive(Debug, Deserialize, Default)]
+#[derive(Deserialize, Default)]
 pub struct KeySymbol {
     /// The symbol name to calculate the offset of.
     pub symbol: Option<String>,
@@ -50,8 +50,20 @@ impl KeySymbol {
     }
 }
 
+impl fmt::Debug for KeySymbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(offset) = &self.offset {
+            write!(f, "KeySymbol {{ offset: 0x{:08X}, signature: 0x{:4X} }}", offset, self.signature)
+        } else if let Some(symbol) = &self.symbol {
+            write!(f, "KeySymbol {{ symbol: {}, signature: 0x{:4X} }}", symbol, self.signature)
+        } else {
+            write!(f, "KeySymbol {{ signature: {} }}", self.signature)
+        }
+    }
+}
+
 /// A struct representing the header of the aux file.
-#[derive(Debug)]
+#[derive(Debug, Pwrite)]
 pub struct ImageValidationDataHeader {
     /// The signature of the header. Must be 0x444C4156
     signature: u32,
@@ -64,58 +76,22 @@ pub struct ImageValidationDataHeader {
     offset_to_first_entry: u32,
     /// The offset to the first default value in the aux file.
     offset_to_first_default: u32,
-    /// A list of key symbols to be added to the auxillary file header.
-    key_symbols: Vec<KeySymbol>,
-}
-
-impl ImageValidationDataHeader {
-    /// Adds a list of key symbols to the header.
-    pub fn add_entries(&mut self, key_symbols: Vec<KeySymbol>, symbols: &Vec<Symbol>) -> anyhow::Result<()> {
-        for mut key_symbol in key_symbols {
-            key_symbol.resolve(&symbols)?;
-            self.key_symbols.push(key_symbol);
-            self.size += 8;
-        }
-        Ok(())
-    }
-
-    /// Returns the size of ImageValidationDataHeader in bytes. The C struct (IMAGE_VALIDATION_DATA_HEADER)
-    /// contains a field, SymbolListCount, that is not present in this struct. The extra 4 bytes of this
-    /// is accounted for when calculating the size of the header.
-    pub fn header_size(&self) -> u32 {
-        20 + 4 + (self.key_symbols.len() as u32 * 8)
-    }
-
-}
-
-impl <'a> ctx::TryIntoCtx<Endian> for &ImageValidationDataHeader {
-    type Error = scroll::Error;
-
-    fn try_into_ctx(self, this: &mut [u8], le: Endian) -> Result<usize, Self::Error> {
-        let mut offset = 0;
-        this.gwrite_with(self.signature, &mut offset, le)?;
-        this.gwrite_with(self.size, &mut offset, le)?;
-        this.gwrite_with(self.entry_count, &mut offset, le)?;
-        this.gwrite_with(self.offset_to_first_entry, &mut offset, le)?;
-        this.gwrite_with(self.offset_to_first_default, &mut offset, le)?;
-        this.gwrite_with(self.key_symbols.len() as u32, &mut offset, le)?;
-        for key_symbol in &self.key_symbols {
-            this.gwrite_with(key_symbol.signature, &mut offset, le)?;
-            this.gwrite_with(key_symbol.offset.expect("Offset should be resolved"), &mut offset, le)?;
-        }
-        Ok(offset)
-    }
+    /// The number of key symbols in the aux file.
+    key_symbol_count: u32,
+    /// The offset to the first key_sybol in the aux file.
+    offset_to_first_key_symbol: u32,
 }
 
 impl Default for ImageValidationDataHeader {
     fn default() -> Self {
         ImageValidationDataHeader {
             signature: 0x444C4156,
-            size: 24,
+            size: 28,
             entry_count: 0,
             offset_to_first_entry: 0,
             offset_to_first_default: 0,
-            key_symbols: Vec::new(),
+            key_symbol_count: 0,
+            offset_to_first_key_symbol: 0,
         }
     }
 }
@@ -307,8 +283,19 @@ impl AuxBuilder {
     /// be generated, so that all symbols are reverted to their original value.
     pub fn generate(mut self, info: &TypeInformation) -> anyhow::Result<AuxFile> {
         let mut aux = AuxFile::default();
-        aux.header.add_entries(self.key_symbols, &self.symbols)?;
-        aux.header.offset_to_first_entry = aux.header.header_size();
+        aux.header.offset_to_first_entry = size_of::<ImageValidationDataHeader>() as u32;
+        
+        for mut symbol in self.key_symbols {
+            symbol.resolve(&self.symbols)?;
+            aux.key_symbols.push(symbol);
+            aux.header.key_symbol_count += 1;
+            aux.header.size += 8;
+            aux.header.offset_to_first_entry += 8;
+        }
+
+        if aux.key_symbols.len() > 0 {
+            aux.header.offset_to_first_key_symbol = size_of::<ImageValidationDataHeader>() as u32;
+        }
 
         let mut offset_in_default = 0;
 
@@ -346,8 +333,10 @@ impl AuxBuilder {
 
         // Now that all entries have been added, we can calculate the offset to
         // the raw data, and update the offset_to_default field in each entry.
-        let offset_to_default_start = aux.header.header_size()
-            + aux.entries.iter().fold(0, |acc, entry| { acc + entry.header_size()}); 
+        let offset_to_default_start = size_of::<ImageValidationDataHeader>() as u32
+            + aux.entries.iter().fold(0, |acc, entry| { acc + entry.header_size()})
+            + aux.key_symbols.len() as u32 * 8;
+
         aux.header.offset_to_first_default = offset_to_default_start;
         for entry_header in &mut aux.entries {
             entry_header.offset_to_default += offset_to_default_start;
@@ -362,6 +351,8 @@ impl AuxBuilder {
 pub struct AuxFile {
     /// The IMAGE_VALIDATION_DATA_HEADER that is written to the aux file.
     pub header: ImageValidationDataHeader,
+    /// a list of KEY_SYMBOL C structs to be written to the aux file.
+    pub key_symbols: Vec<KeySymbol>,
     /// A list of IMAGE_VALIDATION_ENTRY_HEADER's or derivations of it based on
     /// the validation_type field.
     pub entries: Vec<ImageValidationEntryHeader>,
@@ -375,6 +366,10 @@ impl <'a> ctx::TryIntoCtx<Endian> for &AuxFile {
     fn try_into_ctx(self, this: &mut [u8], le: Endian) -> Result<usize, Self::Error> {
         let mut offset = 0;
         this.gwrite_with(&self.header, &mut offset, le)?;
+        for symbol in &self.key_symbols {
+            this.gwrite_with(symbol.signature, &mut offset, le)?;
+            this.gwrite_with(symbol.offset.expect("Symbol offset should be resolved"), &mut offset, le)?;
+        }
         for entry in &self.entries {
             this.gwrite_with(entry, &mut offset, le)?;
         }
@@ -395,8 +390,8 @@ impl AuxFile {
             return Err(anyhow::anyhow!("Aux buffer size mismatch."))
         }
 
-        for (i, symbol) in self.header.key_symbols.iter().enumerate() {
-            let start = 24 + (i * 8);
+        for (i, symbol) in self.key_symbols.iter().enumerate() {
+            let start = self.header.offset_to_first_key_symbol as usize + (i * 8);
             let aux_value = aux_buffer.get(
                 start .. start + 8
             ).ok_or(anyhow::anyhow!("Failed to get Aux Value"))?;

--- a/SpamPkg/Tools/gen_aux/src/auxgen.rs
+++ b/SpamPkg/Tools/gen_aux/src/auxgen.rs
@@ -42,6 +42,10 @@ impl KeySymbol {
         if let Some(symbol) = symbols.iter().find(|&entry| &entry.name == self.symbol.as_ref().unwrap()) {
             self.offset = Some(symbol.address as u32);
         }
+
+        if self.offset.is_none() {
+            return Err(anyhow::anyhow!("Could not resolve offset for symbol {}.", self.symbol.as_ref().unwrap()))
+        }
         Ok(())
     }
 }

--- a/SpamPkg/Tools/gen_aux/src/main.rs
+++ b/SpamPkg/Tools/gen_aux/src/main.rs
@@ -10,7 +10,7 @@ pub mod auxgen;
 pub mod util;
 pub mod validation;
 
-use auxgen::{Symbol, AuxBuilder, KeySymbol};
+use auxgen::{Symbol, AuxBuilder};
 use validation::{ValidationRule, ValidationType};
 
 pub const POINTER_LENGTH: u64 = 8;
@@ -34,6 +34,43 @@ pub struct Args {
     // Display the parse Symbol information.
     #[arg(short, long)]
     pub debug: bool
+}
+
+/// A struct that represents an signature/address pair to be added to the
+/// auxillary file header.
+#[derive(Deserialize, Default)]
+pub struct KeySymbol {
+    /// The symbol name to calculate the offset of.
+    pub symbol: Option<String>,
+    /// The offset
+    pub offset: Option<u32>,
+    /// The signature that tells the firmware what to do with the address.
+    pub signature: u32,
+}
+
+impl KeySymbol {
+    pub fn resolve(&mut self, symbols: &Vec<Symbol>) -> anyhow::Result<()> {
+        if let Some(symbol) = symbols.iter().find(|&entry| &entry.name == self.symbol.as_ref().unwrap()) {
+            self.offset = Some(symbol.address as u32);
+        }
+
+        if self.offset.is_none() {
+            return Err(anyhow::anyhow!("Could not resolve offset for symbol {}.", self.symbol.as_ref().unwrap()))
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for KeySymbol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(offset) = &self.offset {
+            write!(f, "KeySymbol {{ offset: 0x{:08X}, signature: 0x{:4X} }}", offset, self.signature)
+        } else if let Some(symbol) = &self.symbol {
+            write!(f, "KeySymbol {{ symbol: {}, signature: 0x{:4X} }}", symbol, self.signature)
+        } else {
+            write!(f, "KeySymbol {{ signature: {} }}", self.signature)
+        }
+    }
 }
 
 /// Configuration options available in the config file.

--- a/SpamPkg/Tools/gen_aux/src/main.rs
+++ b/SpamPkg/Tools/gen_aux/src/main.rs
@@ -10,7 +10,7 @@ pub mod auxgen;
 pub mod util;
 pub mod validation;
 
-use auxgen::{Symbol, AuxBuilder};
+use auxgen::{Symbol, AuxBuilder, KeySymbol};
 use validation::{ValidationRule, ValidationType};
 
 pub const POINTER_LENGTH: u64 = 8;
@@ -39,6 +39,9 @@ pub struct Args {
 /// Configuration options available in the config file.
 #[derive(Debug, Deserialize, Default)]
 pub struct Config {
+    /// A list of key symbols to be added to the auxillary file header.
+    #[serde(alias = "key", default = "Vec::new")]
+    pub key_symbols: Vec<KeySymbol>,
     /// A list of validation rules that ultimately create a validation entry in
     /// the auxillary file.
     #[serde(alias = "rule", default = "Vec::new")]

--- a/SpamPkg/Tools/gen_aux/src/main.rs
+++ b/SpamPkg/Tools/gen_aux/src/main.rs
@@ -92,6 +92,9 @@ pub fn main() -> Result<()> {
 
     if args.debug {
         println!("{:?}", aux.header);
+        for symbol in aux.key_symbols.iter() {
+            println!("  {:?}", symbol);
+        }
         for entry in aux.entries.iter() {
             println!("  {:?}", entry);
         }


### PR DESCRIPTION
## Description

Adds two additional fields to `IMAGE_VALIDATION_DATA_HEADER`, `KeySymbolCount` and `OffsetToFirstKeySymbol` and a new struct, `KEY_SYMBOL` which is a U32, U32 (Signature / Offset) pair. 

Updates the aux gen to support adding key symbols via the config file by using the `[[key]]` config header.

This will allow a consumer of the auxillary file to define a set of key symbols that are necessary before performing any validation of an efi. The expectation is that the signature will allow the consumer to identify the purpose of the provided offset and act accordingly. The expectation is not that the signature will match the symbol name, but the purpose that the symbol is used for.

```
+--------------------------------------------+
+  IMAGE_VALIDATION_DATA_HEADER
+--------------------------------------------+
+  KEY_SYMBOL's
+--------------------------------------------+
+  IMAGE_VALIDATION_ENTRY_HEADER's
+--------------------------------------------+
+  Raw Data
+--------------------------------------------+
```

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

<_Please describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
