### PR TITLE
Fix IDTr for the standalone MMI entry binary

### DIFF
--- a/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -69,7 +69,7 @@ EFI_SM_MONITOR_INIT_PROTOCOL  mSmMonitorInitProtocol = {
 extern BOOLEAN mCetSupported;
 extern BOOLEAN gPatchXdSupported;
 extern BOOLEAN gPatchMsrIa32MiscEnableSupported;
-extern BOOLEAN gPatch5LevelPagingNeeded;
+extern BOOLEAN m5LevelPagingNeeded;
 
 extern UINT32 mCetPl0Ssp;
 extern UINT32 mCetInterruptSsp;
@@ -568,8 +568,13 @@ SmmCpuFeaturesInstallSmiHandler (
   // Initialize values in template before copy
   //
   tSmiStack                = (UINT32)((UINTN)SmiStack + StackSize - sizeof (UINTN));
-  gStmSmiHandlerIdtr.Base  = IdtBase;
-  gStmSmiHandlerIdtr.Limit = (UINT16)(IdtSize - 1);
+  if ((gStmSmiHandlerIdtr.Base == 0) && (gStmSmiHandlerIdtr.Limit == 0)) {
+    gStmSmiHandlerIdtr.Base  = IdtBase;
+    gStmSmiHandlerIdtr.Limit = (UINT16)(IdtSize - 1);
+  } else {
+    ASSERT (gStmSmiHandlerIdtr.Base == IdtBase);
+    ASSERT (gStmSmiHandlerIdtr.Limit == (UINT16)(IdtSize - 1));
+  }
 
   //
   // Set the value at the top of the CPU stack to the CPU Index
@@ -613,7 +618,7 @@ SmmCpuFeaturesInstallSmiHandler (
   Fixup64Ptr[FIXUP64_SMI_RDZ_ENTRY] = (UINT64)SmiRendezvous;
   Fixup64Ptr[FIXUP64_XD_SUPPORTED] = (UINT64)&gPatchXdSupported;
   Fixup64Ptr[FIXUP64_CET_SUPPORTED] = (UINT64)&mCetSupported;
-  Fixup64Ptr[FIXUP64_SMI_HANDLER_IDTR] = IdtBase;
+  Fixup64Ptr[FIXUP64_SMI_HANDLER_IDTR] = (UINT64)&gStmSmiHandlerIdtr;
 
   Fixup8Ptr[FIXUP8_gPatchXdSupported] = gPatchXdSupported;
   Fixup8Ptr[FIXUP8_gPatchMsrIa32MiscEnableSupported] = gPatchMsrIa32MiscEnableSupported;


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The IDTr is incorrect using the IDT base. This change fixed the IDT usage and updated the check for newly supplied IDTr values.

A build fix is also added to fix the error from the last nasmb fix.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is tested Q35 with viable page fault exceptions.

## Integration Instructions

N/A
