### PR TITLE
Remove code patching when not using the default SMI entry

### DIFF
--- a/MmSupervisorPkg/Core/Mem/SmmProfile.c
+++ b/MmSupervisorPkg/Core/Mem/SmmProfile.c
@@ -875,11 +875,15 @@ CheckFeatureSupported (
       AsmCpuidEx (CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS, CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_SUB_LEAF_INFO, NULL, NULL, &RegEcx, NULL);
       if ((RegEcx & CPUID_CET_SS) == 0) {
         mCetSupported = FALSE;
-        PatchInstructionX86 (mPatchCetSupported, mCetSupported, 1);
+        if (SmmCpuFeaturesGetSmiHandlerSize () == 0) {
+          PatchInstructionX86 (mPatchCetSupported, mCetSupported, 1);
+        }
       }
     } else {
       mCetSupported = FALSE;
-      PatchInstructionX86 (mPatchCetSupported, mCetSupported, 1);
+      if (SmmCpuFeaturesGetSmiHandlerSize () == 0) {
+        PatchInstructionX86 (mPatchCetSupported, mCetSupported, 1);
+      }
     }
   }
 

--- a/MmSupervisorPkg/Core/Relocate/Relocate.c
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.c
@@ -743,7 +743,9 @@ SetupSmiEntryExit (
       DEBUG ((DEBUG_INFO, "  CET_IBT - 0x%08x\n", RegEdx & CPUID_CET_IBT));
       if ((RegEcx & CPUID_CET_SS) == 0) {
         mCetSupported = FALSE;
-        PatchInstructionX86 (mPatchCetSupported, mCetSupported, 1);
+        if (SmmCpuFeaturesGetSmiHandlerSize () == 0) {
+          PatchInstructionX86 (mPatchCetSupported, mCetSupported, 1);
+        }
       }
 
       if (mCetSupported) {


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The system will not patch the SMI entry during initialization if the default SMI entry will not be used.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is tested on QEMU Q35 and verified bootable to Shell.

## Integration Instructions

N/A
