### PR TITLE
aux_gen: Update key symbol signature format

### DIFF
--- a/SpamPkg/Tools/gen_aux/readme.md
+++ b/SpamPkg/Tools/gen_aux/readme.md
@@ -30,12 +30,12 @@ the key command (`[[key]]`) is a configuration option to tell the tool to genera
 
 ``` toml
 [[key]]
-signature = 'Required[u32]'
+signature = 'Required[[char; 4]]'
 symbol = 'Optional[String]'
 offset = 'Optional[u32]'
 ```
 
-- `signature`: The 4 byte signature used by the firmware to determine how to use the offset
+- `signature`: The 4 byte signature used by the firmware to determine how to use the offset (i.e. ['F', 'P', 'O', 'L'])
 - `symbol`: Used to calculate the offset value. Mutually exclusive to `offset`
 - `offset`: The offset used by the firmware. Mutually exclusive to `symbol`
 

--- a/SpamPkg/Tools/gen_aux/src/auxgen.rs
+++ b/SpamPkg/Tools/gen_aux/src/auxgen.rs
@@ -336,7 +336,7 @@ impl <'a> ctx::TryIntoCtx<Endian> for &AuxFile {
         let mut offset = 0;
         this.gwrite_with(&self.header, &mut offset, le)?;
         for symbol in &self.key_symbols {
-            this.gwrite_with(symbol.signature_as_u32(), &mut offset, le)?;
+            this.gwrite_with(symbol.signature(), &mut offset, le)?;
             this.gwrite_with(symbol.offset.expect("Symbol offset should be resolved"), &mut offset, le)?;
         }
         for entry in &self.entries {
@@ -368,7 +368,7 @@ impl AuxFile {
             let sig: u32 = aux_value.gread(&mut 0)?;
             let offset: u32 = aux_value.gread(&mut 4)?;
 
-            if sig != symbol.signature_as_u32() || offset != symbol.offset.unwrap_or_default() {
+            if sig != symbol.signature() || offset != symbol.offset.unwrap_or_default() {
                 return Err(anyhow::anyhow!("Aux / Image mismatch."))
             }
         }

--- a/SpamPkg/Tools/gen_aux/src/auxgen.rs
+++ b/SpamPkg/Tools/gen_aux/src/auxgen.rs
@@ -336,7 +336,7 @@ impl <'a> ctx::TryIntoCtx<Endian> for &AuxFile {
         let mut offset = 0;
         this.gwrite_with(&self.header, &mut offset, le)?;
         for symbol in &self.key_symbols {
-            this.gwrite_with(symbol.signature, &mut offset, le)?;
+            this.gwrite_with(symbol.signature_as_u32(), &mut offset, le)?;
             this.gwrite_with(symbol.offset.expect("Symbol offset should be resolved"), &mut offset, le)?;
         }
         for entry in &self.entries {
@@ -368,7 +368,7 @@ impl AuxFile {
             let sig: u32 = aux_value.gread(&mut 0)?;
             let offset: u32 = aux_value.gread(&mut 4)?;
 
-            if sig != symbol.signature || offset != symbol.offset.unwrap_or_default() {
+            if sig != symbol.signature_as_u32() || offset != symbol.offset.unwrap_or_default() {
                 return Err(anyhow::anyhow!("Aux / Image mismatch."))
             }
         }

--- a/SpamPkg/Tools/gen_aux/src/main.rs
+++ b/SpamPkg/Tools/gen_aux/src/main.rs
@@ -46,7 +46,7 @@ pub struct KeySymbol {
     /// The offset
     pub offset: Option<u32>,
     /// The signature that tells the firmware what to do with the address.
-    pub signature: [char; 4],
+    signature: [char; 4],
 }
 
 impl KeySymbol {
@@ -61,7 +61,7 @@ impl KeySymbol {
         Ok(())
     }
 
-    pub fn signature_as_u32(&self) -> u32 {
+    pub fn signature(&self) -> u32 {
         let buffer = self.signature.iter().map(|&c| c as u8).collect::<Vec<u8>>();
         buffer.pread::<u32>(0).unwrap()
     }
@@ -70,11 +70,11 @@ impl KeySymbol {
 impl std::fmt::Debug for KeySymbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(offset) = &self.offset {
-            write!(f, "KeySymbol {{ offset: 0x{:08X}, signature: 0x{:4X} }}", offset, self.signature_as_u32())
+            write!(f, "KeySymbol {{ offset: 0x{:08X}, signature: 0x{:4X} }}", offset, self.signature())
         } else if let Some(symbol) = &self.symbol {
-            write!(f, "KeySymbol {{ symbol: {}, signature: 0x{:4X} }}", symbol, self.signature_as_u32())
+            write!(f, "KeySymbol {{ symbol: {}, signature: 0x{:4X} }}", symbol, self.signature())
         } else {
-            write!(f, "KeySymbol {{ signature: 0x{:4X} }}", self.signature_as_u32())
+            write!(f, "KeySymbol {{ signature: 0x{:4X} }}", self.signature())
         }
     }
 }

--- a/SpamPkg/Tools/gen_aux/src/main.rs
+++ b/SpamPkg/Tools/gen_aux/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use pdb::PDB;
 use anyhow::Result;
 use serde::Deserialize;
+use scroll::Pread;
 
 pub mod auxgen;
 pub mod util;
@@ -45,7 +46,7 @@ pub struct KeySymbol {
     /// The offset
     pub offset: Option<u32>,
     /// The signature that tells the firmware what to do with the address.
-    pub signature: u32,
+    pub signature: [char; 4],
 }
 
 impl KeySymbol {
@@ -59,16 +60,21 @@ impl KeySymbol {
         }
         Ok(())
     }
+
+    pub fn signature_as_u32(&self) -> u32 {
+        let buffer = self.signature.iter().map(|&c| c as u8).collect::<Vec<u8>>();
+        buffer.pread::<u32>(0).unwrap()
+    }
 }
 
 impl std::fmt::Debug for KeySymbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(offset) = &self.offset {
-            write!(f, "KeySymbol {{ offset: 0x{:08X}, signature: 0x{:4X} }}", offset, self.signature)
+            write!(f, "KeySymbol {{ offset: 0x{:08X}, signature: 0x{:4X} }}", offset, self.signature_as_u32())
         } else if let Some(symbol) = &self.symbol {
-            write!(f, "KeySymbol {{ symbol: {}, signature: 0x{:4X} }}", symbol, self.signature)
+            write!(f, "KeySymbol {{ symbol: {}, signature: 0x{:4X} }}", symbol, self.signature_as_u32())
         } else {
-            write!(f, "KeySymbol {{ signature: {} }}", self.signature)
+            write!(f, "KeySymbol {{ signature: 0x{:4X} }}", self.signature_as_u32())
         }
     }
 }


### PR DESCRIPTION
## Description

Updates the config file to accept a [char; 4] instead of a u32 for the key symbol signature. This is to better match the SIGNATURE_32 function provided by edk2, which converts 4 characters into a u32 signature.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Locally confirmed a config file and efi/pdb are successfully parsed.

## Integration Instructions

N/A