### PR TITLE
GenSpamArtifacts.py: Support Python 3.10, 3.11

### DIFF
--- a/SpamPkg/Tools/GenSpamArtifacts/GenSpamArtifacts.py
+++ b/SpamPkg/Tools/GenSpamArtifacts/GenSpamArtifacts.py
@@ -199,7 +199,7 @@ def generate_stm_binary(stm_dll: Path, output_dir: Path):
     gen_stm = base_tools_dir / "Bin" / "Win32" / "GenStm.exe"
     cmd = str(gen_stm)
 
-    args = f"-e --debug 5 {stm_dll} -o {output_dir / "Stm.bin"}"
+    args = f"-e --debug 5 {stm_dll} -o {output_dir / 'Stm.bin'}"
     ret = RunCmd(cmd, args)
     if ret != 0:
         raise RuntimeError("GenStm failed. Review command output.")


### PR DESCRIPTION
## Description

Python 3.10 and 3.11 do not support nested double quotes in f-strings. Replaces the nested double quote with a single quote.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
