### PR TITLE
Fix SPAM responder data in a torn state

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -56,7 +56,7 @@ UINT64                MmSupvEfiFileSize;
 VOID   *mMmHobStart;
 UINTN  mMmHobSize;
 
-// Inidicator to check if this is the first MMI.
+// Indicator to check if this is the first MMI.
 STATIC BOOLEAN    mFirstMmi = TRUE;
 
 //

--- a/SpamPkg/Core/Runtime/SpamResponderReport.c
+++ b/SpamPkg/Core/Runtime/SpamResponderReport.c
@@ -562,7 +562,7 @@ VerifyAndMeasureImage (
               DigestList
               );
   if (!EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a Measured image at %p of size %x successfully.\n", __func__, NewBuffer, NewBufferSize, Status));
+    DEBUG ((DEBUG_INFO, "%a Measured image at %p of size %x successfully.\n", __func__, NewBuffer, NewBufferSize));
   } else {
     DEBUG ((DEBUG_ERROR, "%a Failed to measure image at %p of size %x - %r\n", __func__, NewBuffer, NewBufferSize, Status));
   }

--- a/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -494,8 +494,6 @@ PopulateSpamInformation (
   mSpamResponderTemplate.MmSupervisorAuxBase = MmSupvAuxFileBase;
   mSpamResponderTemplate.MmSupervisorAuxSize = MmSupvAuxFileSize;
 
-  CopyMem ((VOID *)(UINTN)(StackBase + StackSize - sizeof (SPAM_RESPONDER_DATA)), &mSpamResponderTemplate, sizeof (SPAM_RESPONDER_DATA));
-
   return EFI_SUCCESS;
 }
 
@@ -772,8 +770,7 @@ MmEndOfDxeEventNotify (
 
     StmHeader->SwStmHdr.PerProcDynamicMemorySize;
     SpamResponderData = (SPAM_RESPONDER_DATA*)((UINTN)LongRsp + StmHeader->SwStmHdr.PerProcDynamicMemorySize -
-                        sizeof (SPAM_RESPONDER_DATA) -
-                        (NoHandles - 1) * sizeof (USER_MODULE_INFO));
+                        sizeof (SPAM_RESPONDER_DATA));
 
     CopyMem (SpamResponderData, &mSpamResponderTemplate, sizeof (SPAM_RESPONDER_DATA));
     // TODO: Mark the region as supervisor read-only, or even read prevention...

--- a/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -166,14 +166,10 @@ SPAM_RESPONDER_DATA mSpamResponderTemplate = {
   .Size = 0,
   .Reserved = 0,
   .CpuIndex = 0,
-  .MmEntryBase = 0,
   .MmEntrySize = 0,
-  .MmSupervisorBase = 0,
   .MmSupervisorSize = 0,
-  .MmSecurePolicyBase = 0,
-  .MmSecurePolicySize = 0,
-  .UserModuleOffset = sizeof (SPAM_RESPONDER_DATA),
-  .UserModuleCount = 0
+  .MmSupervisorAuxBase = 0,
+  .MmSupervisorAuxSize = 0
 };
 
 //
@@ -489,19 +485,16 @@ PopulateSpamInformation (
   IN UINTN                  StackSize
   )
 {
-  mSpamResponderTemplate.Signature          = SPAM_RESPONDER_STRUCT_SIGNATURE;
-  mSpamResponderTemplate.VersionMajor       = SPAM_REPSONDER_STRUCT_MAJOR_VER;
-  mSpamResponderTemplate.VersionMinor       = SPAM_REPSONDER_STRUCT_MINOR_VER;
-  mSpamResponderTemplate.Size               = sizeof (SPAM_RESPONDER_DATA);
-  mSpamResponderTemplate.CpuIndex           = CpuIndex;
-  mSpamResponderTemplate.MmEntryBase        = MmEntryBase;
-  mSpamResponderTemplate.MmEntrySize        = MmEntrySize;
-  mSpamResponderTemplate.MmSecurePolicyBase = (UINT64)FirmwarePolicy;
-  mSpamResponderTemplate.MmSecurePolicySize = FirmwarePolicy->Size;
-  mSpamResponderTemplate.UserModuleOffset   = 0;
-  mSpamResponderTemplate.UserModuleCount    = 0;
+  mSpamResponderTemplate.Signature           = SPAM_RESPONDER_STRUCT_SIGNATURE;
+  mSpamResponderTemplate.VersionMajor        = SPAM_REPSONDER_STRUCT_MAJOR_VER;
+  mSpamResponderTemplate.VersionMinor        = SPAM_REPSONDER_STRUCT_MINOR_VER;
+  mSpamResponderTemplate.Size                = sizeof (SPAM_RESPONDER_DATA);
+  mSpamResponderTemplate.CpuIndex            = CpuIndex;
+  mSpamResponderTemplate.MmEntrySize         = MmEntrySize;
+  mSpamResponderTemplate.MmSupervisorAuxBase = MmSupvAuxFileBase;
+  mSpamResponderTemplate.MmSupervisorAuxSize = MmSupvAuxFileSize;
 
-  // TODO: Populate more user modules and fix up the size.
+  CopyMem ((VOID *)(UINTN)(StackBase + StackSize - sizeof (SPAM_RESPONDER_DATA)), &mSpamResponderTemplate, sizeof (SPAM_RESPONDER_DATA));
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

After updating the SPAM responder data definition, the C code in SmmStm.c is not updated accordingly.

This change fixed the torn state issue by correctly populating the data fields.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is not tested...

## Integration Instructions

N/A
