### PR TITLE
Move secure policy into a common library

### DIFF
--- a/MmSupervisorPkg/Core/Mem/Mem.h
+++ b/MmSupervisorPkg/Core/Mem/Mem.h
@@ -656,6 +656,7 @@ InspectTargetRangeOwnership (
   @retval FALSE This buffer is from MMRAM.
 **/
 BOOLEAN
+EFIAPI
 IsBufferInsideMmram (
   IN EFI_PHYSICAL_ADDRESS  Buffer,
   IN UINT64                Length

--- a/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
+++ b/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
@@ -26,7 +26,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "Services/MpService/MpService.h"
 #include "Relocate/Relocate.h"
 #include "Request/Request.h"
-#include "Policy/Policy.h"
 
 //
 // attributes for reserved memory before it is promoted to system memory
@@ -1680,6 +1679,7 @@ SkipResourceDescriptor (
   @retval FALSE This buffer is from MMRAM.
 **/
 BOOLEAN
+EFIAPI
 IsBufferInsideMmram (
   IN EFI_PHYSICAL_ADDRESS  Buffer,
   IN UINT64                Length

--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -14,6 +14,7 @@
 
 #include <PiMm.h>
 #include <StandaloneMm.h>
+#include <SmmSecurePolicy.h>
 
 #include <Protocol/DxeMmReadyToLock.h>
 #include <Protocol/MmReadyToLock.h>
@@ -232,22 +233,24 @@ typedef struct {
 //
 // MM Core Global Variables
 //
-extern MM_CORE_PRIVATE_DATA        *gMmCorePrivate;
-extern MM_CORE_PRIVATE_DATA        *gMmCoreMailbox;
-extern EFI_MM_SYSTEM_TABLE         gMmCoreMmst;
-extern EFI_MM_SYSTEM_TABLE         *gMmUserMmst;
-extern LIST_ENTRY                  gHandleList;
-extern EFI_PHYSICAL_ADDRESS        gLoadModuleAtFixAddressMmramBase;
-extern MM_SUPV_USER_COMMON_BUFFER  *SupervisorToUserDataBuffer;
-extern MM_CORE_MMI_HANDLERS        mMmCoreMmiHandlers[];
-extern EFI_MM_DRIVER_ENTRY         *mMmCoreDriverEntry;
-extern BOOLEAN                     mMmReadyToLockDone;
-extern BOOLEAN                     mCoreInitializationComplete;
-extern EFI_MEMORY_DESCRIPTOR       mMmSupervisorAccessBuffer[MM_OPEN_BUFFER_CNT];
-extern LIST_ENTRY                  mFfsDriverCacheList;
-extern VOID                        *mMmHobStart;
-extern UINTN                       mMmHobSize;
-extern VOID                        *mInternalCommBufferCopy[MM_OPEN_BUFFER_CNT];
+extern MM_CORE_PRIVATE_DATA              *gMmCorePrivate;
+extern MM_CORE_PRIVATE_DATA              *gMmCoreMailbox;
+extern EFI_MM_SYSTEM_TABLE               gMmCoreMmst;
+extern EFI_MM_SYSTEM_TABLE               *gMmUserMmst;
+extern LIST_ENTRY                        gHandleList;
+extern EFI_PHYSICAL_ADDRESS              gLoadModuleAtFixAddressMmramBase;
+extern MM_SUPV_USER_COMMON_BUFFER        *SupervisorToUserDataBuffer;
+extern MM_CORE_MMI_HANDLERS              mMmCoreMmiHandlers[];
+extern EFI_MM_DRIVER_ENTRY               *mMmCoreDriverEntry;
+extern BOOLEAN                           mMmReadyToLockDone;
+extern BOOLEAN                           mCoreInitializationComplete;
+extern EFI_MEMORY_DESCRIPTOR             mMmSupervisorAccessBuffer[MM_OPEN_BUFFER_CNT];
+extern LIST_ENTRY                        mFfsDriverCacheList;
+extern VOID                              *mMmHobStart;
+extern UINTN                             mMmHobSize;
+extern VOID                              *mInternalCommBufferCopy[MM_OPEN_BUFFER_CNT];
+extern SMM_SUPV_SECURE_POLICY_DATA_V1_0  *FirmwarePolicy;
+extern SMM_SUPV_SECURE_POLICY_DATA_V1_0  *MemPolicySnapshot;
 
 /**
   Called to initialize the memory service.

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -83,10 +83,6 @@
   Services/MpService/MpService.c
   Services/MpService/SyncTimer.c
 
-  Policy/GeneralPolicy.c
-  Policy/MemPolicy.c
-  Policy/Policy.h
-
   PrivilegeMgmt/PrivilegeMgmt.h
   PrivilegeMgmt/CallGateTransfer.c
   PrivilegeMgmt/AsmCallGateTransfer.nasm
@@ -148,6 +144,7 @@
   CpuPageTableLib
   MmSaveStateLib
   SmmCpuSyncLib
+  SecurePolicyLib
 
 [Protocols]
   gEfiMmEndOfDxeProtocolGuid                   ## PRODUCES

--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
@@ -25,7 +25,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "Relocate/Relocate.h"
 #include "Handler/Handler.h"
 #include "Mem/Mem.h"
-#include "Policy/Policy.h"
 
 EFI_MM_SYSTEM_TABLE  *gMmUserMmst = NULL;
 

--- a/MmSupervisorPkg/Core/Relocate/SmramSaveState.c
+++ b/MmSupervisorPkg/Core/Relocate/SmramSaveState.c
@@ -20,7 +20,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/IhvSmmSaveStateSupervisionLib.h>
 
 #include "Relocate.h"
-#include "Policy/Policy.h"
 #include "Services/MpService/MpService.h"
 #include "MmSupervisorCore.h"
 

--- a/MmSupervisorPkg/Core/Request/FetchPolicy.c
+++ b/MmSupervisorPkg/Core/Request/FetchPolicy.c
@@ -17,10 +17,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BaseLib.h>
 #include <Library/MmServicesTableLib.h>
 #include <Library/DebugLib.h>
+#include <Library/SecurePolicyLib.h>
 
 #include "MmSupervisorCore.h"
-#include "Policy/Policy.h"
 #include "Mem/Mem.h"
+
+SMM_SUPV_SECURE_POLICY_DATA_V1_0  *MemPolicySnapshot = NULL;
 
 /**
   Function that combines current memory policy and firmware secure policy for requestor.

--- a/MmSupervisorPkg/Include/Library/SecurePolicyLib.h
+++ b/MmSupervisorPkg/Include/Library/SecurePolicyLib.h
@@ -13,13 +13,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <SmmSecurePolicy.h>
 
-extern SMM_SUPV_SECURE_POLICY_DATA_V1_0  *FirmwarePolicy;
-extern SMM_SUPV_SECURE_POLICY_DATA_V1_0  *MemPolicySnapshot;
+#define MEM_POLICY_SNAPSHOT_SIZE  0x400   // 1K should be more than enough to describe allowed non-MMRAM regions
 
 /**
   Dump a single memory policy data.
 **/
 VOID
+EFIAPI
 DumpMemPolicyEntry (
   SMM_SUPV_SECURE_POLICY_MEM_DESCRIPTOR_V1_0  *MemoryPolicy
   );
@@ -49,6 +49,7 @@ PopulateMemoryPolicyEntries (
 
 **/
 BOOLEAN
+EFIAPI
 CompareMemoryPolicy (
   SMM_SUPV_SECURE_POLICY_DATA_V1_0  *SmmPolicyData1,
   SMM_SUPV_SECURE_POLICY_DATA_V1_0  *SmmPolicyData2
@@ -62,8 +63,9 @@ CompareMemoryPolicy (
   @retval Errors                    Other error during populating memory errors.
 **/
 EFI_STATUS
+EFIAPI
 PrepareMemPolicySnapshot (
-  VOID
+  IN SMM_SUPV_SECURE_POLICY_DATA_V1_0  *MemPolicySnapshot
   );
 
 /**
@@ -73,8 +75,9 @@ PrepareMemPolicySnapshot (
   @retval EFI_OUT_OF_RESOURCES      Cannot allocate enough resources for snapshot.
 **/
 EFI_STATUS
+EFIAPI
 AllocateMemForPolicySnapshot (
-  VOID
+  IN SMM_SUPV_SECURE_POLICY_DATA_V1_0  **MemPolicySnapshot
   );
 
 /**
@@ -90,6 +93,7 @@ AllocateMemForPolicySnapshot (
                                   checking.
 **/
 EFI_STATUS
+EFIAPI
 SecurityPolicyCheck (
   IN SMM_SUPV_SECURE_POLICY_DATA_V1_0  *SmmSecurityPolicy
   );
@@ -98,20 +102,9 @@ SecurityPolicyCheck (
   Dump the smm policy data.
 **/
 VOID
+EFIAPI
 DumpSmmPolicyData (
   SMM_SUPV_SECURE_POLICY_DATA_V1_0  *Data
-  );
-
-/**
-  Routine for initializing policy data provided by firmware.
-
-  @retval EFI_SUCCESS           The handler for the processor interrupt was successfully installed or uninstalled.
-  @retval Errors                The supervisor is unable to locate or protect the policy from firmware.
-
-**/
-EFI_STATUS
-InitializePolicy (
-  VOID
   );
 
 #endif // _MM_SUPV_POLICY_H_

--- a/MmSupervisorPkg/Library/SecurePolicyLib/SecurePolicyLib.inf
+++ b/MmSupervisorPkg/Library/SecurePolicyLib/SecurePolicyLib.inf
@@ -1,0 +1,35 @@
+## @file
+# This library provides basic operation for supervisor policy manipulation.
+#
+# Copyright (C) Microsoft Corporation.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = SecurePolicyLib
+  FILE_GUID                      = D783E653-2CA2-4730-AB01-7C796C61A0DE
+  MODULE_TYPE                    = MM_CORE_STANDALONE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  LIBRARY_CLASS                  = SecurePolicyLib|MM_CORE_STANDALONE
+
+#  VALID_ARCHITECTURES           = X64
+
+[Sources]
+  GeneralPolicy.c
+  MemPolicy.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+  MmSupervisorPkg/MmSupervisorPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib

--- a/MmSupervisorPkg/MmSupervisorPkg.dec
+++ b/MmSupervisorPkg/MmSupervisorPkg.dec
@@ -27,6 +27,7 @@
   SysCallLib|Include/Library/SysCallLib.h
   SmmPolicyGateLib|Include/Library/SmmPolicyGateLib.h
   IhvSmmSaveStateSupervisionLib|Include/Library/IhvSmmSaveStateSupervisionLib.h
+  SecurePolicyLib|Include/Library/SecurePolicyLib.h
 
 [Guids]
   gMmCommonRegionHobGuid                          = { 0xd4ffc718, 0xfb82, 0x4274, { 0x9a, 0xfc, 0xaa, 0x8b, 0x1e, 0xef, 0x52, 0x93 } }

--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -96,6 +96,7 @@
   IhvSmmSaveStateSupervisionLib|MmSupervisorPkg/Library/IhvMmSaveStateSupervisionLib/IhvMmSaveStateSupervisionLib.inf
   MmServicesTableLib|StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
   SmmCpuSyncLib|MmSupervisorPkg/Library/StandaloneMmCpuSyncLib/StandaloneMmCpuSyncLib.inf
+  SecurePolicyLib|MmSupervisorPkg/Library/SecurePolicyLib/SecurePolicyLib.inf
 
 [LibraryClasses.X64.MM_STANDALONE]
   BaseLib|MmSupervisorPkg/Library/BaseLibSysCall/BaseLib.inf

--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -145,6 +145,7 @@
   MmSupervisorPkg/Library/MmSupervisorMemLib/MmSupervisorCoreMemLib.inf
   MmSupervisorPkg/Library/MmSupervisorMemLib/MmSupervisorMemLibSyscall.inf
   MmSupervisorPkg/Library/IhvMmSaveStateSupervisionLib/IhvMmSaveStateSupervisionLib.inf
+  MmSupervisorPkg/Library/SecurePolicyLib/SecurePolicyLib.inf
 
   MmSupervisorPkg/Core/MmSupervisorCore.inf
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The preparation and walk through of general policy as well as memory policy are common code that does not require module specific knowledge.

This change moves the policy related manipulation code into a common library implementation.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU Q35 platform and booted to UEFI shell.

## Integration Instructions

N/A
