### PR TITLE
Fix Dsc offsets in MmiEntrySpam.nasmb

### DIFF
--- a/SpamPkg/Core/Runtime/SmmEptHandler.c
+++ b/SpamPkg/Core/Runtime/SmmEptHandler.c
@@ -677,8 +677,8 @@ GetMemoryAttributes (
   // MU_CHANGE Ends
   MemAttr = (UINT64)-1;
 
-  Cr4.UintN         = AsmReadCr4 ();
-  EnablePML5Paging  = (BOOLEAN)(Cr4.Bits.LA57 == 1);
+  Cr4.UintN        = AsmReadCr4 ();
+  EnablePML5Paging = (BOOLEAN)(Cr4.Bits.LA57 == 1);
 
   do {
     PageEntry = GetPageTableEntry (PageTableBase, EnablePML5Paging, BaseAddress, &PageAttr);

--- a/SpamPkg/Core/Runtime/SpamResponderUtilities.c
+++ b/SpamPkg/Core/Runtime/SpamResponderUtilities.c
@@ -118,7 +118,7 @@ IsBufferInsideMmram (
   MmRamBase = AsmReadMsr64 (MSR_IA32_SMRR_PHYSBASE);
   MmrrMask  = AsmReadMsr64 (MSR_IA32_SMRR_PHYSMASK);
   // Extend the mask to account for the reserved bits.
-  MmrrMask    |= 0xffffffff00000000ULL;
+  MmrrMask   |= 0xffffffff00000000ULL;
   MmRamLength = ((~(MmrrMask & MtrrValidAddressMask)) & MtrrValidBitsMask) + 1;
 
   Status = Range1InsideRange2 (Buffer, Length, MmRamBase, MmRamLength, &IsInside);

--- a/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -628,7 +628,7 @@ SmmCpuFeaturesInstallSmiHandler (
   Fixup64Ptr[FIXUP64_CET_SUPPORTED]    = (UINT64)&mCetSupported;
   Fixup64Ptr[FIXUP64_SMI_HANDLER_IDTR] = (UINT64)&gStmSmiHandlerIdtr;
 
-  Fixup8Ptr[FIXUP8_gPatchXdSupported]                = mXdSupported;
+  Fixup8Ptr[FIXUP8_gPatchXdSupported] = mXdSupported;
   if (StandardSignatureIsAuthenticAMD ()) {
     //
     // AMD processors do not support MSR_IA32_MISC_ENABLE
@@ -637,8 +637,9 @@ SmmCpuFeaturesInstallSmiHandler (
   } else {
     Fixup8Ptr[FIXUP8_gPatchMsrIa32MiscEnableSupported] = TRUE;
   }
-  Fixup8Ptr[FIXUP8_m5LevelPagingNeeded]              = m5LevelPagingNeeded;
-  Fixup8Ptr[FIXUP8_mPatchCetSupported]               = mCetSupported;
+
+  Fixup8Ptr[FIXUP8_m5LevelPagingNeeded] = m5LevelPagingNeeded;
+  Fixup8Ptr[FIXUP8_mPatchCetSupported]  = mCetSupported;
 
   // TODO: Sort out these values, if needed
   Psd->SmmSmiHandlerRip = 0;

--- a/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SpamPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -637,7 +637,6 @@ SmmCpuFeaturesInstallSmiHandler (
   } else {
     Fixup8Ptr[FIXUP8_gPatchMsrIa32MiscEnableSupported] = TRUE;
   }
-  //Fixup8Ptr[FIXUP8_gPatchMsrIa32MiscEnableSupported] = gPatchMsrIa32MiscEnableSupported;
   Fixup8Ptr[FIXUP8_m5LevelPagingNeeded]              = m5LevelPagingNeeded;
   Fixup8Ptr[FIXUP8_mPatchCetSupported]               = mCetSupported;
 

--- a/SpamPkg/MmiEntrySpam/MmiEntrySpam.nasmb
+++ b/SpamPkg/MmiEntrySpam/MmiEntrySpam.nasmb
@@ -43,12 +43,10 @@
 ; Constants relating to PROCESSOR_SMM_DESCRIPTOR
 ;
 %define DSC_OFFSET 0xfb00
-%define DSC_GDTPTR 0x30
-%define DSC_GDTSIZ 0x38
-%define DSC_CS 14
-%define DSC_DS 16
-%define DSC_SS 18
-%define DSC_OTHERSEG 20
+%define DSC_CS 0x14
+%define DSC_DS 0x16
+%define DSC_SS 0x18
+%define DSC_OTHERSEG 0x1a
 ;
 ; Constants relating to CPU State Save Area
 ;


### PR DESCRIPTION
## Description

The values used for the various DSC offsets in MmiEntrySpam.nasmb were based on the normal SmiEntry.nasm used in the MM Supervisor.  Instead, the needed to align with the STM file structure.  This change changes the offsets to correctly match the structure they're referencing when pulling variable data.

Additionally, SmmStm.c was updated to reference mXdSupported instead of gPatchDxSupported.  This also included a check for setting gPatchMsrIa32MiscEnableSupported based on the return value of StandardSignatureIsAuthenticAMD().

Also 2 files in the spam core had uncrustified run on them to pass CI.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Intel physical platform.  The correct offsets are being used to get the relevant CS/DS/SS values.

## Integration Instructions

N/A
