### PR TITLE
Expand common secure policy library to accept page table address as input

### DIFF
--- a/MmSupervisorPkg/Core/Request/FetchPolicy.c
+++ b/MmSupervisorPkg/Core/Request/FetchPolicy.c
@@ -93,7 +93,7 @@ FetchNUpdateSecurityPolicy (
   CopyMem (DrtmSmmPolicyData, FirmwarePolicy, FirmwarePolicy->Size);
 
   // Then leave the heavy lifting job to the library
-  Status = PopulateMemoryPolicyEntries (DrtmSmmPolicyData, MaxPolicyBufferSize);
+  Status = PopulateMemoryPolicyEntries (DrtmSmmPolicyData, MaxPolicyBufferSize, 0);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Fail to PopulateMemoryPolicyEntries %r\n", __FUNCTION__, Status));
     goto Exit;

--- a/MmSupervisorPkg/Include/Library/SecurePolicyLib.h
+++ b/MmSupervisorPkg/Include/Library/SecurePolicyLib.h
@@ -28,6 +28,7 @@ DumpMemPolicyEntry (
   Helper function that populates memory policy on demands.
 
   @param[in] SmmPolicyBuffer   Input buffer points to the entire v1.0 policy.
+  @param[in] MaxPolicySize     Maximum size of the policy buffer.
   @param[in] Cr3               CR3 value to be converted, if input is zero, check the real HW register.
 
   @param[in] CpuIndex Logical number assigned to CPU.
@@ -36,7 +37,8 @@ EFI_STATUS
 EFIAPI
 PopulateMemoryPolicyEntries (
   IN  SMM_SUPV_SECURE_POLICY_DATA_V1_0  *SmmPolicyBuffer,
-  IN  UINT64                            MaxPolicySize
+  IN  UINT64                            MaxPolicySize,
+  IN  UINT64                            Cr3
   );
 
 /**

--- a/MmSupervisorPkg/Library/SecurePolicyLib/MemPolicy.c
+++ b/MmSupervisorPkg/Library/SecurePolicyLib/MemPolicy.c
@@ -497,6 +497,7 @@ DumpMemPolicyEntry (
   Helper function that populates memory policy on demands.
 
   @param[in] SmmPolicyBuffer   Input buffer points to the entire v1.0 policy.
+  @param[in] MaxPolicySize     Maximum size of the policy buffer.
   @param[in] Cr3               CR3 value to be converted, if input is zero, check the real HW register.
 
   @param[in] CpuIndex Logical number assigned to CPU.
@@ -505,7 +506,8 @@ EFI_STATUS
 EFIAPI
 PopulateMemoryPolicyEntries (
   IN  SMM_SUPV_SECURE_POLICY_DATA_V1_0  *SmmPolicyBuffer,
-  IN  UINT64                            MaxPolicySize
+  IN  UINT64                            MaxPolicySize,
+  IN  UINT64                            Cr3
   )
 {
   SMM_SUPV_SECURE_POLICY_MEM_DESCRIPTOR_V1_0  *MemoryPolicy;
@@ -552,7 +554,7 @@ PopulateMemoryPolicyEntries (
   MemoryPolicy        = (SMM_SUPV_SECURE_POLICY_MEM_DESCRIPTOR_V1_0 *)((UINTN)SmmPolicyBuffer + PolicyRoot->Offset);
   MemoryPolicySize    = MaxPolicySize - PolicyRoot->Offset - 1;
   // Generate Policy of current Pagetable
-  Status = GenMemPolicyAndShadowPageTable (0, MemoryPolicy, MemoryPolicySize, &PolicyRoot->Count);
+  Status = GenMemPolicyAndShadowPageTable (Cr3, MemoryPolicy, MemoryPolicySize, &PolicyRoot->Count);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Fail to GenMemPolicyAndShadowPageTable for non-legacy structures %r\n", __FUNCTION__, Status));
     goto Exit;
@@ -667,7 +669,7 @@ PrepareMemPolicySnapshot (
   PolicyRoot->Type                    = SMM_SUPV_SECURE_POLICY_DESCRIPTOR_TYPE_MEM;
 
   // Then leave the heavy lifting job to the library
-  Status = PopulateMemoryPolicyEntries (MemPolicySnapshot, MEM_POLICY_SNAPSHOT_SIZE);
+  Status = PopulateMemoryPolicyEntries (MemPolicySnapshot, MEM_POLICY_SNAPSHOT_SIZE, 0);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Fail to PopulateMemoryPolicyEntries %r\n", __FUNCTION__, Status));
   }

--- a/SpamPkg/Core/Runtime/SpamResponderReport.c
+++ b/SpamPkg/Core/Runtime/SpamResponderReport.c
@@ -840,7 +840,7 @@ SpamResponderReport (
   CopyMem (DrtmSmmPolicyData, FirmwarePolicy, FirmwarePolicy->Size);
 
   // Then leave the heavy lifting job to the library
-  Status = PopulateMemoryPolicyEntries ((SMM_SUPV_SECURE_POLICY_DATA_V1_0 *)(UINTN)DrtmSmmPolicyData, sizeof (DrtmSmmPolicyData));
+  Status = PopulateMemoryPolicyEntries ((SMM_SUPV_SECURE_POLICY_DATA_V1_0 *)(UINTN)DrtmSmmPolicyData, FirmwarePolicy->Size + MEM_POLICY_SNAPSHOT_SIZE, SupvPageTableBase);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Fail to PopulateMemoryPolicyEntries %r\n", __FUNCTION__, Status));
     goto Exit;


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change added the input argument of page table when walking through the page table.

This will allow the SPAM core and supervisor core to walk through page tables at the same address.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This change was tested on QEMU Q35 platform and booted to UEFI shell.

## Integration Instructions

N/A
