### PR TITLE
Port Recent MpService Changes [Rebase & FF]

### DIFF
--- a/MmSupervisorPkg/Core/Services/MpService/MpService.c
+++ b/MmSupervisorPkg/Core/Services/MpService/MpService.c
@@ -1741,11 +1741,13 @@ SmiRendezvous (
             //
             // Platform hook fails to determine, use default BSP election method
             //
-            InterlockedCompareExchange32 (
-              (UINT32 *)&mSmmMpSyncData->BspIndex,
-              MAX_UINT32,
-              (UINT32)CpuIndex
-              );
+            if (mSmmMpSyncData->BspIndex == MAX_UINT32) {
+              InterlockedCompareExchange32 (
+                (UINT32 *)&mSmmMpSyncData->BspIndex,
+                MAX_UINT32,
+                (UINT32)CpuIndex
+                );
+            }
           }
         }
       }

--- a/MmSupervisorPkg/Core/Services/MpService/MpService.c
+++ b/MmSupervisorPkg/Core/Services/MpService/MpService.c
@@ -665,12 +665,12 @@ BSPHandler (
   *mSmmMpSyncData->InsideSmm = FALSE;
   ReleaseAllAPs ();
 
-  //
-  // Wait for all APs to complete their pending tasks
-  //
-  SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
-
   if (SmmCpuFeaturesNeedConfigureMtrrs ()) {
+    //
+    // Wait for all APs the readiness to program MTRRs
+    //
+    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
+
     //
     // Signal APs to restore MTRRs
     //
@@ -681,12 +681,12 @@ BSPHandler (
     //
     SmmCpuFeaturesReenableSmrr ();
     MtrrSetAllMtrrs (&Mtrrs);
-
-    //
-    // Wait for all APs to complete MTRR programming
-    //
-    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
   }
+
+  //
+  // Wait for all APs to complete their pending tasks including MTRR programming if needed.
+  //
+  SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
 
   //
   // Stop source level debug in BSP handler, the code below will not be

--- a/MmSupervisorPkg/Core/Services/MpService/MpService.c
+++ b/MmSupervisorPkg/Core/Services/MpService/MpService.c
@@ -689,15 +689,15 @@ BSPHandler (
   SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
 
   //
+  // Signal APs to Reset states/semaphore for this processor
+  //
+  ReleaseAllAPs ();
+
+  //
   // Stop source level debug in BSP handler, the code below will not be
   // debugged.
   //
   InitializeDebugAgent (DEBUG_AGENT_INIT_EXIT_SMI, NULL, NULL);
-
-  //
-  // Signal APs to Reset states/semaphore for this processor
-  //
-  ReleaseAllAPs ();
 
   //
   // Perform pending operations for hot-plug

--- a/MmSupervisorPkg/Core/Services/MpService/MpService.c
+++ b/MmSupervisorPkg/Core/Services/MpService/MpService.c
@@ -1950,6 +1950,16 @@ InitializeMpSyncData (
       // Enable BSP election by setting BspIndex to -1
       //
       mSmmMpSyncData->BspIndex = (UINT32)-1;
+    } else {
+      //
+      // Use NonSMM BSP as SMM BSP
+      //
+      for (CpuIndex = 0; CpuIndex < gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus; CpuIndex++) {
+        if (GetApicId () == gSmmCpuPrivate->ProcessorInfo[CpuIndex].ProcessorId) {
+          mSmmMpSyncData->BspIndex = (UINT32)CpuIndex;
+          break;
+        }
+      }
     }
 
     mSmmMpSyncData->EffectiveSyncMode = mCpuSmmSyncMode;

--- a/MmSupervisorPkg/Core/Services/MpService/MpService.c
+++ b/MmSupervisorPkg/Core/Services/MpService/MpService.c
@@ -683,15 +683,17 @@ BSPHandler (
     MtrrSetAllMtrrs (&Mtrrs);
   }
 
-  //
-  // Wait for all APs to complete their pending tasks including MTRR programming if needed.
-  //
-  SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
+  if (SmmCpuFeaturesNeedConfigureMtrrs ()) {
+    //
+    // Wait for all APs to complete their pending tasks including MTRR programming if needed.
+    //
+    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
 
-  //
-  // Signal APs to Reset states/semaphore for this processor
-  //
-  ReleaseAllAPs ();
+    //
+    // Signal APs to Reset states/semaphore for this processor
+    //
+    ReleaseAllAPs ();
+  }
 
   //
   // Stop source level debug in BSP handler, the code below will not be
@@ -939,15 +941,17 @@ APHandler (
     MtrrSetAllMtrrs (&Mtrrs);
   }
 
-  //
-  // Notify BSP the readiness of this AP to Reset states/semaphore for this processor
-  //
-  SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+  if (SmmCpuFeaturesNeedConfigureMtrrs ()) {
+    //
+    // Notify BSP the readiness of this AP to Reset states/semaphore for this processor
+    //
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 
-  //
-  // Wait for the signal from BSP to Reset states/semaphore for this processor
-  //
-  SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    //
+    // Wait for the signal from BSP to Reset states/semaphore for this processor
+    //
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+  }
 
   //
   // Reset states/semaphore for this processor

--- a/MmSupervisorPkg/Core/Services/MpService/MpService.c
+++ b/MmSupervisorPkg/Core/Services/MpService/MpService.c
@@ -732,10 +732,10 @@ BSPHandler (
   ResetTokens ();
 
   //
-  // Reset BspIndex to -1, meaning BSP has not been elected.
+  // Reset BspIndex to MAX_UINT32, meaning BSP has not been elected.
   //
   if (FeaturePcdGet (PcdCpuSmmEnableBspElection)) {
-    mSmmMpSyncData->BspIndex = (UINT32)-1;
+    mSmmMpSyncData->BspIndex = MAX_UINT32;
   }
 
   //
@@ -783,7 +783,7 @@ APHandler (
     //
     // BSP timeout in the first round
     //
-    if (mSmmMpSyncData->BspIndex != -1) {
+    if (mSmmMpSyncData->BspIndex != MAX_UINT32) {
       //
       // BSP Index is known
       // Existing AP is in SMI now but BSP not in, so, try bring BSP in SMM.
@@ -1743,7 +1743,7 @@ SmiRendezvous (
             //
             InterlockedCompareExchange32 (
               (UINT32 *)&mSmmMpSyncData->BspIndex,
-              (UINT32)-1,
+              MAX_UINT32,
               (UINT32)CpuIndex
               );
           }
@@ -1951,9 +1951,9 @@ InitializeMpSyncData (
     mSmmMpSyncData->CandidateBsp = (BOOLEAN *)(mSmmMpSyncData->CpuData + gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus);
     if (FeaturePcdGet (PcdCpuSmmEnableBspElection)) {
       //
-      // Enable BSP election by setting BspIndex to -1
+      // Enable BSP election by setting BspIndex to MAX_UINT32
       //
-      mSmmMpSyncData->BspIndex = (UINT32)-1;
+      mSmmMpSyncData->BspIndex = MAX_UINT32;
     } else {
       //
       // Use NonSMM BSP as SMM BSP


### PR DESCRIPTION
## Description

Primarily made to pull in this change [`UefiCpuPkg/PiSmmCpuDxeSmm: Use NonSmm BSP as default SMM BSP.`](https://github.com/tianocore/edk2/commit/68d506e0d15c0c412142be68ed006c65b641560f).

Also includes other optimizations to keep the file in sync with edk2. The history of the recent changes in the file in this repo vs edk2 are shown for reference.

| Commit URL                                                                                             | Title                                             | Notes                                                                            |
|--------------------------------------------------------------------------------------------------------|----------------------------------------------------|-----------------------------------------------------------------------------------------------|
| [2ca8d55974...](https://github.com/tianocore/edk2/commit/2ca8d559744319025592df10ada0f714fc3b8e15) | [UefiCpuPkg/PiSmmCpuDxeSmm: Check BspIndex first before lock cmpxchg](https://github.com/tianocore/edk2/commit/2ca8d559744319025592df10ada0f714fc3b8e15)                                           | **New incoming change**                                                                                              |
| [d698bcfe4f...](https://github.com/tianocore/edk2/commit/d698bcfe4f3da50418561eaf8d6163136c714f01) | [UefiCpuPkg/PiSmmCpuDxeSmm: Avoid BspIndex typecasting](https://github.com/tianocore/edk2/commit/d698bcfe4f3da50418561eaf8d6163136c714f01)                                           | **New incoming change**                                                                                              |
| [58d9463939...](https://github.com/tianocore/edk2/commit/58d94639390803e375a7d16c94a5a527ec158474) | [UefiCpuPkg/PiSmmCpuDxeSmm: Reduce one round BSP & AP sync](https://github.com/tianocore/edk2/commit/58d94639390803e375a7d16c94a5a527ec158474)                                                   | **New incoming change**                                                                                              |
| [41d1c4475b...](https://github.com/tianocore/edk2/commit/41d1c4475b91760982c48403047adeb0a3cb1141) | [UefiCpuPkg/PiSmmCpuDxeSmm: Invert ReleaseAllAPs & InitializeDebugAgent](https://github.com/tianocore/edk2/commit/41d1c4475b91760982c48403047adeb0a3cb1141)                                           | **New incoming change**                                                                                       |
| [3a4ec6de01...](https://github.com/tianocore/edk2/commit/3a4ec6de01209a0310a6e4c63d6941e7a592a457) | [UefiCpuPkg/PiSmmCpuDxeSmm: Align BSP and AP sync logic for SMI exit](https://github.com/tianocore/edk2/commit/3a4ec6de01209a0310a6e4c63d6941e7a592a457)                                           | **New incoming change**                                                                                       |
| [e1b62f3e28...](https://github.com/tianocore/edk2/commit/e1b62f3e28a95847c6ab23ae3a07a640d7e300cf) | [UefiCpuPkg/PiSmmCpuDxeSmm: Check SMM Debug Agent support or not](https://github.com/tianocore/edk2/commit/e1b62f3e28a95847c6ab23ae3a07a640d7e300cf)                                               | Skipped since it touches other files and is unrelated.                                                                            |
| [a83d953dc2...](https://github.com/tianocore/edk2/commit/a83d953dc2741f650cc273f39fe803ae406b0fad) | [UefiCpuPkg/PiSmmCpuDxeSmm: Consume SmmCpuSyncLib](https://github.com/tianocore/edk2/commit/a83d953dc2741f650cc273f39fe803ae406b0fad) | Cherry-picked to basecore. Included in StandaloneMmCpuSyncLib PR ([#257](https://github.com/microsoft/mu_feature_mm_supv/pull/257)).                                                                                              |
| [cc698d0335...](https://github.com/tianocore/edk2/commit/cc698d033504210303ee1df94fab0d18b65e10a0) | [UefiCpuPkg/PiSmmCpuDxeSmm: Simplify RunningApCount decrement](https://github.com/tianocore/edk2/commit/cc698d033504210303ee1df94fab0d18b65e10a0) | Cherry-picked to basecore.  Included in StandaloneMmCpuSyncLib PR ([#257](https://github.com/microsoft/mu_feature_mm_supv/pull/257)).                                                                                               |
| [e14a022246...](https://github.com/tianocore/edk2/commit/e14a022246f056847108e9e7882366fee4fece91) | [UefiCpuPkg/PiSmmCpuDxeSmm: Optimize Semaphore Sync between BSP and AP](https://github.com/tianocore/edk2/commit/e14a022246f056847108e9e7882366fee4fece91) | Included in StandaloneMmCpuSyncLib PR ([#257](https://github.com/microsoft/mu_feature_mm_supv/pull/257))                                                                                              |
| [68d506e0d1...](https://github.com/tianocore/edk2/commit/68d506e0d15c0c412142be68ed006c65b641560f) | [UefiCpuPkg/PiSmmCpuDxeSmm: Use NonSmm BSP as default SMM BSP.](https://github.com/tianocore/edk2/commit/68d506e0d15c0c412142be68ed006c65b641560f)    | **New incoming change**                                                                                               |
| [b4dde1ae6a...](https://github.com/tianocore/edk2/commit/b4dde1ae6a8a573c84a70d197a4a341f7d5bfb3d) | [UefiCpuPkg: Use GenSmmPageTable() to create Smm S3 page table](https://github.com/tianocore/edk2/commit/b4dde1ae6a8a573c84a70d197a4a341f7d5bfb3d)                           | Last commit in the 202311 update.                                                                                              |

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- MmSupervisorPkg build.
- Intel physical platform build and boot to Windows OS.
- QemuQ35Pkg build and boot to Windows OS.

## Integration Instructions

- N/A