### PR TITLE
Various fixes caught by CLANG

### DIFF
--- a/MmSupervisorPkg/Core/Dispatcher/Dispatcher.c
+++ b/MmSupervisorPkg/Core/Dispatcher/Dispatcher.c
@@ -867,7 +867,7 @@ FvIsBeingProcessed (
 {
   KNOWN_FWVOL  *KnownFwVol;
   EFI_GUID     FvNameGuid;
-  BOOLEAN      FvNameGuidIsFound;
+  BOOLEAN      FvNameGuidIsFound = FALSE;
   LIST_ENTRY   *Link;
 
   DEBUG ((DEBUG_INFO, "FvIsBeingProcessed - 0x%08x\n", FwVolHeader));

--- a/MmSupervisorPkg/Core/Request/UnblockMemory.c
+++ b/MmSupervisorPkg/Core/Request/UnblockMemory.c
@@ -123,7 +123,7 @@ CollectUnblockedRegionsFromNthNode (
     if (Index >= StartIndex) {
       // This is in our target
       UnblockedListEntry = BASE_CR (Node, UNBLOCKED_MEM_LIST, Link);
-      UnblockedMemEntry  = UnblockedListEntry->UnblockMemData;
+      CopyMem (&UnblockedMemEntry, &UnblockedListEntry->UnblockMemData, sizeof (MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS));
       CopyMem (&Buffer[Index - StartIndex], &UnblockedMemEntry, sizeof (UnblockedMemEntry));
     }
 
@@ -171,7 +171,7 @@ VerifyUnblockRequest (
   Node = mUnblockedMemoryList.ForwardLink;
   while (Node != &mUnblockedMemoryList) {
     UnblockedListEntry    = BASE_CR (Node, UNBLOCKED_MEM_LIST, Link);
-    UnblockedMemEntry     = UnblockedListEntry->UnblockMemData;
+    CopyMem (&UnblockedMemEntry, &UnblockedListEntry->UnblockMemData, sizeof (MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS));
     UnblockedStartAddress = UnblockedMemEntry.MemoryDescriptor.PhysicalStart;
     UnblockedEndAddress   = UnblockedStartAddress +
                             EFI_PAGES_TO_SIZE (UnblockedMemEntry.MemoryDescriptor.NumberOfPages);


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change will cover a few more CLANG fixes, including uninitialized variables and unintentionally pulled in compiler intrinsics.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU Q35.

## Integration Instructions

N/A
