### PR TITLE
Fixing override break due to PiSmmCpuDxeSmm updates.

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -11,7 +11,7 @@
 ##
 
 #Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | c76826a5d7096269b15df7c68bf217dd | 2024-01-31T14-26-14 | 75cc3bfa5fecce1f750cbecc2da58c09519a3323
-#Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | b69b124897133b7394ab703495c54e1e | 2024-06-06T18-20-35 | 8acf1781381d93e067b05d07bab5d288f6129c5a
+#Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 58361677d643e473bbe08e3e7d7b66c4 | 2024-06-22T03-33-39 | e6d01390794aa0505d0659bc484f4d2fdba1e5d4
 #Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 0f126959ecf2d99db4940bb0d0bba0df | 2024-04-12T17-27-10 | d6e01136697c1aed85bb83cff98b74ec11e96e1a
 
 [Defines]


### PR DESCRIPTION
## Description

PiSmmCpuDxeSmm was updated to use Panic library and Panic calls instead of CPU_DEADLOOPs for error conditions.
This changed the generated override validation tag. mu_feature_mm_supv needed updated.

The consumption of PanicLib was not introduced at this time. Details can be seen at link below:
 
https://github.com/microsoft/mu_basecore/commit/bbbff00dc39a67dc1e44aa0ce392d460b12f66b9

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Local CI, and a mu_tiano_platforms build with newer version. 

## Integration Instructions

N/A