### PR TITLE
Changed AllocatePageTableMemory to include a new variable

### DIFF
--- a/MmSupervisorPkg/Core/Mem/Mem.h
+++ b/MmSupervisorPkg/Core/Mem/Mem.h
@@ -481,7 +481,7 @@ SmmGetMemoryAttributes (
 VOID *
 AllocatePageTableMemory (
   IN UINTN     Pages,
-  OUT BOOLEAN  *NewAllocation
+  OUT BOOLEAN  *NewAllocation OPTIONAL
   );
 
 /**

--- a/MmSupervisorPkg/Core/Mem/Mem.h
+++ b/MmSupervisorPkg/Core/Mem/Mem.h
@@ -472,13 +472,16 @@ SmmGetMemoryAttributes (
   returned.
 
   @param  Pages                 The number of 4 KB pages to allocate.
+  @param  NewAllocation         Pointer to a passed in BOOLEAN that will be TRUE if new pages have been allocated
+                                for the page pool and FALSE otherwise.
 
   @return A pointer to the allocated buffer or NULL if allocation fails.
 
 **/
 VOID *
 AllocatePageTableMemory (
-  IN UINTN  Pages
+  IN UINTN     Pages,
+  OUT BOOLEAN  *NewAllocation
   );
 
 /**

--- a/MmSupervisorPkg/Core/Mem/PageTbl.c
+++ b/MmSupervisorPkg/Core/Mem/PageTbl.c
@@ -298,7 +298,7 @@ SmmInitPageTable (
     //
     // Add pages to page pool
     //
-    FreePage = (LIST_ENTRY *)AllocatePageTableMemory (PAGE_TABLE_PAGES);
+    FreePage = (LIST_ENTRY *)AllocatePageTableMemory (PAGE_TABLE_PAGES, NULL);
     if (FreePage == NULL) {
       DEBUG ((DEBUG_ERROR, "%a Failed to allocate page for FreePage!!!\n", __FUNCTION__));
       Status = EFI_OUT_OF_RESOURCES;

--- a/MmSupervisorPkg/Core/Mem/PageTbl.c
+++ b/MmSupervisorPkg/Core/Mem/PageTbl.c
@@ -238,10 +238,6 @@ SmmInitPageTable (
   UINT64                    *Pml5Entry;
   UINT8                     PhysicalAddressBits;
 
-  BOOLEAN  SamePageTable;
-
-  SamePageTable = TRUE;
-
   //
   // Initialize spin lock
   //
@@ -302,7 +298,7 @@ SmmInitPageTable (
     //
     // Add pages to page pool
     //
-    FreePage = (LIST_ENTRY *)AllocatePageTableMemory (PAGE_TABLE_PAGES, &SamePageTable);
+    FreePage = (LIST_ENTRY *)AllocatePageTableMemory (PAGE_TABLE_PAGES);
     if (FreePage == NULL) {
       DEBUG ((DEBUG_ERROR, "%a Failed to allocate page for FreePage!!!\n", __FUNCTION__));
       Status = EFI_OUT_OF_RESOURCES;

--- a/MmSupervisorPkg/Core/Mem/PageTbl.c
+++ b/MmSupervisorPkg/Core/Mem/PageTbl.c
@@ -238,6 +238,10 @@ SmmInitPageTable (
   UINT64                    *Pml5Entry;
   UINT8                     PhysicalAddressBits;
 
+  BOOLEAN  SamePageTable;
+
+  SamePageTable = TRUE;
+
   //
   // Initialize spin lock
   //
@@ -298,7 +302,7 @@ SmmInitPageTable (
     //
     // Add pages to page pool
     //
-    FreePage = (LIST_ENTRY *)AllocatePageTableMemory (PAGE_TABLE_PAGES);
+    FreePage = (LIST_ENTRY *)AllocatePageTableMemory (PAGE_TABLE_PAGES, &SamePageTable);
     if (FreePage == NULL) {
       DEBUG ((DEBUG_ERROR, "%a Failed to allocate page for FreePage!!!\n", __FUNCTION__));
       Status = EFI_OUT_OF_RESOURCES;

--- a/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
+++ b/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
@@ -244,10 +244,15 @@ AllocatePageTableMemory (
 {
   VOID  *Buffer;
 
-  *NewAllocation = TRUE;
+  if (NewAllocation != NULL) {
+    *NewAllocation = TRUE;
+  }
 
   if (Pages == 0) {
-    *NewAllocation = FALSE;
+    if (NewAllocation != NULL) {
+      *NewAllocation = FALSE;
+    }
+
     return NULL;
   }
 
@@ -257,7 +262,10 @@ AllocatePageTableMemory (
   if ((mPageTablePool == NULL) ||
       (Pages > mPageTablePool->FreePages))
   {
-    *NewAllocation = FALSE;
+    if (NewAllocation != NULL) {
+      *NewAllocation = FALSE;
+    }
+
     if (!InitializePageTablePool (Pages)) {
       return NULL;
     }

--- a/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
+++ b/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
@@ -589,7 +589,11 @@ ConvertMemoryPageAttributes (
 
     if (Status == RETURN_BUFFER_TOO_SMALL) {
       PageTableBuffer = AllocatePageTableMemory (EFI_SIZE_TO_PAGES (PageTableBufferSize), &UpdatedPageTable);
-      ASSERT (PageTableBuffer != NULL);
+      if (PageTableBuffer == NULL) {
+        DEBUG ((DEBUG_ERROR, "Failed to allocate page table memory for the page pool!\n"));
+        ASSERT (PageTableBuffer != NULL);
+        break; // We failed to allocate more memory so exit the loop and don't call into PageTableMap again
+      }
       if (UpdatedPageTable) {
         // Need to check the PageTableMap again with the newly allocated pages
         continue;
@@ -597,7 +601,7 @@ ConvertMemoryPageAttributes (
 
       Status = PageTableMap (&PageTableBase, PagingMode, PageTableBuffer, &PageTableBufferSize, BaseAddress, Length, &PagingAttribute, &PagingAttrMask, IsModified);
     } else {
-      break; // In the off chance we don't return buffer to small we need to exit the loop or be stuck
+      break; // In the off chance we don't return BUFFER_TOO_SMALL we need to exit the loop or be stuck
     }
   }
 

--- a/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
+++ b/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
@@ -859,7 +859,7 @@ GenSmmPageTable (
   Status = PageTableMap (&PageTable, PagingMode, NULL, &PageTableBufferSize, 0, Length, &MapAttribute, &MapMask, NULL);
   ASSERT (Status == RETURN_BUFFER_TOO_SMALL);
   DEBUG ((DEBUG_INFO, "GenSMMPageTable: 0x%x bytes needed for initial SMM page table\n", PageTableBufferSize));
-  PageTableBuffer = AllocatePageTableMemory (EFI_SIZE_TO_PAGES (PageTableBufferSize));
+  PageTableBuffer = AllocatePageTableMemory (EFI_SIZE_TO_PAGES (PageTableBufferSize), NULL);
   ASSERT (PageTableBuffer != NULL);
   Status = PageTableMap (&PageTable, PagingMode, PageTableBuffer, &PageTableBufferSize, 0, Length, &MapAttribute, &MapMask, NULL);
   ASSERT (Status == RETURN_SUCCESS);

--- a/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
+++ b/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
@@ -594,6 +594,7 @@ ConvertMemoryPageAttributes (
         ASSERT (PageTableBuffer != NULL);
         break; // We failed to allocate more memory so exit the loop and don't call into PageTableMap again
       }
+
       if (UpdatedPageTable) {
         // Need to check the PageTableMap again with the newly allocated pages
         continue;


### PR DESCRIPTION
## Description

Updated AllocatePageTableMemory to include a new input variable *NewAllocation.  This variable is used to keep track of if new pages were allocated for use in the page table page pool.  This fixes a bug where if we run out of page table pool pages while changing some pages memory attributes we'll recursively call into ConvertMemoryPageAttributes while allocating pages leading to unaccounted for pages in the original call.  This leads to an assert by the ConvertMemoryPageAttributes code.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on two separate physical platforms that experienced the issue in different circumstances.  This fix tested on those reproing platforms have the issue resolved and no longer saw any asserts.

## Integration Instructions

N/A