### PR TITLE
Fix init step for SEA core

### DIFF
--- a/SeaPkg/Core/Init/x64/AsmStmInit.asm
+++ b/SeaPkg/Core/Init/x64/AsmStmInit.asm
@@ -27,7 +27,7 @@ STM_STACK_SIZE                EQU 08000h
 
 ;------------------------------------------------------------------------------
 ; VOID
-; AsmSeaVmcallDispatcher  (
+; AsmSeaVmcallDispatcher (
 ;   VOID
 ;   )
 _ModuleEntryPoint PROC PUBLIC
@@ -75,9 +75,9 @@ GoGetCapabilities:
   jmp  DeadLoop
 
 GoGetResources:
-  ;
-  ; assign unique ESP for each processor
-  ;
+;
+; assign unique ESP for each processor
+;
 ; |------------|<-ESP (PerProc)
 ; | Reg        |
 ; |------------|

--- a/SeaPkg/Core/Init/x64/AsmStmInit.asm
+++ b/SeaPkg/Core/Init/x64/AsmStmInit.asm
@@ -27,10 +27,54 @@ STM_STACK_SIZE                EQU 08000h
 
 ;------------------------------------------------------------------------------
 ; VOID
-; AsmSeaVmcallDispatcher (
+; AsmSeaVmcallDispatcher  (
 ;   VOID
 ;   )
 _ModuleEntryPoint PROC PUBLIC
+  cmp eax, SEA_API_GET_CAPABILITIES ; for get capabilities
+  jz  GoGetCapabilities
+  cmp eax, SEA_API_GET_RESOURCES ; for get resources
+  jz  GoGetResources
+  jmp DeadLoop
+
+GoGetCapabilities:
+  ; Assume ThisOffset is 0
+  ; ESP is pointer to stack bottom, NOT top
+  mov  eax, STM_STACK_SIZE     ; eax = STM_STACK_SIZE, 
+  lock xadd [esp], eax         ; eax = ThisOffset, ThisOffset += STM_STACK_SIZE (LOCK instruction)
+  add  eax, STM_STACK_SIZE     ; eax = ThisOffset + STM_STACK_SIZE
+  add  esp, eax                ; esp += ThisOffset + STM_STACK_SIZE
+
+  ;
+  ; Jump to C code
+  ;
+  sub rsp, 512
+  fxsave  [rsp]
+  push r15
+  push r14
+  push r13
+  push r12
+  push r11
+  push r10
+  push r9
+  push r8
+  push rdi
+  push rsi
+  push rbp
+  push rbp ; should be rsp
+  push rbx
+  push rdx
+  push rcx
+  mov  eax, SEA_API_GET_CAPABILITIES
+  push rax
+  mov  rcx, rsp ; parameter
+  sub  rsp, 20h
+  call SeaVmcallDispatcher
+  add  rsp, 20h
+  ; should never get here
+  jmp  DeadLoop
+
+GoGetResources:
   ;
   ; assign unique ESP for each processor
   ;


### PR DESCRIPTION
## Description

The original code corrupted the RAX value. This change fixed the issue by using check and jump from the beginning of the code.

For details on how to complete to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Not tested.

## Integration Instructions

N/A
