### PR TITLE
StmInit: Validate SeaVmcallDispatcher() parameter

### DIFF
--- a/SeaPkg/Core/Init/StmInit.c
+++ b/SeaPkg/Core/Init/StmInit.c
@@ -987,6 +987,11 @@ SeaVmcallDispatcher (
   UINT32      ServiceId;
   EFI_STATUS  Status;
 
+  if (Register == NULL) {
+    ASSERT (Register != NULL);
+    return;
+  }
+
   CpuIndex  = GetIndexFromStack (Register);
   ServiceId = ReadUnaligned32 ((UINT32 *)&Register->Rax);
 


### PR DESCRIPTION
## Description

Prevent dereference of the `Register` parameter if the argument is NULL.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Build and boot

## Integration Instructions

- N/A