### PR TITLE
SeaPkg/MsegSmramPei: Produce gMsegIdentifiedPpiGuid

### DIFF
--- a/SeaPkg/Drivers/MsegSmramPei/MsegSmramPei.c
+++ b/SeaPkg/Drivers/MsegSmramPei/MsegSmramPei.c
@@ -25,6 +25,12 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/PcdLib.h>
 
+GLOBAL_REMOVE_IF_UNREFERENCED EFI_PEI_PPI_DESCRIPTOR  mMsegIdentifiedPpiDescriptor = {
+  EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST,
+  &gMsegIdentifiedPpiGuid,
+  NULL
+};
+
 /**
   Retrieves the data structure associated with the GUIDed HOB of type gEfiSmmSmramMemoryGuid
 
@@ -213,6 +219,7 @@ MsegSmramHobEntry (
   //
   Status = SplitSmramReserveHob ();
   if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
     return Status;
   }
 
@@ -220,6 +227,10 @@ MsegSmramHobEntry (
   // Create MsegSmram hob.
   //
   Status = CreateMsegSmramHob ();
+  ASSERT_EFI_ERROR (Status);
+
+  Status = PeiServicesInstallPpi (&mMsegIdentifiedPpiDescriptor);
+  ASSERT_EFI_ERROR (Status);
 
   return Status;
 }

--- a/SeaPkg/Drivers/MsegSmramPei/MsegSmramPei.inf
+++ b/SeaPkg/Drivers/MsegSmramPei/MsegSmramPei.inf
@@ -32,6 +32,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   StandaloneMmPkg/StandaloneMmPkg.dec
+  SeaPkg/SeaPkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
 
 [LibraryClasses]
@@ -49,6 +50,9 @@
 [Guids]
   gEfiSmmSmramMemoryGuid             ## CONSUMES ## HOB
   gMsegSmramGuid                     ## PRODUCES ## HOB
+
+[Ppis]
+  gMsegIdentifiedPpiGuid             ## PRODUCES
 
 [Depex]
   gEfiPeiMemoryDiscoveredPpiGuid

--- a/SeaPkg/SeaPkg.dec
+++ b/SeaPkg/SeaPkg.dec
@@ -50,3 +50,9 @@
 
   # The SHA256 hash of the MM supervisor core EFI binary file
   gEfiSeaPkgTokenSpaceGuid.PcdMmSupervisorCoreHash|{0x0}|VOID*|0x00000004
+
+[Ppis]
+  ## MSEG Identified PPI
+  #
+  #  {883d59ac-13ee-4bb7-aace-ddd8a1e03982}
+  gMsegIdentifiedPpiGuid = {0x883d59ac, 0x13ee, 0x4bb7, {0xaa, 0xce, 0xdd, 0xd8, 0xa1, 0xe0, 0x39, 0x82}}


### PR DESCRIPTION
## Description

Produces a PPI that acts a signal to other code that MSEG has been configured. Platform code can optionally choose to act on the signal, for example, producing the MM Access PPI when MSEG has been identified.

Note: The PPI is produced unconditionally after MSEG identification has been attempted.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verified PPI is produced as expected

## Integration Instructions

Use the PPI in a notification or DEPEX if helpful.