### PR TITLE
Fixing MmRanges would pull in extra data from the next hob

### DIFF
--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.c
@@ -1090,13 +1090,15 @@ GetFullMmramRanges (
     return NULL;
   }
 
+  // Need an empty entry for SMM core
   MmramRangeCount += 1;
   FullMmramRanges  = (EFI_MMRAM_DESCRIPTOR *)AllocateZeroPool (MmramRangeCount * sizeof (EFI_MMRAM_DESCRIPTOR));
   if (FullMmramRanges == NULL) {
     return NULL;
   }
 
-  CopyMem (FullMmramRanges, MmramRanges, MmramRangeCount * sizeof (EFI_MMRAM_DESCRIPTOR));
+  // Be mindful on not copying junk from the next hob into our region...
+  CopyMem (FullMmramRanges, MmramRanges, (MmramRangeCount - 1) * sizeof (EFI_MMRAM_DESCRIPTOR));
   *FullMmramRangeCount = MmramRangeCount;
 
   return FullMmramRanges;


### PR DESCRIPTION
## Description

Currently the MmRanges reported through initialization steps will be manipulated by the IPL code to extend the last entry to be an empty placeholder so that it will be populated during the `ExecuteMmCoreFromMmram` routine.

However, the preemptively extended range will pull in extra data from the next hob, which could cause the rest of supervisor initialization to fault. This change fixed such issue by not overly copying data from hob.

For details on how to complete to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on both QEMU Q35 and proprietary hardware platforms.

## Integration Instructions

N/A
