### PR TITLE
SeaPkg/StmInit: Fix cast type

### DIFF
--- a/SeaPkg/Core/Init/StmInit.c
+++ b/SeaPkg/Core/Init/StmInit.c
@@ -1084,7 +1084,7 @@ GetResources (
              PcdGet64 (PcdMmiEntryBinSize),
              DigestList,
              SUPPORTED_DIGEST_COUNT,
-             (VOID *)&PolicyBuffer
+             (VOID **)&PolicyBuffer
              );
 
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
## Description

Should be `VOID **`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Compilation and boot

## Integration Instructions

- N/A