### PR TITLE
SeaPkg/BasePeCoffNegativeLib: Use track tags

### DIFF
--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf
@@ -20,6 +20,10 @@
 #
 #
 ##
+# Non-Secure
+#Track : 00000002 | MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf | 401f7e82e499c011b2ebef8e30db4949 | 2024-09-18T21-52-54 | 22bec4019f02a51bd2bd57e50cfb0f5beebb6aa3
+# Secure
+#Track : 00000002 | MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf | 94e1d8f671f627907c809381328cbf8b | 2024-09-18T21-52-00 | dfa4f5831084ae1e52864074683d73606e4cdd1f
 
 [Defines]
   INF_VERSION                    = 0x00010005
@@ -28,8 +32,6 @@
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = PeCoffLibNegative
-
-#Override : 00000002 | MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf | 401f7e82e499c011b2ebef8e30db4949 | 2024-02-28T21-39-40 | a880ead29bce709ecba1c047604ebffc16ff3e07
 
 #
 #  VALID_ARCHITECTURES           = IA32 X64 EBC ARM AARCH64


### PR DESCRIPTION
## Description

Use track tags to BasePeCoffLib to support different versions of the library instance.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI build

## Integration Instructions

- N/A