### PR TITLE
gen_rim: Multiple updates per CBOR rfc's

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_rim/src/lib.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_rim/src/lib.rs
@@ -516,7 +516,6 @@ pub struct CoseAlgorithmPayload {
 
 #[derive(Encode, Decode)]
 #[cbor(map)]
-#[cbor(tag(16))]
 /// A File Measurement payload
 pub struct FileMeasurement {
     #[n(23)]

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_rim/src/lib.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_rim/src/lib.rs
@@ -144,11 +144,13 @@ pub struct SignProtected;
 
 /// protected-signed-coswid-header
 /// https://www.rfc-editor.org/rfc/rfc9393.html#name-signed-coswid-tags
+/// Use the following for the algorithm_identifier:
+/// https://www.iana.org/assignments/named-information/named-information.xhtml
 #[derive(Encode, Decode)]
 #[cbor(map)]
 pub struct ProtectedHeader {
     #[n(1)]
-    /// The algorithm used to sign the payload - 18556 + Algorithm Identifier
+    /// The algorithm used to sign the payload
     pub algorithm_identifier: i16,
     /// Should always be "application/swid+cbor"
     #[n(3)]
@@ -501,6 +503,8 @@ pub struct CoseMac0 {}
 #[cbor(array)]
 /// A COSE Algorithm payload
 /// https://www.rfc-editor.org/rfc/rfc9393.html#section-2.9.1
+/// algorithm ID should be from:
+/// https://www.iana.org/assignments/named-information/named-information.xhtml
 pub struct CoseAlgorithmPayload {
     #[n(0)]
     /// The algorithm identifier.
@@ -524,7 +528,7 @@ pub struct FileMeasurement {
     #[n(20)]
     /// The size of the file in bytes.
     size: u64,
-    #[n(18556)]
+    #[n(7)]
     /// The algorithm and digest of the file.
     alg: CoseAlgorithmPayload,
 }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_rim/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_rim/src/main.rs
@@ -179,10 +179,11 @@ fn generate_signing(args: SigningArgs) -> Result<()> {
 }
 
 fn generate_measurements(file: &PathBuf) -> Result<Vec<FileMeasurement>> {
-    const SHA256_ID: i16 = 18556 + 5; // Standard
-    const SHA384_ID: i16 = 18556 + 6; // Standard
-    const SHA512_ID: i16 = 18556 + 7; // Standard
-    const SM3_ID: i16 = 18556 + 30; // Not Standard
+    // https://www.iana.org/assignments/named-information/named-information.xhtml
+    const SHA256_ID: i16 = 1; // Standard
+    const SHA384_ID: i16 = 7; // Standard
+    const SHA512_ID: i16 = 8; // Standard
+    const SM3_ID: i16 = 30; // Not Standard
 
     if !file.exists() {
         return Err(anyhow!("Path does not exist: {:?}", file));


### PR DESCRIPTION
## Description

Has the following updates to match the expected CBOR RIM format per multiple RFCs regarding CBOR.

1. Wraps The Protected header and payload in a byte string. What this means is that the protected header and payload are first cbor encoded into their respective final byte strings, then those byte strings are then further cbor encoded into the final byte string. This makes for an extra wrapper around the protected header and payload (The extra wrapper being a bytestring wrapper).

2. Converts the Signature to a byte string.

3. Converts the STM_BIN_GUID to a byte string.

4. Convert the digest values to a byte string

5. Convert the ConciseSwidTag payload to a map containing a single entry, 17, which is a list of the file measurements

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Confirmed std parsing of the generated RIM works as expected

## Integration Instructions

N/A
