### PR TITLE
Revert "SeaPkg/SeaResponderReport: Temporarily disable VerifyAndHashImage()"

### DIFF
--- a/SeaPkg/Core/Runtime/SeaResponderReport.c
+++ b/SeaPkg/Core/Runtime/SeaResponderReport.c
@@ -563,31 +563,29 @@ SeaResponderReport (
   }
 
   // Step 3.2: Hash MM Core code
-  // [TODO - BEGIN] - Temporarily disable VerifyAndHashImage()
-  // Status = VerifyAndHashImage (
-  //            MmSupervisorBase,
-  //            MmSupervisorImageSize,
-  //            AuxFileBase,
-  //            AuxFileSize,
-  //            SupvPageTableBase,
-  //            &DigestList
-  //            );
-  // if (EFI_ERROR (Status)) {
-  //   DEBUG ((DEBUG_ERROR, "%a Failed to VerifyAndHashImage %r!!!.\n", __func__, Status));
-  //   goto Exit;
-  // }
+  Status = VerifyAndHashImage (
+             MmSupervisorBase,
+             MmSupervisorImageSize,
+             AuxFileBase,
+             AuxFileSize,
+             SupvPageTableBase,
+             &DigestList
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Failed to VerifyAndHashImage %r!!!.\n", __func__, Status));
+    goto Exit;
+  }
 
-  // if (!CompareDigest (&GoldDigestList[MM_SUPV_DIGEST_INDEX], &DigestList, TPM_ALG_SHA256)) {
-  //   DEBUG ((DEBUG_ERROR, "%a Hash of MM core does not match expectation! Calculated:\n", __func__));
-  //   DUMP_HEX (DEBUG_ERROR, 0, &DigestList, sizeof (TPML_DIGEST_VALUES), "    ");
-  //   Status = EFI_SECURITY_VIOLATION;
-  //   goto Exit;
-  // }
+  if (!CompareDigest (&GoldDigestList[MM_SUPV_DIGEST_INDEX], &DigestList, TPM_ALG_SHA256)) {
+    DEBUG ((DEBUG_ERROR, "%a Hash of MM core does not match expectation! Calculated:\n", __func__));
+    DUMP_HEX (DEBUG_ERROR, 0, &DigestList, sizeof (TPML_DIGEST_VALUES), "    ");
+    Status = EFI_SECURITY_VIOLATION;
+    goto Exit;
+  }
 
-  // if (GoldDigestList != NULL) {
-  //   CopyMem (GoldDigestList + 1, &DigestList, sizeof (DigestList));
-  // }
-  // [TODO - END] - Temporarily disable VerifyAndHashImage()
+  if (GoldDigestList != NULL) {
+    CopyMem (GoldDigestList + 1, &DigestList, sizeof (DigestList));
+  }
 
   FirmwarePolicy = (SMM_SUPV_SECURE_POLICY_DATA_V1_0 *)(UINTN)FirmwarePolicyBase;
 

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -764,6 +764,7 @@ Done:
   @return EFI_SUCCESS               The PE/COFF image was reverted.
   @return EFI_INVALID_PARAMETER     The parameter is invalid.
   @return EFI_COMPROMISED_DATA      The PE/COFF image is compromised.
+  @return EFI_BAD_BUFFER_SIZE       A Memory Attributes entry in the the cfg file is not referencing an address
 **/
 EFI_STATUS
 EFIAPI
@@ -880,6 +881,19 @@ PeCoffImageDiffValidation (
         }
 
         // Inspection of the memory attributes of the target image
+        if (ImageValidationEntryHdr->Size > sizeof (AddrInTarget)) {
+          DEBUG ((
+            DEBUG_ERROR,
+            "%a: A new cfg entry is larger than a memory address!  Only pointers can have their memory attributes validated!  Address: %p, Address size: %x, Entry Size: %x\n",
+            __func__,
+            AddrInTarget,
+            sizeof (AddrInTarget),
+            ImageValidationEntryHdr->Size
+            ));
+          Status = EFI_BAD_BUFFER_SIZE;
+          break;
+        }
+
         AddrInTarget = 0;
         CopyMem (&AddrInTarget, (UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryHdr->Size);
         Status = InspectTargetRangeAttribute (


### PR DESCRIPTION
## Description

This reverts commit 2f41c3a8da0dbc65e0170091ff5fa023bc5ec54b.  The initial issues with the hash verification have been fixed it can now be re-enabled here.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested VerifyAndHashImage on a physical platform.  We're no longer seeing a page fault.

## Integration Instructions

N/A