### PR TITLE
Update override hash on PiSmmCore

### DIFF
--- a/MmSupervisorPkg/Core/Handler/Mmi.c
+++ b/MmSupervisorPkg/Core/Handler/Mmi.c
@@ -157,6 +157,7 @@ MmiManage (
   PERF_FUNCTION_BEGIN ();
 
   mMmiManageCallingDepth++;
+  WillReturn     = FALSE;
   Status         = EFI_NOT_FOUND;
   ReturnStatus   = Status;
   SupervisorPath = FALSE;

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -12,7 +12,7 @@
 
 #Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 22aa8d1b884e477e1e078b485974dc90 | 2024-08-28T16-51-15 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
 #Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 465d5d5aecd11469c7b706462e194f94 | 2024-08-28T16-50-23 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
-#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | b775d90b4549dbd378f23de48a0f3a16 | 2024-08-28T16-42-21 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
+#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | a391d46c2a0b5cf66f61056e2f79ae72 | 2024-10-01T17-01-09 | f2547000cccf6f8d37d730498c8f0b5a91ce8d89
 
 [Defines]
   INF_VERSION                    = 0x0001001A

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
@@ -10,7 +10,7 @@
 
 # This module contains an instance of protocol/handle from StandaloneMmCore and pool memory + guard management from PiSmmCore.
 #Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 22aa8d1b884e477e1e078b485974dc90 | 2024-08-28T16-51-15 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
-#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | b775d90b4549dbd378f23de48a0f3a16 | 2024-08-28T16-42-21 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
+#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | a391d46c2a0b5cf66f61056e2f79ae72 | 2024-10-01T17-01-09 | f2547000cccf6f8d37d730498c8f0b5a91ce8d89
 
 [Defines]
   INF_VERSION                    = 0x0001001A


### PR DESCRIPTION
## Description

Fixing an override hash failure from PiSmmCore

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change was tested on Q35.

## Integration Instructions

N/A
