### PR TITLE
gen_rim: Update uuid encoding byteorder

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_rim/src/lib.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_rim/src/lib.rs
@@ -241,7 +241,7 @@ impl<Payload> ConciseSwidTag<Payload> {
             tag_id: ByteVec::from(
                 uuid::Uuid::from_str(&tag_id.into())
                     .unwrap()
-                    .into_bytes()
+                    .to_bytes_le()
                     .to_vec(),
             ),
             tag_version,


### PR DESCRIPTION
## Description

The previous iteration had the wrong byte order for encoding the UUID into the RIM. This PR reverses the byte order.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified through the C based RIM parser that the uuid is correct.

## Integration Instructions

N/A
