### PR TITLE
gen_aux: Allow validation rules to only apply to certain build targets

### DIFF
--- a/MmSupervisorPkg/Library/BaseLibSysCall/BaseLib.inf
+++ b/MmSupervisorPkg/Library/BaseLibSysCall/BaseLib.inf
@@ -12,7 +12,7 @@
 #
 ##
 
-#Override : 00000002 | MdePkg/Library/BaseLib/BaseLib.inf | 324fec503d64e0ccc1593805857da09d | 2024-04-03T05-45-53 | dcdd08f1f09de204b5c8499a7799981060802399
+#Override : 00000002 | MdePkg/Library/BaseLib/BaseLib.inf | 639eb920db26cd9267d6ddb5385bf055 | 2024-10-07T16-41-27 | 8b26fc44c911a8d130c94e392a8cca36898e77b5
 
 [Defines]
   INF_VERSION                    = 0x00010005

--- a/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
+++ b/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
@@ -241,7 +241,7 @@ def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, targ
     args += f" --efi {str(mm_supervisor_build_dir / 'MmSupervisorCore.efi')}"
     args += f" --output {str(output_path)}"
     args += f" --config {str(aux_config_path)}"
-    args += f" --target {target}"
+    args += f" --target {target.lower()}"
 
     ret = RunCmd("cargo", args)
     if ret != 0:

--- a/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
+++ b/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
@@ -26,7 +26,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
         obj.Register("generate_rim_artifact", GenSeaArtifacts.generate_rim, fp)
 
     @staticmethod
-    def generate_sea_includes(aux_config_path: Path, mm_supervisor_build_dir: Path, sea_build_dir: Path, inc_file_path: Path):
+    def generate_sea_includes(build_target: str, aux_config_path: Path, mm_supervisor_build_dir: Path, sea_build_dir: Path, inc_file_path: Path):
         """Generates SEA artifacts.
 
         Generates the following artifacts:
@@ -34,6 +34,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
         - MmSupervisorCore.efi (As Build by edk2 build system)
 
         Args:
+            build_target: Build Target (DEBUG, RELEASE, NOOPT)
             aux_config_path: Path to the aux gen config file.
             mm_supervisor_build_dir: Path to the MM Supervisor build output.
             sea_build_dir: Path to the Sea Package build output.
@@ -48,7 +49,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
             temp_hash_dir = stm_build_dir / "temp_hash.bin"
             temp_out_dir = stm_build_dir / "temp_out.inc"
 
-            aux_path = generate_aux_file(aux_config_path, mm_supervisor_build_dir, stm_build_dir)
+            aux_path = generate_aux_file(aux_config_path, mm_supervisor_build_dir, build_target, stm_build_dir)
 
             cmd = "BinToPcd.py"
             args = f"-i {aux_path}"
@@ -220,12 +221,13 @@ class GenSeaArtifacts(IUefiHelperPlugin):
 
         return 0
 
-def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, output_dir: Path):
+def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, target: str, output_dir: Path):
     """Generates the auxiliary file for the MmsupervisorCore.
 
     Args:
         aux_config_path: Path to the aux gen config file.
         mm_supervisor_build_dir: Path to the MM Supervisor build output.
+        target: Build Target (DEBUG, RELEASE, NOOPT)
         output_dir: Path to place the artifacts.
 
     Raises:
@@ -239,6 +241,7 @@ def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, outp
     args += f" --efi {str(mm_supervisor_build_dir / 'MmSupervisorCore.efi')}"
     args += f" --output {str(output_path)}"
     args += f" --config {str(aux_config_path)}"
+    args += f" --target {target}"
 
     ret = RunCmd("cargo", args)
     if ret != 0:

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -51,13 +51,14 @@ The rule comes with the following standard options:
 
 ``` toml
 [[rule]]
+target = 'Optional[List[String]]'
 symbol = 'Required[String]'
 field = 'Optional[String]'
 offset = 'Optional[Int]'
 size = 'Optional[Int]'
 validation.type = 'Required[String]'
 ```
-
+- `target`: A list of build targets this rule applies to. Can be `debug`, `release`, or `noopt`. By default, is all three
 - `symbol`: Determines the address and size for the rule
 - `field`: Updates the address and size to be that of the field, rather than the symbol itself.
 - `offset`: Updates the address to `symbol.address + offset`. Offset can be negative. Providing an offset requires that the

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -58,6 +58,7 @@ offset = 'Optional[Int]'
 size = 'Optional[Int]'
 validation.type = 'Required[String]'
 ```
+
 - `target`: A list of build targets this rule applies to. Can be `debug`, `release`, or `noopt`. By default, is all three
 - `symbol`: Determines the address and size for the rule
 - `field`: Updates the address and size to be that of the field, rather than the symbol itself.

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -10,7 +10,7 @@
 use std::{fmt, io::Write, mem::size_of};
 use pdb::{TypeIndex, TypeInformation};
 use scroll::{self, ctx, Endian, Pread, Pwrite, LE};
-use crate::{Config, ValidationRule, ValidationType, KeySymbol};
+use crate::{validation::ValidationTarget, Config, KeySymbol, ValidationRule, ValidationType};
 
 /// A struct representing a symbol in the PDB file.
 #[derive(Default, Clone)]
@@ -250,7 +250,7 @@ impl AuxBuilder {
     /// config file have entries in the aux file. If `autogen=true` is
     /// specified in the configuration file, a rule (with no validation) will
     /// be generated, so that all symbols are reverted to their original value.
-    pub fn generate(mut self, info: &TypeInformation) -> anyhow::Result<AuxFile> {
+    pub fn generate(mut self, info: &TypeInformation, target: ValidationTarget) -> anyhow::Result<AuxFile> {
         let mut aux = AuxFile::default();
         aux.header.offset_to_first_entry = size_of::<ImageValidationDataHeader>() as u32;
         
@@ -270,7 +270,7 @@ impl AuxBuilder {
 
         if self.auto_generate{
             for symbol in &self.symbols {
-                let rule = self.rules.iter().find(|&entry| &entry.symbol == &symbol.name);
+                let rule = self.rules.iter().find(|&entry| &entry.symbol == &symbol.name && entry.target.contains(&target));
                 if rule.is_none() {
                     self.rules.push(ValidationRule {
                         symbol: symbol.name.clone(),
@@ -278,12 +278,17 @@ impl AuxBuilder {
                         validation: ValidationType::None,
                         offset: None,
                         size: None,
+                        target: ValidationTarget::all(),
                     })
                 }
             }
         }
 
         for rule in self.rules.iter_mut() {
+            if !rule.target.contains(&target) {
+                println!("Rule: {:?} Skipped... Does not apply to target: {:?}", rule, target);
+                continue;
+            }
             let symbol = self.symbols
                 .iter()
                 .find(|&entry| &entry.name == &rule.symbol)

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -10,7 +10,7 @@
 use std::{fmt, io::Write, mem::size_of};
 use pdb::{TypeIndex, TypeInformation};
 use scroll::{self, ctx, Endian, Pread, Pwrite, LE};
-use crate::{validation::ValidationTarget, Config, KeySymbol, ValidationRule, ValidationType};
+use crate::{Config, KeySymbol, ValidationRule, ValidationTarget, ValidationType};
 
 /// A struct representing a symbol in the PDB file.
 #[derive(Default, Clone)]

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -18,7 +18,7 @@ pub mod util;
 pub mod validation;
 
 use auxgen::{Symbol, AuxBuilder};
-use validation::{ValidationRule, ValidationType};
+use validation::{ValidationRule, ValidationType, ValidationTarget};
 
 pub const POINTER_LENGTH: u64 = 8;
 
@@ -38,6 +38,8 @@ pub struct Args {
     /// Path to the config file.
     #[arg(short, long)]
     pub config: Option<PathBuf>,
+    #[arg(short, long, default_value = "DEBUG")]
+    pub target: ValidationTarget,
     // Display the parse Symbol information.
     #[arg(short, long)]
     pub debug: bool
@@ -137,7 +139,7 @@ pub fn main() -> Result<()> {
         .with_image(&efi)?
         .with_config(args.config)?
         .with_symbols(parsed_symbols.values().cloned().collect())
-        .generate(&type_information)?;
+        .generate(&type_information, args.target)?;
 
     if args.debug {
         println!("{:?}", aux.header);

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -38,7 +38,7 @@ pub struct Args {
     /// Path to the config file.
     #[arg(short, long)]
     pub config: Option<PathBuf>,
-    #[arg(short, long)]
+    #[arg(short, long, value_enum)]
     pub target: ValidationTarget,
     // Display the parse Symbol information.
     #[arg(short, long)]

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -38,7 +38,7 @@ pub struct Args {
     /// Path to the config file.
     #[arg(short, long)]
     pub config: Option<PathBuf>,
-    #[arg(short, long, default_value = "DEBUG")]
+    #[arg(short, long)]
     pub target: ValidationTarget,
     // Display the parse Symbol information.
     #[arg(short, long)]

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
@@ -6,11 +6,10 @@
 //!
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //! 
-use std::str::FromStr;
-
 use pdb::TypeInformation;
 use scroll::{ctx, Endian, Pwrite};
 use serde::Deserialize;
+use clap::ValueEnum;
 
 use crate::Symbol;
 
@@ -134,7 +133,7 @@ impl <'a> ctx::TryIntoCtx<Endian> for &ValidationType {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default, ValueEnum)]
 pub enum ValidationTarget{
     #[default]
     #[serde(alias = "DEBUG", alias = "Debug", alias = "debug")]
@@ -142,24 +141,11 @@ pub enum ValidationTarget{
     #[serde(alias = "RELEASE", alias = "Release", alias = "release")]
     Release,
     #[serde(alias = "NOOPT", alias = "NoOpt", alias = "Noopt", alias = "noopt")]
-    NoOpt,
+    Noopt,
 }
 
 impl ValidationTarget {
     pub fn all() -> Vec<ValidationTarget> {
-        vec![ValidationTarget::Debug, ValidationTarget::Release, ValidationTarget::NoOpt]
-    }
-}
-
-impl FromStr for ValidationTarget {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "DEBUG" | "Debug" | "debug" => Ok(ValidationTarget::Debug),
-            "RELEASE" | "Release" | "release" => Ok(ValidationTarget::Release),
-            "NOOPT" | "NoOpt" | "Noopt" | "noopt" => Ok(ValidationTarget::NoOpt),
-            _ => Err(format!("Unknown target: {}", s)),
-        }
+        vec![ValidationTarget::Debug, ValidationTarget::Release, ValidationTarget::Noopt]
     }
 }


### PR DESCRIPTION
## Description

This change allows validation rules to only apply to certain build targets (DEBUG, RELEASE, NOOPT). By default, validation rules apply to all three, but a rule can be marked to only apply to a subset of them by adding a `target` field to the rule, which is a list of the supported targets.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated that no change to a config continues to apply all rules.

Validated that filtering a rule to a specific build target results in that rule being skipped in the final aux.

## Integration Instructions

Add a `target = ['debug']`, `target = ['release']` or `target = ['noop']` or any combination there-of to any [[rule]] entry.
