### PR TITLE
Update override tags and add hob prints to Supervisor Core

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -44,6 +44,7 @@
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
+#include <Library/HobPrintLib.h>
 #include <Library/PerformanceLib.h>
 
 #include <Library/StandaloneMmMemLib.h>

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -10,7 +10,7 @@
 #
 ##
 
-#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 22aa8d1b884e477e1e078b485974dc90 | 2024-08-28T16-51-15 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
+#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 87c25fbb792799ab47fddb63e316588b | 2024-11-05T20-39-35 | c1d39dfc22e383d2652a7a696696431d12ed1f58
 #Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 465d5d5aecd11469c7b706462e194f94 | 2024-08-28T16-50-23 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
 #Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | a391d46c2a0b5cf66f61056e2f79ae72 | 2024-10-01T17-01-09 | f2547000cccf6f8d37d730498c8f0b5a91ce8d89
 
@@ -148,6 +148,7 @@
   MmSaveStateLib
   SmmCpuSyncLib
   PanicLib
+  HobPrintLib
 
 [Protocols]
   gEfiMmEndOfDxeProtocolGuid                   ## PRODUCES

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
@@ -9,7 +9,7 @@
 #**/
 
 # This module contains an instance of protocol/handle from StandaloneMmCore and pool memory + guard management from PiSmmCore.
-#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 22aa8d1b884e477e1e078b485974dc90 | 2024-08-28T16-51-15 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
+#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 87c25fbb792799ab47fddb63e316588b | 2024-11-05T20-39-35 | c1d39dfc22e383d2652a7a696696431d12ed1f58
 #Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | a391d46c2a0b5cf66f61056e2f79ae72 | 2024-10-01T17-01-09 | f2547000cccf6f8d37d730498c8f0b5a91ce8d89
 
 [Defines]

--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -54,6 +54,7 @@
   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   PanicLib|MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.IA32]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf


### PR DESCRIPTION
## Description

Update override tags and print all the hobs from the Supervisor core. 
Taken from this BASECORE commit: [178020177b](https://github.com/microsoft/mu_basecore/commit/17802017780ad3cc96f3d9a7b9075768acb0d30b#diff-0f2782559480b3bbe2fb89076d9b412c3a9c31eda054d14cde237e37e9353810R63)

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with CI and on physical platforms

## Integration Instructions

Add HobPrintLib to your platform dsc.
