### PR TITLE
Update commit hashes to latest basecore, v2024050000.1.2

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -10,7 +10,7 @@
 #
 ##
 
-#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | e1beec4df1092189d6c6881362f26bee | 2024-10-29T17-45-47 | e634b4b1be7fd22e3ac08616bce4f533f49b940b
+#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 87c25fbb792799ab47fddb63e316588b | 2024-11-05T21-48-12 | 7c9458ec0ef7f304b68fe12cef85216daf006e23
 #Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 465d5d5aecd11469c7b706462e194f94 | 2024-08-28T16-50-23 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
 #Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | a391d46c2a0b5cf66f61056e2f79ae72 | 2024-10-01T17-01-09 | f2547000cccf6f8d37d730498c8f0b5a91ce8d89
 

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
@@ -9,7 +9,7 @@
 #**/
 
 # This module contains an instance of protocol/handle from StandaloneMmCore and pool memory + guard management from PiSmmCore.
-#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | e1beec4df1092189d6c6881362f26bee | 2024-10-29T17-45-47 | e634b4b1be7fd22e3ac08616bce4f533f49b940b
+#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 87c25fbb792799ab47fddb63e316588b | 2024-11-05T21-48-12 | 7c9458ec0ef7f304b68fe12cef85216daf006e23
 #Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | a391d46c2a0b5cf66f61056e2f79ae72 | 2024-10-01T17-01-09 | f2547000cccf6f8d37d730498c8f0b5a91ce8d89
 
 [Defines]


### PR DESCRIPTION
## Description

Basecore brought in a HobPrintLib dependency to print hobs. This change is not being taken into mm_supv at this point.

Updating hash to account for this.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local CI.

## Integration Instructions
N/A