### PR TITLE
Move the GDT data to be read only data section

### DIFF
--- a/MmSupervisorPkg/Core/Relocate/SmiException.nasm
+++ b/MmSupervisorPkg/Core/Relocate/SmiException.nasm
@@ -18,7 +18,7 @@ global  ASM_PFX(gcSmiIdtr)
 global  ASM_PFX(gcSmiGdtr)
 global  ASM_PFX(gcPsd)
 
-    SECTION .data
+    SECTION .rdata
 
 NullSeg: DQ 0                   ; reserved by architecture
 CodeSeg32:
@@ -118,6 +118,15 @@ TssSeg:
             DD      0                   ; Reserved
 GDT_SIZE equ $ -   NullSeg
 
+;
+; CODE & DATA segments for SMM runtime
+;
+CODE_SEL    equ   CodeSeg64R0 -   NullSeg
+DATA_SEL    equ   DataSeg64R0 -   NullSeg
+CODE32_SEL  equ   CodeSeg32 -   NullSeg
+
+    SECTION .data
+
 ; Create TSS Descriptor just after GDT
 TssDescriptor:
             DD      0                   ; Reserved
@@ -161,13 +170,6 @@ ASM_PFX(gcPsd):
             times   24 DB 0
             DQ      0
 PSD_SIZE  equ $ -   ASM_PFX(gcPsd)
-
-;
-; CODE & DATA segments for SMM runtime
-;
-CODE_SEL    equ   CodeSeg64R0 -   NullSeg
-DATA_SEL    equ   DataSeg64R0 -   NullSeg
-CODE32_SEL  equ   CodeSeg32 -   NullSeg
 
 ASM_PFX(gcSmiGdtr):
     DW      GDT_SIZE - 1

--- a/MmSupervisorPkg/Core/Relocate/SmiException.nasm
+++ b/MmSupervisorPkg/Core/Relocate/SmiException.nasm
@@ -129,8 +129,6 @@ CODE_SEL    equ   CodeSeg64R0 -   NullSeg
 DATA_SEL    equ   DataSeg64R0 -   NullSeg
 CODE32_SEL  equ   CodeSeg32 -   NullSeg
 
-    SECTION .data
-
 ; Create TSS Descriptor just after GDT
 TssDescriptor:
             DD      0                   ; Reserved
@@ -174,6 +172,8 @@ ASM_PFX(gcPsd):
             times   24 DB 0
             DQ      0
 PSD_SIZE  equ $ -   ASM_PFX(gcPsd)
+
+    SECTION .data
 
 ASM_PFX(gcSmiIdtr):
     DW      0

--- a/MmSupervisorPkg/Core/Relocate/SmiException.nasm
+++ b/MmSupervisorPkg/Core/Relocate/SmiException.nasm
@@ -118,6 +118,10 @@ TssSeg:
             DD      0                   ; Reserved
 GDT_SIZE equ $ -   NullSeg
 
+ASM_PFX(gcSmiGdtr):
+    DW      GDT_SIZE - 1
+    DQ        NullSeg
+
 ;
 ; CODE & DATA segments for SMM runtime
 ;
@@ -170,10 +174,6 @@ ASM_PFX(gcPsd):
             times   24 DB 0
             DQ      0
 PSD_SIZE  equ $ -   ASM_PFX(gcPsd)
-
-ASM_PFX(gcSmiGdtr):
-    DW      GDT_SIZE - 1
-    DQ        NullSeg
 
 ASM_PFX(gcSmiIdtr):
     DW      0

--- a/MmSupervisorPkg/Core/Relocate/SmiException.nasm
+++ b/MmSupervisorPkg/Core/Relocate/SmiException.nasm
@@ -118,17 +118,6 @@ TssSeg:
             DD      0                   ; Reserved
 GDT_SIZE equ $ -   NullSeg
 
-ASM_PFX(gcSmiGdtr):
-    DW      GDT_SIZE - 1
-    DQ        NullSeg
-
-;
-; CODE & DATA segments for SMM runtime
-;
-CODE_SEL    equ   CodeSeg64R0 -   NullSeg
-DATA_SEL    equ   DataSeg64R0 -   NullSeg
-CODE32_SEL  equ   CodeSeg32 -   NullSeg
-
 ; Create TSS Descriptor just after GDT
 TssDescriptor:
             DD      0                   ; Reserved
@@ -172,6 +161,17 @@ ASM_PFX(gcPsd):
             times   24 DB 0
             DQ      0
 PSD_SIZE  equ $ -   ASM_PFX(gcPsd)
+
+;
+; CODE & DATA segments for SMM runtime
+;
+CODE_SEL    equ   CodeSeg64R0 -   NullSeg
+DATA_SEL    equ   DataSeg64R0 -   NullSeg
+CODE32_SEL  equ   CodeSeg32 -   NullSeg
+
+ASM_PFX(gcSmiGdtr):
+    DW      GDT_SIZE - 1
+    DQ        NullSeg
 
     SECTION .data
 


### PR DESCRIPTION
## Description

This change moves the GDT data to be read only section.

Note that `TssDescriptor` symbol is also going to be manipulated. But execution-wise, this is always updated after disabling data writing. SEA validation-wise, this change will enforce a rule of `TssDescriptor` to be added for better validation.
 
- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change was tested on QEMU Q35 and booted to UEFI shell.

## Integration Instructions

N/A