### PR TITLE
Update for latest basecore

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -10,7 +10,7 @@
 #
 ##
 
-#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 6967cd9168f4e96b0df5067c87ad9bc3 | 2025-01-12T06-15-24 | ab883845a076ebabbd07168589004c3c3834680e
+#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | e1beec4df1092189d6c6881362f26bee | 2025-01-14T23-01-46 | e634b4b1be7fd22e3ac08616bce4f533f49b940b
 #Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 465d5d5aecd11469c7b706462e194f94 | 2024-08-28T16-50-23 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
 #Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | a391d46c2a0b5cf66f61056e2f79ae72 | 2024-10-01T17-01-09 | f2547000cccf6f8d37d730498c8f0b5a91ce8d89
 

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
@@ -9,7 +9,7 @@
 #**/
 
 # This module contains an instance of protocol/handle from StandaloneMmCore and pool memory + guard management from PiSmmCore.
-#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 6967cd9168f4e96b0df5067c87ad9bc3 | 2025-01-12T06-15-24 | ab883845a076ebabbd07168589004c3c3834680e
+#Override : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | e1beec4df1092189d6c6881362f26bee | 2025-01-14T22-35-15 | e634b4b1be7fd22e3ac08616bce4f533f49b940b
 #Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | a391d46c2a0b5cf66f61056e2f79ae72 | 2024-10-01T17-01-09 | f2547000cccf6f8d37d730498c8f0b5a91ce8d89
 
 [Defines]

--- a/SeaPkg/SeaPkg.ci.yaml
+++ b/SeaPkg/SeaPkg.ci.yaml
@@ -165,7 +165,8 @@
             "xrstor",
             "xsave",
             "xsetbv",
-            "xstate"
+            "xstate",
+            "Emption"
         ]
     }
 }


### PR DESCRIPTION
## Description

Update override validation hashes for latest version of basecore.

Triggered by cherry-picked update from EDK for unloading images (code already existed in Mm Supv).

Fix CI error in SeaPkg. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local CI build
Mu Tiano Platforms Build

## Integration Instructions
N/A