### PR TITLE
MmSupervisorPkg: Add MmSupervisorRing3Performance

### DIFF
--- a/MmSupervisorPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
+++ b/MmSupervisorPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
@@ -285,6 +285,9 @@ flash drivers, SW MMI dispatcher drivers, etc.
   IoLib|MmSupervisorPkg/Library/BaseIoLibIntrinsicSysCall/BaseIoLibIntrinsic.inf
   SysCallLib|MmSupervisorPkg/Library/SysCallLib/SysCallLib.inf
 
+  # This library instance is only necessary if performance tracing is enabled in MM code.
+  PerformanceLib|MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.inf
+
 [Components.IA32]
   MmSupervisorPkg/Drivers/StandaloneMmHob/StandaloneMmHob.inf
   MmSupervisorPkg/Drivers/MmCommunicationBuffer/MmCommunicationBufferPei.inf
@@ -312,7 +315,19 @@ flash drivers, SW MMI dispatcher drivers, etc.
       # Note that this should be whatever suits the target platform + MM standalone conversion for constructor input arguments
       SmmCpuFeaturesLib|$(PLATFORM_SI_PACKAGE)/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
   }
-  MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+  MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf {
+    <LibraryClasses>
+      # Because the Ring 3 Broker is the first MM_STANDALONE driver to load. The MM Performance protocol will
+      # not be installed yet.
+      PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
+  }
+  # Note: The following driver is only necessary if performance tracing is enabled in MM code.
+  MmSupervisorPkg/Drivers/MmSupervisorRing3Performance/MmSupervisorRing3Performance.inf {
+    <LibraryClasses>
+      # It is recommended to link this instance of the Standalone MM Core performance library against this
+      # driver.
+      PerformanceLib|MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.inf
+  }
 
   MdeModulePkg/Universal/ReportStatusCodeRouter/Smm/ReportStatusCodeRouterStandaloneMm.inf
   UefiCpuPkg/CpuIo2Smm/CpuIo2StandaloneMm.inf

--- a/MmSupervisorPkg/Docs/PlatformIntegration/SoftwareComponentOverview.md
+++ b/MmSupervisorPkg/Docs/PlatformIntegration/SoftwareComponentOverview.md
@@ -49,8 +49,9 @@ For more general background about the steps necessary to integrate the MM Superv
 
 | MM Driver | Location |
 | ---| ---|
-| MmSupervisorRing3Broker | MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf |
-| MmSupervisorErrorReport | MmSupervisorPkg/Drivers/MmSupervisorErrorReport/MmSupervisorErrorReport.inf |
+| MmSupervisorRing3Broker       | MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf |
+| MmSupervisorRing3Performance  | MmSupervisorPkg/Drivers/MmSupervisorRing3Performance/MmSupervisorRing3Performance.inf |
+| MmSupervisorErrorReport       | MmSupervisorPkg/Drivers/MmSupervisorErrorReport/MmSupervisorErrorReport.inf |
 
 ## MM Standalone User Mode Libraries
 

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Performance/MmSupervisorRing3Performance.c
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Performance/MmSupervisorRing3Performance.c
@@ -1,0 +1,35 @@
+/** @file
+  Driver to initialize and provide user mode performance data in an MM Supervisor environment.
+
+  This driver is expected to be linked against a PerformanceLib instance that implements the
+  code typically in a MM Core for user mode performance data. This includes installing the
+  performance protocol and registering a MMI to return performance data to the MMI caller.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Pi/PiMmCis.h>
+
+#include <Library/DebugLib.h>
+
+/**
+  The MM Supervisor Ring 3 Performance Entry Point.
+
+  @param[in]  ImageHandle    The firmware allocated handle for the EFI image.
+  @param[in]  SystemTable    A pointer to the MM System Table.
+
+  @retval EFI_SUCCESS    The entry point is executed successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+MmSupervisorRing3PerformanceEntryPoint (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return EFI_SUCCESS;
+}

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Performance/MmSupervisorRing3Performance.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Performance/MmSupervisorRing3Performance.inf
@@ -1,0 +1,36 @@
+#/** @file
+#  Driver to initialize and provide user mode performance data in an MM Supervisor environment.
+#
+#  This driver is expected to be linked against a PerformanceLib instance that implements the
+#  code typically in a MM Core for user mode performance data. This includes installing the
+#  performance protocol and registering a MMI to return performance data to the MMI caller.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = MmSupervisorRing3Performance
+  FILE_GUID                      = 8B479EAC-C3C8-4A1C-BF58-2BEDAE9E1CFB
+  MODULE_TYPE                    = MM_STANDALONE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  ENTRY_POINT                    = MmSupervisorRing3PerformanceEntryPoint
+
+[Sources]
+  MmSupervisorRing3Performance.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MmSupervisorPkg/MmSupervisorPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  StandaloneMmDriverEntryPoint
+  PerformanceLib
+
+[Depex]
+  TRUE

--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -158,6 +158,7 @@
 
   MmSupervisorPkg/Drivers/MmSupervisorErrorReport/MmSupervisorErrorReport.inf
   MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+  MmSupervisorPkg/Drivers/MmSupervisorRing3Performance/MmSupervisorRing3Performance.inf
   MmSupervisorPkg/Drivers/StandaloneMmUnblockMem/StandaloneMmUnblockMem.inf
   MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplX64Relay.inf
   MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.inf


### PR DESCRIPTION
## Description

Closes #383 

Adds a new `MM_STANDALONE` driver that is used to link against a
`PerformanceLib` core instance for MM user mode drivers.

An empty driver is reserved for this use case for the following
reasons:

1. Make integration and debug obvious and easy by having a clearly
   named and designated driver for this purpose.
2. To be among the first MM user mode drivers dispatched to install
   the performance protocol and make the performance service
   available to other user mode drivers as early as possible.
3. To avoid linking directly to `MmSupervisorRing3Broker`. The MM
   Core performance library instance code has functionality that
   depends on MM services to be available. Since the Ring 3 Broker
   is reponsible for initializing MM services in user mode, it is
   complicated and error prone to attempt to defer using those
   services to install the performance protocol until syscall has
   been set up with the core and a proper `gMmst` global could be
   used by the common MM code. This is all much simpler and easier
   to integrate in a separate MM user mode driver.
4. To avoid linking the library to a pre-existing MM module that
   may have an unknown number of depdencies in its DEPEX. Since
   the DEPEX on a given platform aggregates all of the dependencies
   in linked libraries, it is not safe to assume any given MM module
   not dedicated exclusively for this purpose will not have unrelated
   dependencies that unnecessarily prolong installation of the
   performance protocol.

---

Temporarily includes this commit:

**TEMP - .pytool/CISettings.py: Use Mu Basecore Standalone MM Perf Branch**

Temporarily use this branch for testing.

This commit will be reverted after the following Mu Basecore PR is
merged:

https://github.com/microsoft/mu_basecore/pull/1268

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- Use `MmSupervisorRing3Performance` to retrieve MM performance records
  with the MM Supervisor on Q35.

## Integration Instructions

- Included in MmSupervisorPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md