### PR TITLE
Add ability to generate a dummy config file with all parsed symbols

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -31,6 +31,16 @@ impl std::fmt::Debug for Symbol {
     }
 }
 
+impl Symbol {
+    /// Returns true if the symbol is in a section that is read-only (READ, !WRITE, !EXECUTE)
+    pub fn in_readonly_section(&self, sections: &[pdb::ImageSectionHeader]) -> bool {
+        sections
+            .iter()
+            .filter(|s| s.characteristics.read() && !s.characteristics.write() && !s.characteristics.execute())
+            .any(|s| self.address >= s.virtual_address && self.address < s.virtual_address + s.virtual_size)
+    }
+}
+
 /// A struct representing the header of the aux file.
 #[derive(Debug, Pwrite)]
 pub struct ImageValidationDataHeader {


### PR DESCRIPTION
## Description

This auto generation ignores any symbols that are in code sections when auto generating a default configuration file for a particular PDB.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A