### PR TITLE
Make it so PiSmmCpuSmiEntryFixupAddress is only called when not using SEA

### DIFF
--- a/MmSupervisorPkg/Core/Relocate/Relocate.c
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.c
@@ -697,8 +697,12 @@ SetupSmiEntryExit (
 
   //
   // Initialize address fixup
-  //
-  PiSmmCpuSmiEntryFixupAddress ();
+  //s
+
+  // This is only necessary when using the MmSupervisorCore SmiEntry.nasm.  Ignore it with SEA.
+  if (SmmCpuFeaturesGetSmiHandlerSize () == 0) {
+    PiSmmCpuSmiEntryFixupAddress ();
+  }
 
   //
   // Initialize Debug Agent to support source level debug in SMM code

--- a/MmSupervisorPkg/Core/Relocate/Relocate.c
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.c
@@ -697,7 +697,7 @@ SetupSmiEntryExit (
 
   //
   // Initialize address fixup
-  //s
+  //
 
   // This is only necessary when using the MmSupervisorCore SmiEntry.nasm.  Ignore it with SEA.
   if (SmmCpuFeaturesGetSmiHandlerSize () == 0) {

--- a/MmSupervisorPkg/Core/Relocate/Relocate.c
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.c
@@ -699,7 +699,7 @@ SetupSmiEntryExit (
   // Initialize address fixup
   //
 
-  // This is only necessary when using the MmSupervisorCore SmiEntry.nasm.  Ignore it with SEA.
+  // If a feature lib has its own entry code we shouldn't fixup the addresses.
   if (SmmCpuFeaturesGetSmiHandlerSize () == 0) {
     PiSmmCpuSmiEntryFixupAddress ();
   }


### PR DESCRIPTION
## Description

Currently we touch up the SmiEntry.nasm file when calling PiSmmCpuSmiEntryFixupAddress which is something we don't want to do when using the SEA  MmiEntrySea.nasmb file.  This change makes it so PiSmmCpuSmiEntryFixupAddress is only called when we aren't using a different MmiEntry._>

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical system.  The SmiEntry.nasm is no longer being fixed up.

## Integration Instructions

N/A