### PR TITLE
Switch target filtering to scopes

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
+++ b/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
@@ -27,7 +27,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
         obj.Register("generate_manifest_artifact", GenSeaArtifacts.generate_sea_manifest, fp)
 
     @staticmethod
-    def generate_sea_includes(build_target: str, aux_config_path: Path, mm_supervisor_build_dir: Path, sea_build_dir: Path, inc_file_path: Path):
+    def generate_sea_includes(scopes: list[str], aux_config_path: Path, mm_supervisor_build_dir: Path, sea_build_dir: Path, inc_file_path: Path):
         """Generates SEA artifacts.
 
         Generates the following artifacts:
@@ -35,7 +35,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
         - MmSupervisorCore.efi (As Build by edk2 build system)
 
         Args:
-            build_target: Build Target (DEBUG, RELEASE, NOOPT)
+            scopes: A list of scopes to activate for rule filtering. See gen_aux --help for more information.
             aux_config_path: Path to the aux gen config file.
             mm_supervisor_build_dir: Path to the MM Supervisor build output.
             sea_build_dir: Path to the Sea Package build output.
@@ -50,7 +50,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
             temp_hash_dir = stm_build_dir / "temp_hash.bin"
             temp_out_dir = stm_build_dir / "temp_out.inc"
 
-            aux_path = generate_aux_file(aux_config_path, mm_supervisor_build_dir, build_target, stm_build_dir)
+            aux_path = generate_aux_file(aux_config_path, mm_supervisor_build_dir, scopes, stm_build_dir)
 
             cmd = "BinToPcd.py"
             args = f"-i {aux_path}"
@@ -253,13 +253,13 @@ class GenSeaArtifacts(IUefiHelperPlugin):
 
         return 0
 
-def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, target: str, output_dir: Path):
+def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, scopes: list[str], output_dir: Path):
     """Generates the auxiliary file for the MmsupervisorCore.
 
     Args:
         aux_config_path: Path to the aux gen config file.
         mm_supervisor_build_dir: Path to the MM Supervisor build output.
-        target: Build Target (DEBUG, RELEASE, NOOPT)
+        scopes: A list of scopes to activate for rule filtering. See gen_aux --help for more information.
         output_dir: Path to place the artifacts.
 
     Raises:
@@ -273,7 +273,8 @@ def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, targ
     args += f" --efi {str(mm_supervisor_build_dir / 'MmSupervisorCore.efi')}"
     args += f" --output {str(output_path)}"
     args += f" --config {str(aux_config_path)}"
-    args += f" --target {target.lower()}"
+    for scope in scopes: 
+        args += f" --scope {scope}"
 
     ret = RunCmd("cargo", args)
     if ret != 0:

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -51,7 +51,7 @@ The rule comes with the following standard options:
 
 ``` toml
 [[rule]]
-target = 'Optional[List[String]]'
+scope = 'Optional[String]'
 symbol = 'Required[String]'
 field = 'Optional[String]'
 offset = 'Optional[Int]'
@@ -59,7 +59,7 @@ size = 'Optional[Int]'
 validation.type = 'Required[String]'
 ```
 
-- `target`: A list of build targets this rule applies to. Can be `debug`, `release`, or `noopt`. By default, is all three
+- `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
 - `symbol`: Determines the address and size for the rule
 - `field`: Updates the address and size to be that of the field, rather than the symbol itself.
 - `offset`: Updates the address to `symbol.address + offset`. Offset can be negative. Providing an offset requires that the

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -261,7 +261,6 @@ impl AuxBuilder {
     /// specified in the configuration file, a rule (with no validation) will
     /// be generated, so that all symbols are reverted to their original value.
     pub fn generate(self, info: &TypeInformation, scopes: Vec<String>) -> anyhow::Result<AuxFile> {
-        
         // Filter out rules that are not in scope
         let (mut rules, filtered): (Vec<_>, Vec<_>) = self.rules
             .into_iter()
@@ -270,7 +269,6 @@ impl AuxBuilder {
         for rule in filtered {
             println!("Rule: {:?} Skipped... Does not apply to scopes: {:?}", rule, scopes);
         }
-
         
         let mut aux = AuxFile::default();
         aux.header.offset_to_first_entry = size_of::<ImageValidationDataHeader>() as u32;

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -138,6 +138,7 @@ pub fn main() -> Result<()> {
     while let Some(symbol) = raw_symbol_iter.next()? {
         util::add_symbol(&mut parsed_symbols, symbol, &address_map, &type_information)?;
     }
+
     if args.generate_config {
         let sections = pdb.sections()?.unwrap_or_default();
         let rules: Vec<ValidationRule> = parsed_symbols

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -138,7 +138,6 @@ pub fn main() -> Result<()> {
     while let Some(symbol) = raw_symbol_iter.next()? {
         util::add_symbol(&mut parsed_symbols, symbol, &address_map, &type_information)?;
     }
-
     if args.generate_config {
         let sections = pdb.sections()?.unwrap_or_default();
         let rules: Vec<ValidationRule> = parsed_symbols
@@ -158,12 +157,11 @@ pub fn main() -> Result<()> {
     } else {
         let output = args.output.unwrap_or(args.efi.with_extension("aux"));
         let efi = std::fs::read(args.efi)?;
-        let scopes = args.scopes.iter().map(|s| s.to_ascii_lowercase()).collect();
         let aux = AuxBuilder::default()
             .with_image(&efi)?
             .with_config(args.config)?
             .with_symbols(parsed_symbols.values().cloned().collect())
-            .generate(&type_information, scopes)?;
+            .generate(&type_information, args.scopes)?;
     
         if args.debug {
             println!("{:?}", aux.header);

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -22,7 +22,7 @@ use validation::{ValidationRule, ValidationType};
 
 pub const POINTER_LENGTH: u64 = 8;
 
-/// Command line arguments for the Auxillary File Generator.
+/// Command line arguments for the Auxiliary File Generator.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
@@ -41,7 +41,7 @@ pub struct Args {
     /// Path to the config file to read (or write to if generating a config).
     #[arg(short, long)]
     pub config: Option<PathBuf>,
-    /// A list of scopes to include in the auxillary file. Rules without scopes\n
+    /// A list of scopes to include in the auxiliary file. Rules without scopes
     /// are always applied. Rules with scopes are only applied if the scope is
     /// also provided via this argument.
     #[arg(short, long = "scope")]
@@ -52,7 +52,7 @@ pub struct Args {
 }
 
 /// A struct that represents an signature/address pair to be added to the
-/// auxillary file header.
+/// auxiliary file header.
 #[derive(Serialize, Deserialize, Default)]
 pub struct KeySymbol {
     /// The symbol name to calculate the offset of.
@@ -96,11 +96,11 @@ impl std::fmt::Debug for KeySymbol {
 /// Configuration options available in the config file.
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Config {
-    /// A list of key symbols to be added to the auxillary file header.
+    /// A list of key symbols to be added to the auxiliary file header.
     #[serde(alias = "key", default = "Vec::new")]
     pub key_symbols: Vec<KeySymbol>,
     /// A list of validation rules that ultimately create a validation entry in
-    /// the auxillary file.
+    /// the auxiliary file.
     #[serde(alias = "rule", default = "Vec::new", rename = "rule")]
     pub rules: Vec<ValidationRule>,
     /// An option that if true, will generate a validation entry of 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
@@ -75,7 +75,6 @@ pub fn add_symbol(map: &mut HashMap<String, crate::Symbol>, symbol: pdb::Symbol<
             let address = data.offset.to_rva(&address_map).unwrap_or_default().0;
             let size = get_size_from_index(&info, data.type_index)? as u32;
             let name = data.name.to_string().to_string();
-
             let type_index = Some(data.type_index);
             
             // A data symbol should always take precedence over an existing

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
@@ -75,6 +75,7 @@ pub fn add_symbol(map: &mut HashMap<String, crate::Symbol>, symbol: pdb::Symbol<
             let address = data.offset.to_rva(&address_map).unwrap_or_default().0;
             let size = get_size_from_index(&info, data.type_index)? as u32;
             let name = data.name.to_string().to_string();
+
             let type_index = Some(data.type_index);
             
             // A data symbol should always take precedence over an existing

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
@@ -35,9 +35,11 @@ pub struct ValidationRule {
     /// The size of the symbol that the validation should be performed on. This
     /// is used in conjunction with the `offset` attribute only.
     pub size: Option<u32>,
-    /// The build target that the rule is associated with.
-    #[serde(default = "ValidationTarget::all", skip_serializing)]
-    pub target: Vec<ValidationTarget>,
+    /// A scope that the validation rule should be applied to. This validation
+    /// rule is only applied if it's scope matches any of the scopes passed to
+    /// the tool on the command line. If the rule has no scope, it is always
+    /// applied.
+    pub scope: Option<String>
 }
 
 impl ValidationRule {
@@ -79,7 +81,7 @@ impl From<&Symbol> for ValidationRule {
             validation: ValidationType::Content{ content: 0xDEADBEEFu32.to_le_bytes().to_vec() },
             offset: None,
             size: Some(2),
-            target: Vec::new()
+            scope: None,
         }
     }
 }
@@ -143,22 +145,5 @@ impl <'a> ctx::TryIntoCtx<Endian> for &ValidationType {
         let value: u32 = self.into();
         this.pwrite_with(value, 0, ctx)?;
         Ok(4)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, ValueEnum)]
-pub enum ValidationTarget{
-    #[default]
-    #[serde(alias = "DEBUG", alias = "Debug", alias = "debug")]
-    Debug,
-    #[serde(alias = "RELEASE", alias = "Release", alias = "release")]
-    Release,
-    #[serde(alias = "NOOPT", alias = "NoOpt", alias = "Noopt", alias = "noopt")]
-    Noopt,
-}
-
-impl ValidationTarget {
-    pub fn all() -> Vec<ValidationTarget> {
-        vec![ValidationTarget::Debug, ValidationTarget::Release, ValidationTarget::Noopt]
     }
 }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
@@ -9,7 +9,6 @@
 use pdb::TypeInformation;
 use scroll::{ctx, Endian, Pwrite};
 use serde::{Serialize, Deserialize};
-use clap::ValueEnum;
 
 use crate::Symbol;
 
@@ -43,6 +42,18 @@ pub struct ValidationRule {
 }
 
 impl ValidationRule {
+    /// Creates a new empty validation rule with the given symbol name.
+    pub fn new(symbol: String) -> Self {
+        ValidationRule {
+            symbol,
+            field: None,
+            validation: ValidationType::None,
+            offset: None,
+            size: None,
+            scope: None
+        }
+    }
+
     /// Resolve any symbols in the rule to their actual addresses
     pub fn resolve(&mut self, symbol: &Symbol, symbols: &Vec<Symbol>, info: &TypeInformation) -> anyhow::Result<()> {
         
@@ -70,6 +81,14 @@ impl ValidationRule {
         }
 
         Ok(())
+    }
+
+    /// Returns true if the rule is in scope
+    pub fn is_in_scope(&self, scopes: &[String]) -> bool {
+        if let Some(scope) = &self.scope {
+            return scopes.iter().any(|s| s.eq_ignore_ascii_case(scope));
+        }
+        true
     }
 }
 


### PR DESCRIPTION
## Description

Previously, each rule could apply to a subset of 3 different targets (release, debug, noopt) and during auxiliary file generation, a single target was passed to filter the applied rules.

To extend this functionality, this logic is now reversed, and scopes can be any string, instead of limited to release, debug, and noopt:

1. Previously, a platform passed a single target and a rule could support multiple targets
2. Now, A platform passes multiple scopes, and a rule only supports one scope
3. If a rule does not specify a scope, it is always applied

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Confirmed the same config file is generated based off of a scope similar to the previous target

## Integration Instructions

Platforms must update any `[[rule]]` that has a `target = [...]` section to now be `scope = ""`. If a `[[rule]]` had multiple `target` values, the platform will need to determine any appopriate scope updates or rule additions to account for that, as each `[[rule]]` now only has one scope. 
