### PR TITLE
[REBASE&FF] image_validation: bugfix aux file bounds checks

### DIFF
--- a/SeaPkg/Core/Runtime/SeaResponderReport.c
+++ b/SeaPkg/Core/Runtime/SeaResponderReport.c
@@ -104,10 +104,10 @@ Done:
 EFI_STATUS
 EFIAPI
 VerifyAndHashImage (
-  IN  UINTN                         ImageBase,
+  IN  EFI_PHYSICAL_ADDRESS          ImageBase,
   IN  UINT64                        ImageSize,
   IN  IMAGE_VALIDATION_DATA_HEADER  *AuxFileHdr,
-  IN  UINT64                        PageTableBase,
+  IN  EFI_PHYSICAL_ADDRESS          PageTableBase,
   OUT TPML_DIGEST_VALUES            *DigestList
   )
 {
@@ -321,10 +321,10 @@ SeaResponderReport (
   UINT8                             *LocalMmiEntryBase = NULL;
   PER_CORE_MMI_ENTRY_STRUCT_HDR     *MmiEntryStructHdr;
   UINT32                            MmiEntryStructHdrSize;
-  UINT64                            MmSupervisorBase;
+  EFI_PHYSICAL_ADDRESS              MmSupervisorBase;
   UINT64                            MmSupervisorImageSize;
   UINT64                            FirmwarePolicyBase;
-  UINT64                            SupvPageTableBase;
+  EFI_PHYSICAL_ADDRESS              SupvPageTableBase;
   TPML_DIGEST_VALUES                DigestList;
   UINT8                             *DrtmSmmPolicyData;
   SMM_SUPV_SECURE_POLICY_DATA_V1_0  *FirmwarePolicy;
@@ -508,7 +508,7 @@ SeaResponderReport (
   }
 
   // CR3 should be pointing to the page table from symbol list in the aux file
-  SupvPageTableBase = *(UINT64 *)(MmSupervisorBase + PageTableSymbol->Offset);
+  SupvPageTableBase = *(EFI_PHYSICAL_ADDRESS *)(MmSupervisorBase + PageTableSymbol->Offset);
   if (Fixup32Ptr[FIXUP32_CR3_OFFSET] != SupvPageTableBase) {
     DEBUG ((DEBUG_ERROR, "%a Calculated page table 0x%p does not match MM entry code populated value 0x%p.\n", __func__, SupvPageTableBase, Fixup32Ptr[FIXUP32_CR3_OFFSET]));
     Status = EFI_SECURITY_VIOLATION;

--- a/SeaPkg/Include/Library/PeCoffLibNegative.h
+++ b/SeaPkg/Include/Library/PeCoffLibNegative.h
@@ -56,10 +56,10 @@ typedef struct {
 
 typedef struct {
   UINT32    EntrySignature;
-  UINT32    Offset; // Offset to the start of the target image
-  UINT32    Size;   // Size of this entry
-  UINT32    ValidationType;
-  UINT32    OffsetToDefault;
+  UINT32    Offset;           // Offset to the data to validate in the loaded image.
+  UINT32    Size;             // Size (in bytes) of the data to validate in the loaded image.
+  UINT32    ValidationType;   // The Validation type to be performed on this data.
+  UINT32    OffsetToDefault;  // Offset to the default value in the aux file this header is contained in.
 } IMAGE_VALIDATION_ENTRY_HEADER;
 
 typedef struct {

--- a/SeaPkg/Include/Library/PeCoffLibNegative.h
+++ b/SeaPkg/Include/Library/PeCoffLibNegative.h
@@ -201,8 +201,7 @@ PeCoffLoaderImageNegativeReadFromMemory (
                                             should not touch the content of this buffer.
   @param[in,out]  TargetImage               The pointer to the target image buffer.
   @param[in]      TargetImageSize           The size of the target image buffer.
-  @param[in]      ReferenceData             The pointer to the reference data buffer to assist .
-  @param[in]      ReferenceDataSize         The size of the reference data buffer.
+  @param[in]      ImageValidationHdr        The pointer to the auxiliary file data buffer to assist.
   @param[in]      PageTableBase             The base address of the page table.
 
   @return EFI_SUCCESS               The PE/COFF image was reverted.
@@ -212,12 +211,11 @@ PeCoffLoaderImageNegativeReadFromMemory (
 EFI_STATUS
 EFIAPI
 PeCoffImageDiffValidation (
-  IN      VOID                  *OriginalImageBaseAddress,
-  IN OUT  VOID                  *TargetImage,
-  IN      UINTN                 TargetImageSize,
-  IN      CONST VOID            *ReferenceData,
-  IN      UINTN                 ReferenceDataSize,
-  IN      EFI_PHYSICAL_ADDRESS  PageTableBase
+  IN      VOID                                *OriginalImageBaseAddress,
+  IN OUT  VOID                                *TargetImage,
+  IN      UINTN                               TargetImageSize,
+  IN      CONST IMAGE_VALIDATION_DATA_HEADER  *ImageValidationEntryHdr,
+  IN      EFI_PHYSICAL_ADDRESS                PageTableBase
   );
 
 #endif // BASE_PECOFF_LIB_NEGATIVE_H_

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -107,7 +107,7 @@ pub struct ImageValidationEntryHeader {
     /// The type of validation to perform on the symbol. Contains the data
     /// necessary to perform the validation.
     validation_type: ValidationType,
-    /// Offset of the default value in the raw data
+    /// Offset of the default value in the aux file.
     offset_to_default: u32
 }
 


### PR DESCRIPTION
## Description

This commit fixes two separate issues with the bounds checks in the image validation code that ensures certain pieces of data in the auxiliary file are within the bounds of the file, according to the size expectations described in the validation entry headers.

1. The first issue resolved is specific to the IMAGE_VALIDATION_CONTENT validation type. In this validation type, the header contains N number of additional bytes, that are the expected value that the particular content should be. The purpose of this validation is to ensure that the content provided by the auxiliary file for validation does not extend beyond the bounds of the file.

The issue was that the bounds check only validated that the overall size of the header + content was less than the overall size of the auxiliary file. This has been updated to ensure that:

addr_of(header) + size_of(header) + size_of(content) <= addr_of(aux) + size_of(aux)

2. The second is that only one validation type had a bounds check to ensure the default value that we revert data to was within the bounds of the auxiliary file. This has been moved out of the specific validation type and is now a general check immediately before the reversion of the particular data.

- [ ] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

TestApp Continues to pass

## Integration Instructions

N/A