### PR TITLE
SeaPkg: Make Image Validation Testable

### DIFF
--- a/SeaPkg/Core/Runtime/SeaResponderReport.c
+++ b/SeaPkg/Core/Runtime/SeaResponderReport.c
@@ -14,6 +14,7 @@
 #include <Register/Cpuid.h>
 #include <Register/SmramSaveStateMap.h>
 #include <SeaResponder.h>
+#include <SeaAuxiliary.h>
 #include <SmmSecurePolicy.h>
 #include <x64/Smx.h>
 

--- a/SeaPkg/Include/Library/PeCoffLibNegative.h
+++ b/SeaPkg/Include/Library/PeCoffLibNegative.h
@@ -27,60 +27,6 @@
 #ifndef BASE_PECOFF_LIB_NEGATIVE_H_
 #define BASE_PECOFF_LIB_NEGATIVE_H_
 
-#define IMAGE_VALIDATION_ENTRY_TYPE_NONE      0x00000000
-#define IMAGE_VALIDATION_ENTRY_TYPE_NON_ZERO  0x00000001
-#define IMAGE_VALIDATION_ENTRY_TYPE_CONTENT   0x00000002
-#define IMAGE_VALIDATION_ENTRY_TYPE_MEM_ATTR  0x00000003
-#define IMAGE_VALIDATION_ENTRY_TYPE_SELF_REF  0x00000004
-#define IMAGE_VALIDATION_ENTRY_TYPE_POINTER   0x00000005
-
-#define IMAGE_VALIDATION_DATA_SIGNATURE   SIGNATURE_32 ('V', 'A', 'L', 'D')
-#define IMAGE_VALIDATION_ENTRY_SIGNATURE  SIGNATURE_32 ('E', 'N', 'T', 'R')
-
-#pragma pack(1)
-
-typedef struct {
-  UINT32    Signature;
-  UINT32    Offset;
-} KEY_SYMBOL;
-
-typedef struct {
-  UINT32    HeaderSignature;
-  UINT32    Size;
-  UINT32    EntryCount;
-  UINT32    OffsetToFirstEntry;
-  UINT32    OffsetToFirstDefault;
-  UINT32    KeySymbolCount;
-  UINT32    OffsetToFirstKeySymbol;
-} IMAGE_VALIDATION_DATA_HEADER;
-
-typedef struct {
-  UINT32    EntrySignature;
-  UINT32    Offset;           // Offset to the data to validate in the loaded image.
-  UINT32    Size;             // Size (in bytes) of the data to validate in the loaded image.
-  UINT32    ValidationType;   // The Validation type to be performed on this data.
-  UINT32    OffsetToDefault;  // Offset to the default value in the aux file this header is contained in.
-} IMAGE_VALIDATION_ENTRY_HEADER;
-
-typedef struct {
-  IMAGE_VALIDATION_ENTRY_HEADER    Header;
-  UINT8                            TargetContent[];
-} IMAGE_VALIDATION_CONTENT;
-
-typedef struct {
-  IMAGE_VALIDATION_ENTRY_HEADER    Header;
-  UINT64                           TargetMemorySize;
-  UINT64                           TargetMemoryAttributeMustHave;
-  UINT64                           TargetMemoryAttributeMustNotHave;
-} IMAGE_VALIDATION_MEM_ATTR;
-
-typedef struct {
-  IMAGE_VALIDATION_ENTRY_HEADER    Header;
-  UINT32                           TargetOffset;
-} IMAGE_VALIDATION_SELF_REF;
-
-#pragma pack()
-
 /**
   Applies relocation fixups to a PE/COFF image that was loaded with PeCoffLoaderLoadImage().
 

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -4,7 +4,7 @@
   multiple validation entries. A validation entry specifies a specific region in the
   target image buffer to validate against, a validation type to perform, and any
   necessary data to assist in the validation.
-  
+
   There currently exists five validation types:
   - Non-Zero: Validates that the specified region in the target image buffer is not all zero.
   - Content: Validates that the specified region in the target image buffer matches the content in the reference data.
@@ -18,6 +18,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
+
 #ifndef BASE_PECOFF_VALIDATION_LIB_H_
 #define BASE_PECOFF_VALIDATION_LIB_H_
 
@@ -33,9 +34,9 @@
 **/
 EFI_STATUS
 PeCoffImageValidationNonZero (
-    IN VOID                           *TargetImage,
-    IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
-);
+  IN VOID                           *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+  );
 
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
@@ -51,10 +52,10 @@ PeCoffImageValidationNonZero (
 **/
 EFI_STATUS
 PeCoffImageValidationContent (
-  IN VOID                               *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER      *Hdr,
-  IN CONST IMAGE_VALIDATION_DATA_HEADER *ImageValidationHdr
-);
+  IN VOID                                *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER       *Hdr,
+  IN CONST IMAGE_VALIDATION_DATA_HEADER  *ImageValidationHdr
+  );
 
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
@@ -64,7 +65,7 @@ PeCoffImageValidationContent (
   @param[in] TargetImage    The pointer to the target image buffer.
   @param[in] Hdr            The header of the validation entry.
   @param[in] PageTableBase  The base address of the page table.
-    
+
   @returns EFI_SUCCESS             The target image passes the validation.
   @returns EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
   @returns EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
@@ -75,7 +76,7 @@ PeCoffImageValidationMemAttr (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
   IN EFI_PHYSICAL_ADDRESS           PageTableBase
-);
+  );
 
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
@@ -94,7 +95,7 @@ PeCoffImageValidationSelfRef (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
   IN VOID                           *OriginalImageBaseAddress
-);
+  );
 
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
@@ -111,6 +112,6 @@ EFI_STATUS
 PeCoffImageValidationPointer (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
-);
+  );
 
 #endif // BASE_PECOFF_VALIDATION_LIB_H_

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -63,7 +63,7 @@ PeCoffImageValidationContent (
 
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
-  belongs to a user page that is mapped inside MM and teh page attributes match the requirements specified
+  belongs to a user page that is mapped inside MM and the page attributes match the requirements specified
   by the validation entry.
 
   @param[in] TargetImage    The pointer to the target image buffer.

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -35,8 +35,8 @@
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationNonZero (
-  IN VOID                           *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
   );
 
 /**
@@ -54,9 +54,9 @@ PeCoffImageValidationNonZero (
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationContent (
-  IN VOID                                *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER       *Hdr,
-  IN CONST IMAGE_VALIDATION_DATA_HEADER  *ImageValidationHdr
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN CONST IMAGE_VALIDATION_DATA_HEADER   *ImageValidationHdr
   );
 
 /**
@@ -76,9 +76,9 @@ PeCoffImageValidationContent (
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationMemAttr (
-  IN VOID                           *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
-  IN EFI_PHYSICAL_ADDRESS           PageTableBase
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN EFI_PHYSICAL_ADDRESS                 PageTableBase
   );
 
 /**
@@ -96,9 +96,9 @@ PeCoffImageValidationMemAttr (
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationSelfRef (
-  IN VOID                           *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
-  IN VOID                           *OriginalImageBaseAddress
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN CONST VOID                           *OriginalImageBaseAddress
   );
 
 /**
@@ -115,8 +115,8 @@ PeCoffImageValidationSelfRef (
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationPointer (
-  IN VOID                           *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
   );
 
 #endif // PECOFF_VALIDATION_LIB_H_

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -48,6 +48,8 @@ PeCoffImageValidationNonZero (
   @param[in] ImageValidationHdr  The pointer to the auxiliary file data buffer to assist.
 
   @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
+  @retval EFI_INVALID_PARAMETER   The provided header has an invalid signature
   @retval EFI_COMPROMISED_DATA    The content to match against overflows the auxiliary file.
   @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image does not match the reference data.
 **/
@@ -69,6 +71,8 @@ PeCoffImageValidationContent (
   @param[in] PageTableBase  The base address of the page table.
 
   @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
+  @retval EFI_INVALID_PARAMETER   The validation entry has invalid signature.
   @retval EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
   @retval EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
   @retval EFI_SECURITY_VIOLATION  The target image does not meet the memory attribute requirements.
@@ -90,7 +94,9 @@ PeCoffImageValidationMemAttr (
   @param[in] OriginalImageBaseAddress  The pointer to the original image buffer.
 
   @retval EFI_SUCCESS             The target image passes the validation.
-  @retval EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
+  @retval EFI_INVALID_PARAMETER   The validation entry has an invalid signature.
+  @retval EFI_INVALID_PARAMETER   The validation entry has an invalid size.
   @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS
@@ -109,7 +115,9 @@ PeCoffImageValidationSelfRef (
   @param[in] Hdr          The header of the validation entry.
 
   @retval EFI_SUCCESS             The target image passes the validation.
-  @retval EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
+  @retval EFI_INVALID_PARAMETER   The validation entry has invalid signature.
+  @retval EFI_INVALID_PARAMETER   The validation entry has an invalid size.
   @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -1,0 +1,116 @@
+/** @file
+  Defines function definitions for validating a loaded PE/COFF image post execution
+  against an auxiliary file (defined in SeaAuxiliary.h) that contains auxiliary
+  multiple validation entries. A validation entry specifies a specific region in the
+  target image buffer to validate against, a validation type to perform, and any
+  necessary data to assist in the validation.
+  
+  There currently exists five validation types:
+  - Non-Zero: Validates that the specified region in the target image buffer is not all zero.
+  - Content: Validates that the specified region in the target image buffer matches the content in the reference data.
+  - MemAttr: Validates that the specified region in the target image buffer belongs to a user page that is mapped inside MM
+             and the page attributes match the requirements specified by the validation entry.
+  - SelfRef: Validates that the specified region in the target image buffer matches the content in the original image buffer as
+             specified by TargetOffset in the validation entry.
+  - Pointer: Validates that the specified region in the target image buffer is a pointer, and that the pointer is not NULL.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef BASE_PECOFF_VALIDATION_LIB_H_
+#define BASE_PECOFF_VALIDATION_LIB_H_
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  is not a zero buffer.
+
+  @param[in] TargetImage  The pointer to the target image buffer.
+  @param[in] Hdr          The header of the validation entry.
+
+  @return EFI_SUCCESS             The target image passes the validation.
+  @return EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
+**/
+EFI_STATUS
+PeCoffImageValidationNonZero (
+    IN VOID                           *TargetImage,
+    IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+);
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  is the same as the content in the reference data.
+
+  @param[in] TargetImage         The pointer to the target image buffer.
+  @param[in] Hdr                 The header of the validation entry.
+  @param[in] ImageValidationHdr  The pointer to the auxiliary file data buffer to assist.
+
+  @return EFI_SUCCESS             The target image passes the validation.
+  @return EFI_COMPROMISED_DATA    The content to match against overflows the auxiliary file.
+  @return EFI_SECURITY_VIOLATION  The specified buffer in the target image does not match the reference data.
+**/
+EFI_STATUS
+PeCoffImageValidationContent (
+  IN VOID                               *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER      *Hdr,
+  IN CONST IMAGE_VALIDATION_DATA_HEADER *ImageValidationHdr
+);
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  belongs to a user page that is mapped inside MM and teh page attributes match the requirements specified
+  by the validation entry.
+
+  @param[in] TargetImage    The pointer to the target image buffer.
+  @param[in] Hdr            The header of the validation entry.
+  @param[in] PageTableBase  The base address of the page table.
+    
+  @returns EFI_SUCCESS             The target image passes the validation.
+  @returns EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
+  @returns EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
+  @returns EFI_SECURITY_VIOLATION  The target image does not meet the memory attribute requirements.
+**/
+EFI_STATUS
+PeCoffImageValidationMemAttr (
+  IN VOID                           *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN EFI_PHYSICAL_ADDRESS           PageTableBase
+);
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  matches the content in the original image buffer as specified by TargetOffset in the validation entry.
+
+  @param[in] TargetImage               The pointer to the target image buffer.
+  @param[in] Hdr                       The header of the validation entry.
+  @param[in] OriginalImageBaseAddress  The pointer to the original image buffer.
+
+  @return EFI_SUCCESS             The target image passes the validation.
+  @return EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @return EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
+**/
+EFI_STATUS
+PeCoffImageValidationSelfRef (
+  IN VOID                           *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN VOID                           *OriginalImageBaseAddress
+);
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  is a pointer, and that the pointer is not NULL.
+
+  @param[in] TargetImage               The pointer to the target image buffer.
+  @param[in] Hdr                       The header of the validation entry.
+
+  @return EFI_SUCCESS             The target image passes the validation.
+  @return EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @return EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
+**/
+EFI_STATUS
+PeCoffImageValidationPointer (
+  IN VOID                           *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+);
+
+#endif // BASE_PECOFF_VALIDATION_LIB_H_

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -30,6 +30,8 @@
   @param[in] Hdr          The header of the validation entry.
 
   @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
+  @retval EFI_INVALID_PARAMETER   The provided header has an invalid signature
   @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
 **/
 EFI_STATUS

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -31,7 +31,7 @@
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The provided header has an invalid signature
+  @retval EFI_COMPROMISED_DATA    The provided header has an invalid signature
   @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
 **/
 EFI_STATUS
@@ -51,7 +51,7 @@ PeCoffImageValidationNonZero (
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The provided header has an invalid signature
+  @retval EFI_COMPROMISED_DATA    The provided header has an invalid signature
   @retval EFI_COMPROMISED_DATA    The content to match against overflows the auxiliary file.
   @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image does not match the reference data.
 **/
@@ -74,9 +74,9 @@ PeCoffImageValidationContent (
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The validation entry has invalid signature.
   @retval EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
   @retval EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
+  @retval EFI_COMPROMISED_DATA   The validation entry has invalid signature.
   @retval EFI_SECURITY_VIOLATION  The target image does not meet the memory attribute requirements.
 **/
 EFI_STATUS
@@ -97,8 +97,8 @@ PeCoffImageValidationMemAttr (
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The validation entry has an invalid signature.
   @retval EFI_INVALID_PARAMETER   The validation entry has an invalid size.
+  @retval EFI_COMPROMISED_DATA    The validation entry has an invalid signature.
   @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS
@@ -118,8 +118,8 @@ PeCoffImageValidationSelfRef (
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The validation entry has invalid signature.
   @retval EFI_INVALID_PARAMETER   The validation entry has an invalid size.
+  @retval EFI_COMPROMISED_DATA    The validation entry has invalid signature.
   @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -1,7 +1,7 @@
 /** @file
   Defines function definitions for validating a loaded PE/COFF image post execution
-  against an auxiliary file (defined in SeaAuxiliary.h) that contains auxiliary
-  multiple validation entries. A validation entry specifies a specific region in the
+  against an auxiliary file (defined in SeaAuxiliary.h) that contains multiple
+  auxiliary validation entries. A validation entry specifies a specific region in the
   target image buffer to validate against, a validation type to perform, and any
   necessary data to assist in the validation.
 

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -19,8 +19,8 @@
 
 **/
 
-#ifndef BASE_PECOFF_VALIDATION_LIB_H_
-#define BASE_PECOFF_VALIDATION_LIB_H_
+#ifndef PECOFF_VALIDATION_LIB_H_
+#define PECOFF_VALIDATION_LIB_H_
 
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
@@ -29,10 +29,11 @@
   @param[in] TargetImage  The pointer to the target image buffer.
   @param[in] Hdr          The header of the validation entry.
 
-  @return EFI_SUCCESS             The target image passes the validation.
-  @return EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationNonZero (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
@@ -46,11 +47,12 @@ PeCoffImageValidationNonZero (
   @param[in] Hdr                 The header of the validation entry.
   @param[in] ImageValidationHdr  The pointer to the auxiliary file data buffer to assist.
 
-  @return EFI_SUCCESS             The target image passes the validation.
-  @return EFI_COMPROMISED_DATA    The content to match against overflows the auxiliary file.
-  @return EFI_SECURITY_VIOLATION  The specified buffer in the target image does not match the reference data.
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_COMPROMISED_DATA    The content to match against overflows the auxiliary file.
+  @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image does not match the reference data.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationContent (
   IN VOID                                *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER       *Hdr,
@@ -66,12 +68,13 @@ PeCoffImageValidationContent (
   @param[in] Hdr            The header of the validation entry.
   @param[in] PageTableBase  The base address of the page table.
 
-  @returns EFI_SUCCESS             The target image passes the validation.
-  @returns EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
-  @returns EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
-  @returns EFI_SECURITY_VIOLATION  The target image does not meet the memory attribute requirements.
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
+  @retval EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
+  @retval EFI_SECURITY_VIOLATION  The target image does not meet the memory attribute requirements.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationMemAttr (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
@@ -86,11 +89,12 @@ PeCoffImageValidationMemAttr (
   @param[in] Hdr                       The header of the validation entry.
   @param[in] OriginalImageBaseAddress  The pointer to the original image buffer.
 
-  @return EFI_SUCCESS             The target image passes the validation.
-  @return EFI_INVALID_PARAMETER   The validation entry has invalid size.
-  @return EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationSelfRef (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
@@ -101,17 +105,18 @@ PeCoffImageValidationSelfRef (
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
   is a pointer, and that the pointer is not NULL.
 
-  @param[in] TargetImage               The pointer to the target image buffer.
-  @param[in] Hdr                       The header of the validation entry.
+  @param[in] TargetImage  The pointer to the target image buffer.
+  @param[in] Hdr          The header of the validation entry.
 
-  @return EFI_SUCCESS             The target image passes the validation.
-  @return EFI_INVALID_PARAMETER   The validation entry has invalid size.
-  @return EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationPointer (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
   );
 
-#endif // BASE_PECOFF_VALIDATION_LIB_H_
+#endif // PECOFF_VALIDATION_LIB_H_

--- a/SeaPkg/Include/SeaAuxiliary.h
+++ b/SeaPkg/Include/SeaAuxiliary.h
@@ -39,10 +39,10 @@ typedef struct {
 
 typedef struct {
   UINT32    EntrySignature;
-  UINT32    Offset; // Offset to the start of the target image
-  UINT32    Size;   // Size of this entry
-  UINT32    ValidationType;
-  UINT32    OffsetToDefault;
+  UINT32    Offset;           // Offset to the data to validate in the loaded image.
+  UINT32    Size;             // Size (in bytes) of the data to validate in the loaded image.
+  UINT32    ValidationType;   // The Validation type to be performed on this data.
+  UINT32    OffsetToDefault;  // Offset to the default value in the aux file this header is contained in.
 } IMAGE_VALIDATION_ENTRY_HEADER;
 
 typedef struct {

--- a/SeaPkg/Include/SeaAuxiliary.h
+++ b/SeaPkg/Include/SeaAuxiliary.h
@@ -1,5 +1,5 @@
 /** @file -- SeaAuxiliary.h
-  Defines necessary structures and constants for parsing auxiliary data for 
+  Defines necessary structures and constants for parsing auxiliary data for
   PE/COFF image validation.
 
   Copyright (c) Microsoft Corporation.

--- a/SeaPkg/Include/SeaAuxiliary.h
+++ b/SeaPkg/Include/SeaAuxiliary.h
@@ -1,0 +1,67 @@
+/** @file -- SeaAuxiliary.h
+  Defines necessary structures and constants for parsing auxiliary data for 
+  PE/COFF image validation.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SEA_AUXILIARY_H_
+#define SEA_AUXILIARY_H_
+
+#define IMAGE_VALIDATION_ENTRY_TYPE_NONE      0x00000000
+#define IMAGE_VALIDATION_ENTRY_TYPE_NON_ZERO  0x00000001
+#define IMAGE_VALIDATION_ENTRY_TYPE_CONTENT   0x00000002
+#define IMAGE_VALIDATION_ENTRY_TYPE_MEM_ATTR  0x00000003
+#define IMAGE_VALIDATION_ENTRY_TYPE_SELF_REF  0x00000004
+#define IMAGE_VALIDATION_ENTRY_TYPE_POINTER   0x00000005
+
+#define IMAGE_VALIDATION_DATA_SIGNATURE   SIGNATURE_32 ('V', 'A', 'L', 'D')
+#define IMAGE_VALIDATION_ENTRY_SIGNATURE  SIGNATURE_32 ('E', 'N', 'T', 'R')
+
+#pragma pack(1)
+
+typedef struct {
+  UINT32    Signature;
+  UINT32    Offset;
+} KEY_SYMBOL;
+
+typedef struct {
+  UINT32    HeaderSignature;
+  UINT32    Size;
+  UINT32    EntryCount;
+  UINT32    OffsetToFirstEntry;
+  UINT32    OffsetToFirstDefault;
+  UINT32    KeySymbolCount;
+  UINT32    OffsetToFirstKeySymbol;
+} IMAGE_VALIDATION_DATA_HEADER;
+
+typedef struct {
+  UINT32    EntrySignature;
+  UINT32    Offset; // Offset to the start of the target image
+  UINT32    Size;   // Size of this entry
+  UINT32    ValidationType;
+  UINT32    OffsetToDefault;
+} IMAGE_VALIDATION_ENTRY_HEADER;
+
+typedef struct {
+  IMAGE_VALIDATION_ENTRY_HEADER    Header;
+  UINT8                            TargetContent[];
+} IMAGE_VALIDATION_CONTENT;
+
+typedef struct {
+  IMAGE_VALIDATION_ENTRY_HEADER    Header;
+  UINT64                           TargetMemorySize;
+  UINT64                           TargetMemoryAttributeMustHave;
+  UINT64                           TargetMemoryAttributeMustNotHave;
+} IMAGE_VALIDATION_MEM_ATTR;
+
+typedef struct {
+  IMAGE_VALIDATION_ENTRY_HEADER    Header;
+  UINT32                           TargetOffset;
+} IMAGE_VALIDATION_SELF_REF;
+
+#pragma pack()
+
+#endif // SEA_AUXILIARY_H_

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -740,11 +740,6 @@ PeCoffImageDiffValidation (
       return EFI_COMPROMISED_DATA;
     }
 
-    if (ImageValidationEntryHdr->EntrySignature != IMAGE_VALIDATION_ENTRY_SIGNATURE) {
-      DEBUG ((DEBUG_ERROR, "%a: Invalid current signature 0x%x at 0x%p\n", __func__, ImageValidationEntryHdr->EntrySignature, ImageValidationEntryHdr));
-      return EFI_COMPROMISED_DATA;
-    }
-
     if (ImageValidationEntryHdr->Offset + ImageValidationEntryHdr->Size > TargetImageSize) {
       DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%x exceeds target image limit 0x%x\n", __func__, ImageValidationEntryHdr->Offset + ImageValidationEntryHdr->Size, TargetImageSize));
       return EFI_INVALID_PARAMETER;

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -25,11 +25,13 @@
 
 #include <Uefi.h>
 #include <Base.h>
+#include <SeaAuxiliary.h>
 #include <Library/PeCoffLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/PeCoffExtraActionLib.h>
 #include <Library/SafeIntLib.h>
+#include <Library/PeCoffValidationLib.h>
 #include <Library/PeCoffLibNegative.h>
 #include <IndustryStandard/PeImage.h>
 
@@ -684,71 +686,6 @@ PeCoffLoaderImageNegativeReadFromMemory (
   return RETURN_SUCCESS;
 }
 
-EFI_STATUS
-EFIAPI
-GetMemoryAttributes (
-  IN  EFI_PHYSICAL_ADDRESS  PageTableBase,
-  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN  UINT64                Length,
-  OUT UINT64                *Attributes
-  );
-
-/**
-  Helper function that will evaluate the page where the input address is located belongs to a
-  user page that is mapped inside MM.
-
-  @param  Address           Target address to be inspected.
-  @param  Size              Address range to be inspected.
-  @param  IsUserRange       Pointer to hold inspection result, TRUE if the region is in User pages, FALSE if
-                            the page is in supervisor pages. Should not be used if return value is not EFI_SUCCESS.
-
-  @return     The result of inspection operation.
-
-**/
-EFI_STATUS
-InspectTargetRangeAttribute (
-  IN  EFI_PHYSICAL_ADDRESS  PageTableBase,
-  IN  EFI_PHYSICAL_ADDRESS  Address,
-  IN  UINTN                 Size,
-  OUT UINT64                *MemAttribute
-  )
-{
-  EFI_STATUS            Status;
-  EFI_PHYSICAL_ADDRESS  AlignedAddress;
-  UINT64                Attributes;
-
-  if ((Address < EFI_PAGE_SIZE) || (Size == 0) || (MemAttribute == NULL)) {
-    Status = EFI_INVALID_PARAMETER;
-    goto Done;
-  }
-
-  AlignedAddress = ALIGN_VALUE (Address - EFI_PAGE_SIZE + 1, EFI_PAGE_SIZE);
-
-  // To cover head portion from "Address" alignment adjustment
-  Status = SafeUintnAdd (Size, Address - AlignedAddress, &Size);
-  if (EFI_ERROR (Status)) {
-    goto Done;
-  }
-
-  // To cover the tail portion of requested buffer range
-  Status = SafeUintnAdd (Size, EFI_PAGE_SIZE - 1, &Size);
-  if (EFI_ERROR (Status)) {
-    goto Done;
-  }
-
-  Size &= ~(EFI_PAGE_SIZE - 1);
-
-  // Go through page table and grab the entry attribute
-  Status = GetMemoryAttributes (PageTableBase, AlignedAddress, Size, &Attributes);
-  if (!EFI_ERROR (Status)) {
-    *MemAttribute = Attributes;
-    goto Done;
-  }
-
-Done:
-  return Status;
-}
-
 /**
   Revert fixups and global data changes to an executed PE/COFF image that was loaded
   with PeCoffLoaderLoadImage() and relocated with PeCoffLoaderRelocateImage().
@@ -776,15 +713,8 @@ PeCoffImageDiffValidation (
   )
 {
   IMAGE_VALIDATION_ENTRY_HEADER  *ImageValidationEntryHdr;
-  IMAGE_VALIDATION_ENTRY_HEADER  *NextImageValidationEntryHdr;
-  IMAGE_VALIDATION_MEM_ATTR      *ImageValidationEntryMemAttr;
-  IMAGE_VALIDATION_SELF_REF      *ImageValidationEntrySelfRef;
-  IMAGE_VALIDATION_CONTENT       *ImageValidationEntryContent;
-  UINT64                         MemAttr;
   UINTN                          Index;
   EFI_STATUS                     Status;
-  EFI_PHYSICAL_ADDRESS           AddrInTarget;
-  EFI_PHYSICAL_ADDRESS           AddrInOrigin;
 
   if ((TargetImage == NULL) || (ImageValidationHdr == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid input pointers 0x%p and 0x%p\n", __func__, TargetImage, ImageValidationHdr));
@@ -834,162 +764,25 @@ PeCoffImageDiffValidation (
 
     switch (ImageValidationEntryHdr->ValidationType) {
       case IMAGE_VALIDATION_ENTRY_TYPE_NONE:
-        NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)(ImageValidationEntryHdr + 1);
-        Status                      = EFI_SUCCESS;
+        Status = EFI_SUCCESS;
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_NON_ZERO:
-        if (IsZeroBuffer ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryHdr->Size)) {
-          DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%p: 0x%x is all 0s\n", __func__, (UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryHdr->Size));
-          Status = EFI_SECURITY_VIOLATION;
-        } else {
-          NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)(ImageValidationEntryHdr + 1);
-        }
-
+        Status = PeCoffImageValidationNonZero(TargetImage, ImageValidationEntryHdr);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_CONTENT:
-        ImageValidationEntryContent = (IMAGE_VALIDATION_CONTENT *)(ImageValidationEntryHdr);
-        // Ensure "Content" in the header (TargetContent) does not overflow the Auxiliary file buffer.
-        if ((UINT8 *)ImageValidationEntryContent + sizeof (*ImageValidationEntryContent) + ImageValidationEntryHdr->Size > (UINT8 *)ImageValidationHdr + ImageValidationHdr->Size) {
-          DEBUG ((
-            DEBUG_ERROR,
-            "%a: Current entry range 0x%p: 0x%x exceeds reference data limit 0x%x\n",
-            __func__,
-            ImageValidationEntryContent,
-            sizeof (*ImageValidationEntryContent) + ImageValidationEntryHdr->Size,
-            ImageValidationHdr->Size
-            ));
-          Status = EFI_COMPROMISED_DATA;
-          break;
-        }
-
-        if (CompareMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryContent->TargetContent, ImageValidationEntryHdr->Size) != 0) {
-          DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%p: 0x%x does not match input content at 0x%p\n", __func__, ImageValidationEntryContent, ImageValidationEntryHdr->Size, ImageValidationEntryContent->TargetContent));
-          Status = EFI_SECURITY_VIOLATION;
-        } else {
-          NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)((UINT8 *)(ImageValidationEntryHdr + 1) + ImageValidationEntryHdr->Size);
-        }
-
+        Status = PeCoffImageValidationContent(TargetImage, ImageValidationEntryHdr, ImageValidationHdr);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_MEM_ATTR:
-        ImageValidationEntryMemAttr = (IMAGE_VALIDATION_MEM_ATTR *)(ImageValidationEntryHdr);
-        if ((ImageValidationEntryMemAttr->TargetMemoryAttributeMustHave == 0) && (ImageValidationEntryMemAttr->TargetMemoryAttributeMustNotHave == 0)) {
-          DEBUG ((
-            DEBUG_ERROR,
-            "%a: Current entry 0x%p has invalid must have 0x%x and must not have 0x%x\n",
-            __func__,
-            ImageValidationEntryMemAttr,
-            ImageValidationEntryMemAttr->TargetMemoryAttributeMustHave,
-            ImageValidationEntryMemAttr->TargetMemoryAttributeMustNotHave
-            ));
-          Status = EFI_COMPROMISED_DATA;
-          break;
-        }
-
-        // Inspection of the memory attributes of the target image
-        if (ImageValidationEntryHdr->Size > sizeof (AddrInTarget)) {
-          DEBUG ((
-            DEBUG_ERROR,
-            "%a: A new cfg entry is larger than a memory address!  Only pointers can have their memory attributes validated!  Address: %p, Address size: %x, Entry Size: %x\n",
-            __func__,
-            AddrInTarget,
-            sizeof (AddrInTarget),
-            ImageValidationEntryHdr->Size
-            ));
-          Status = EFI_BAD_BUFFER_SIZE;
-          break;
-        }
-
-        AddrInTarget = 0;
-        CopyMem (&AddrInTarget, (UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryHdr->Size);
-        Status = InspectTargetRangeAttribute (
-                   PageTableBase,
-                   AddrInTarget,
-                   ImageValidationEntryMemAttr->TargetMemorySize,
-                   &MemAttr
-                   );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((
-            DEBUG_ERROR,
-            "%a: Failed to read memory attribute of 0x%p: 0x%x for entry at 0x%p - %r\n",
-            __func__,
-            AddrInTarget,
-            ImageValidationEntryMemAttr->TargetMemorySize,
-            ImageValidationEntryMemAttr,
-            Status
-            ));
-          break;
-        }
-
-        // Check if the memory attributes of the target image meet the requirements
-        if (((MemAttr & ImageValidationEntryMemAttr->TargetMemoryAttributeMustHave) != ImageValidationEntryMemAttr->TargetMemoryAttributeMustHave) &&
-            ((MemAttr & ImageValidationEntryMemAttr->TargetMemoryAttributeMustNotHave) != 0))
-        {
-          DEBUG ((
-            DEBUG_ERROR,
-            "%a: Current entry range 0x%p: 0x%x attribute 0x%x violated aux file specification must have 0x%x and must not have 0x%x\n",
-            __func__,
-            ImageValidationEntryHdr,
-            ImageValidationEntryHdr->Size,
-            MemAttr,
-            ImageValidationEntryMemAttr->TargetMemoryAttributeMustHave,
-            ImageValidationEntryMemAttr->TargetMemoryAttributeMustNotHave
-            ));
-          Status = EFI_SECURITY_VIOLATION;
-        } else {
-          NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)(ImageValidationEntryMemAttr + 1);
-        }
-
+        Status = PeCoffImageValidationMemAttr(TargetImage, ImageValidationEntryHdr, PageTableBase);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_SELF_REF:
-        ImageValidationEntrySelfRef = (IMAGE_VALIDATION_SELF_REF *)(ImageValidationEntryHdr);
-        // For now, self reference is only valid for address type in x64 mode or below
-        if (ImageValidationEntrySelfRef->Header.Size > sizeof (EFI_PHYSICAL_ADDRESS)) {
-          DEBUG ((
-            DEBUG_ERROR,
-            "%a: Current entry 0x%p is self reference type but not 64 bit value %d\n",
-            __func__,
-            ImageValidationEntrySelfRef,
-            ImageValidationEntrySelfRef->Header.Size
-            ));
-          Status = EFI_INVALID_PARAMETER;
-          break;
-        }
-
-        // Check if the self-reference data of the target image meet the requirements
-        AddrInTarget = 0;
-        CopyMem (&AddrInTarget, (UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryHdr->Size);
-        AddrInOrigin = (EFI_PHYSICAL_ADDRESS)(UINTN)((UINT8 *)OriginalImageBaseAddress + ImageValidationEntrySelfRef->TargetOffset);
-        if (AddrInTarget != AddrInOrigin) {
-          DEBUG ((
-            DEBUG_ERROR,
-            "%a: Current entry at 0x%p regarding 0x%x should self reference 0x%x\n",
-            __func__,
-            ImageValidationEntryHdr,
-            AddrInTarget,
-            AddrInOrigin
-            ));
-          Status = EFI_SECURITY_VIOLATION;
-        } else {
-          NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)(ImageValidationEntrySelfRef + 1);
-        }
-
+        Status = PeCoffImageValidationSelfRef(TargetImage, ImageValidationEntryHdr, OriginalImageBaseAddress);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_POINTER:
-        if (ImageValidationEntryHdr->Size > sizeof (UINTN)) {
-          DEBUG ((DEBUG_ERROR, "%a: Current entry 0x%p is expected to be a pointer but has size 0x%x\n", __func__, ImageValidationEntryHdr, ImageValidationEntryHdr->Size));
-          Status = EFI_INVALID_PARAMETER;
-          break;
-        }
-
-        if ((UINT8 *)((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset) == NULL) {
-          DEBUG ((DEBUG_ERROR, "%a: Current entry 0x%p is a NULL ptr\n", __func__, ImageValidationEntryHdr));
-          Status = EFI_SECURITY_VIOLATION;
-          break;
-        }
-
-        NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)(ImageValidationEntryHdr + 1);
+        Status = PeCoffImageValidationPointer(TargetImage, ImageValidationEntryHdr);
         break;
       default:
+        Status = EFI_INVALID_PARAMETER;
         // Does not support unknown validation type
         DEBUG ((
           DEBUG_ERROR,
@@ -997,7 +790,6 @@ PeCoffImageDiffValidation (
           __func__,
           ImageValidationEntryHdr->ValidationType
           ));
-        Status = EFI_INVALID_PARAMETER;
         break;
     }
 
@@ -1008,7 +800,7 @@ PeCoffImageDiffValidation (
     // We should not do this when the above validation fails
     CopyMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, (UINT8 *)ImageValidationHdr + ImageValidationEntryHdr->OffsetToDefault, ImageValidationEntryHdr->Size);
 
-    ImageValidationEntryHdr = NextImageValidationEntryHdr;
+    ImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)((UINT8 *)ImageValidationEntryHdr + ImageValidationEntryHdr->Size);
   }
 
   return Status;

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -765,7 +765,8 @@ PeCoffImageDiffValidation (
 
     switch (ImageValidationEntryHdr->ValidationType) {
       case IMAGE_VALIDATION_ENTRY_TYPE_NONE:
-        Status = EFI_SUCCESS;
+        Status                      = EFI_SUCCESS;
+        NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)(ImageValidationEntryHdr + 1);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_NON_ZERO:
         Status                      = PeCoffImageValidationNonZero (TargetImage, ImageValidationEntryHdr);

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -767,19 +767,19 @@ PeCoffImageDiffValidation (
         Status = EFI_SUCCESS;
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_NON_ZERO:
-        Status = PeCoffImageValidationNonZero(TargetImage, ImageValidationEntryHdr);
+        Status = PeCoffImageValidationNonZero (TargetImage, ImageValidationEntryHdr);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_CONTENT:
-        Status = PeCoffImageValidationContent(TargetImage, ImageValidationEntryHdr, ImageValidationHdr);
+        Status = PeCoffImageValidationContent (TargetImage, ImageValidationEntryHdr, ImageValidationHdr);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_MEM_ATTR:
-        Status = PeCoffImageValidationMemAttr(TargetImage, ImageValidationEntryHdr, PageTableBase);
+        Status = PeCoffImageValidationMemAttr (TargetImage, ImageValidationEntryHdr, PageTableBase);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_SELF_REF:
-        Status = PeCoffImageValidationSelfRef(TargetImage, ImageValidationEntryHdr, OriginalImageBaseAddress);
+        Status = PeCoffImageValidationSelfRef (TargetImage, ImageValidationEntryHdr, OriginalImageBaseAddress);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_POINTER:
-        Status = PeCoffImageValidationPointer(TargetImage, ImageValidationEntryHdr);
+        Status = PeCoffImageValidationPointer (TargetImage, ImageValidationEntryHdr);
         break;
       default:
         Status = EFI_INVALID_PARAMETER;

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf
@@ -47,5 +47,6 @@
 [LibraryClasses]
   DebugLib
   PeCoffExtraActionLib
+  PeCoffValidationLib
   BaseMemoryLib
 

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -67,7 +67,7 @@ InspectTargetRangeAttribute (
   AlignedAddress = ALIGN_VALUE (Address - EFI_PAGE_SIZE + 1, EFI_PAGE_SIZE);
 
   // To cover head portion from "Address" alignment adjustment
-  Status = SafeUintnAdd (Size, Address - AlignedAddress, &Size);
+  Status = SafeUintnAdd (Size, (UINTN)(Address - AlignedAddress), &Size);
   if (EFI_ERROR (Status)) {
     goto Done;
   }
@@ -221,7 +221,7 @@ PeCoffImageValidationMemAttr (
 
   AddrInTarget = 0;
   CopyMem (&AddrInTarget, (UINT8 *)TargetImage + Hdr->Offset, Hdr->Size);
-  Status = InspectTargetRangeAttribute (PageTableBase, AddrInTarget, MemAttrHdr->TargetMemorySize, &MemAttr);
+  Status = InspectTargetRangeAttribute (PageTableBase, AddrInTarget, (UINTN)MemAttrHdr->TargetMemorySize, &MemAttr);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to read memory attribute of 0x%p: 0x%x for entry at 0x%p - %r\n", __func__, AddrInTarget, MemAttrHdr->TargetMemorySize, MemAttrHdr, Status));
     goto Done;

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -104,8 +104,8 @@ Done:
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationNonZero (
-  IN VOID                           *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
   )
 {
   EFI_STATUS  Status;
@@ -137,9 +137,9 @@ Done:
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationContent (
-  IN VOID                                *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER       *Hdr,
-  IN CONST IMAGE_VALIDATION_DATA_HEADER  *ImageValidationHdr
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN CONST IMAGE_VALIDATION_DATA_HEADER   *ImageValidationHdr
   )
 {
   IMAGE_VALIDATION_CONTENT  *ContentHdr;
@@ -189,9 +189,9 @@ Done:
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationMemAttr (
-  IN VOID                           *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
-  IN EFI_PHYSICAL_ADDRESS           PageTableBase
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN EFI_PHYSICAL_ADDRESS                 PageTableBase
   )
 {
   UINT64                     MemAttr;
@@ -257,9 +257,9 @@ Done:
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationSelfRef (
-  IN VOID                           *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
-  IN VOID                           *OriginalImageBaseAddress
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN CONST VOID                           *OriginalImageBaseAddress
   )
 {
   IMAGE_VALIDATION_SELF_REF  *SelfRefHdr;
@@ -318,8 +318,8 @@ Done:
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationPointer (
-  IN VOID                           *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+  IN CONST VOID                           *TargetImage,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
   )
 {
   EFI_STATUS  Status;

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -99,6 +99,8 @@ Done:
   @param[in] Hdr          The header of the validation entry.
 
   @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
+  @retval EFI_INVALID_PARAMETER   The provided header has an invalid signature
   @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
 **/
 EFI_STATUS

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -221,7 +221,7 @@ Done:
 
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
-  belongs to a user page that is mapped inside MM and teh page attributes match the requirements specified
+  belongs to a user page that is mapped inside MM and the page attributes match the requirements specified
   by the validation entry.
 
   @param[in] TargetImage    The pointer to the target image buffer.

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -207,7 +207,14 @@ PeCoffImageValidationMemAttr (
   }
 
   if (Hdr->Size > sizeof (AddrInTarget)) {
-    DEBUG ((DEBUG_ERROR, "%a: Current entry 0x%p has invalid size: 0x%x\n", __func__, Hdr, Hdr->Size));
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Current entry 0x%p has invalid size of0x%x, max is 0x%x\n",
+      __func__,
+      Hdr,
+      Hdr->Size,
+      sizeof (AddrInTarget)
+      ));
     Status = EFI_INVALID_PARAMETER;
     goto Done;
   }

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -38,11 +38,14 @@ GetMemoryAttributes (
 /**
   Helper function that will evaluate the page where the input address is located belongs to a
   user page that is mapped inside MM.
-  @param  Address           Target address to be inspected.
-  @param  Size              Address range to be inspected.
-  @param  IsUserRange       Pointer to hold inspection result, TRUE if the region is in User pages, FALSE if
-                            the page is in supervisor pages. Should not be used if return value is not EFI_SUCCESS.
-  @return     The result of inspection operation.
+
+  @param[in]  PageTableBase  The base address of the page table.
+  @param[in]  Address        Target address to be inspected.
+  @param[in]  Size           Address range to be inspected.
+  @param[out] MemAttribute   Pointer to hold inspection result, TRUE if the region is in User pages, FALSE if
+                             the page is in supervisor pages. Should not be used if return value is not EFI_SUCCESS.
+
+  @return The result of inspection operation.
 **/
 EFI_STATUS
 InspectTargetRangeAttribute (
@@ -91,12 +94,15 @@ Done:
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
   is not a zero buffer.
+
   @param[in] TargetImage  The pointer to the target image buffer.
   @param[in] Hdr          The header of the validation entry.
-  @return EFI_SUCCESS             The target image passes the validation.
-  @return EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
+
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationNonZero (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
@@ -124,11 +130,12 @@ Done:
   @param[in] Hdr                 The header of the validation entry.
   @param[in] ImageValidationHdr  The pointer to the auxiliary file data buffer to assist.
 
-  @return EFI_SUCCESS             The target image passes the validation.
-  @return EFI_COMPROMISED_DATA    The content to match against overflows the auxiliary file.
-  @return EFI_SECURITY_VIOLATION  The specified buffer in the target image does not match the reference data.
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_COMPROMISED_DATA    The content to match against overflows the auxiliary file.
+  @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image does not match the reference data.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationContent (
   IN VOID                                *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER       *Hdr,
@@ -169,16 +176,18 @@ Done:
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
   belongs to a user page that is mapped inside MM and teh page attributes match the requirements specified
   by the validation entry.
-    @param[in] TargetImage    The pointer to the target image buffer.
-    @param[in] Hdr            The header of the validation entry.
-    @param[in] PageTableBase  The base address of the page table.
 
-    @returns EFI_SUCCESS             The target image passes the validation.
-    @returns EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
-    @returns EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
-    @returns EFI_SECURITY_VIOLATION  The target image does not meet the memory attribute requirements.
+  @param[in] TargetImage    The pointer to the target image buffer.
+  @param[in] Hdr            The header of the validation entry.
+  @param[in] PageTableBase  The base address of the page table.
+
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
+  @retval EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
+  @retval EFI_SECURITY_VIOLATION  The target image does not meet the memory attribute requirements.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationMemAttr (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
@@ -234,11 +243,12 @@ Done:
   @param[in] Hdr                       The header of the validation entry.
   @param[in] OriginalImageBaseAddress  The pointer to the original image buffer.
 
-  @return EFI_SUCCESS             The target image passes the validation.
-  @return EFI_INVALID_PARAMETER   The validation entry has invalid size.
-  @return EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationSelfRef (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
@@ -291,14 +301,15 @@ Done:
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
   is a pointer, and that the pointer is not NULL.
 
-  @param[in] TargetImage               The pointer to the target image buffer.
-  @param[in] Hdr                       The header of the validation entry.
+  @param[in] TargetImage  The pointer to the target image buffer.
+  @param[in] Hdr          The header of the validation entry.
 
-  @return EFI_SUCCESS             The target image passes the validation.
-  @return EFI_INVALID_PARAMETER   The validation entry has invalid size.
-  @return EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
+  @retval EFI_SUCCESS             The target image passes the validation.
+  @retval EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS
+EFIAPI
 PeCoffImageValidationPointer (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -100,7 +100,7 @@ Done:
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The provided header has an invalid signature
+  @retval EFI_COMPROMISED_DATA    The provided header has an invalid signature
   @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
 **/
 EFI_STATUS
@@ -127,7 +127,7 @@ PeCoffImageValidationNonZero (
       Hdr->ValidationType,
       Hdr
       ));
-    Status = EFI_INVALID_PARAMETER;
+    Status = EFI_COMPROMISED_DATA;
     goto Done;
   }
 
@@ -153,7 +153,7 @@ Done:
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The provided header has an invalid signature
+  @retval EFI_COMPROMISED_DATA    The provided header has an invalid signature
   @retval EFI_COMPROMISED_DATA    The content to match against overflows the auxiliary file.
   @retval EFI_SECURITY_VIOLATION  The specified buffer in the target image does not match the reference data.
 **/
@@ -190,7 +190,7 @@ PeCoffImageValidationContent (
       Hdr->ValidationType,
       Hdr
       ));
-    Status = EFI_INVALID_PARAMETER;
+    Status = EFI_COMPROMISED_DATA;
     goto Done;
   }
 
@@ -232,9 +232,9 @@ Done:
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The validation entry has invalid signature.
   @retval EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
   @retval EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
+  @retval EFI_COMPROMISED_DATA   The validation entry has invalid signature.
   @retval EFI_SECURITY_VIOLATION  The target image does not meet the memory attribute requirements.
 **/
 EFI_STATUS
@@ -264,7 +264,7 @@ PeCoffImageValidationMemAttr (
 
   if ((Hdr->EntrySignature != IMAGE_VALIDATION_ENTRY_SIGNATURE) || (Hdr->ValidationType != IMAGE_VALIDATION_ENTRY_TYPE_MEM_ATTR)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid entry signature 0x%x or type 0x%x at 0x%p\n", __func__, Hdr->EntrySignature, Hdr->ValidationType, Hdr));
-    Status = EFI_INVALID_PARAMETER;
+    Status = EFI_COMPROMISED_DATA;
     goto Done;
   }
 
@@ -321,8 +321,8 @@ Done:
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The validation entry has an invalid signature.
   @retval EFI_INVALID_PARAMETER   The validation entry has an invalid size.
+  @retval EFI_COMPROMISED_DATA    The validation entry has an invalid signature.
   @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS
@@ -403,8 +403,8 @@ Done:
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
-  @retval EFI_INVALID_PARAMETER   The validation entry has invalid signature.
   @retval EFI_INVALID_PARAMETER   The validation entry has an invalid size.
+  @retval EFI_COMPROMISED_DATA    The validation entry has invalid signature.
   @retval EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
 **/
 EFI_STATUS
@@ -430,7 +430,7 @@ PeCoffImageValidationPointer (
 
   if ((Hdr->EntrySignature != IMAGE_VALIDATION_ENTRY_SIGNATURE) || (Hdr->ValidationType != IMAGE_VALIDATION_ENTRY_TYPE_POINTER)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid entry signature 0x%x or type 0x%x at 0x%p\n", __func__, Hdr->EntrySignature, Hdr->ValidationType, Hdr));
-    Status = EFI_INVALID_PARAMETER;
+    Status = EFI_COMPROMISED_DATA;
     goto Done;
   }
 

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -42,8 +42,8 @@ GetMemoryAttributes (
   @param[in]  PageTableBase  The base address of the page table.
   @param[in]  Address        Target address to be inspected.
   @param[in]  Size           Address range to be inspected.
-  @param[out] MemAttribute   Pointer to hold inspection result, TRUE if the region is in User pages, FALSE if
-                             the page is in supervisor pages. Should not be used if return value is not EFI_SUCCESS.
+  @param[out] MemAttribute   Pointer to hold inspection result. Should not be used if return
+                             value is not EFI_SUCCESS.
 
   @return The result of inspection operation.
 **/

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -201,7 +201,7 @@ PeCoffImageValidationMemAttr (
 
   MemAttrHdr = (IMAGE_VALIDATION_MEM_ATTR *)Hdr;
   if ((MemAttrHdr->TargetMemoryAttributeMustHave == 0) && (MemAttrHdr->TargetMemoryAttributeMustNotHave == 0)) {
-    DEBUG ((DEBUG_ERROR, "%a: Current entry 0x%p has invalid must have 0x%x and must not have 0x%x\n", __func__, MemAttrHdr, MemAttrHdr->TargetMemoryAttributeMustHave, MemAttrHdr->TargetMemoryAttributeMustNotHave));
+    DEBUG ((DEBUG_ERROR, "%a: Entry 0x%p cannot have zero for must and must not have attribute values\n", __func__, MemAttrHdr));
     Status = EFI_INVALID_PARAMETER;
     goto Done;
   }

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -118,7 +118,7 @@ PeCoffImageValidationNonZero (
     goto Done;
   }
 
-  if ((Hdr->EntrySignature != IMAGE_VALIDATION_ENTRY_SIGNATURE) || (Hdr->EntrySignature != IMAGE_VALIDATION_ENTRY_TYPE_NON_ZERO)) {
+  if ((Hdr->EntrySignature != IMAGE_VALIDATION_ENTRY_SIGNATURE) || (Hdr->ValidationType != IMAGE_VALIDATION_ENTRY_TYPE_NON_ZERO)) {
     DEBUG ((
       DEBUG_ERROR,
       "%a: Invalid entry signature 0x%x or type 0x%x at 0x%p\n",

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -1,7 +1,7 @@
 /** @file
   Defines function definitions for validating a loaded PE/COFF image post execution
-  against an auxiliary file (defined in SeaAuxiliary.h) that contains auxiliary
-  multiple validation entries. A validation entry specifies a specific region in the
+  against an auxiliary file (defined in SeaAuxiliary.h) that contains multiple
+  auxiliary validation entries. A validation entry specifies a specific region in the
   target image buffer to validate against, a validation type to perform, and any
   necessary data to assist in the validation.
 

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf
@@ -1,5 +1,5 @@
 ## @file
-#  PE/COFF Image Validation Library implementation.
+#  SEA PE/COFF Image Validation Library implementation.
 #
 #  Copyright (c) Microsoft Corporation.
 #
@@ -19,7 +19,7 @@
 #
 
 [Sources]
-  Validation.c
+  BasePeCoffValidationLib.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf
@@ -1,0 +1,30 @@
+## @file
+#  PE/COFF Image Validation Library implementation.
+#
+#  Copyright (c) Microsoft Corporation.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = BasePeCoffValidationLib
+  FILE_GUID                      = CD335760-582B-4373-9A3A-9E6721EF2C96
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PeCoffValidationLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC ARM AARCH64
+#
+
+[Sources]
+  Validation.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SeaPkg/SeaPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  BaseMemoryLib

--- a/SeaPkg/Library/BasePeCoffValidationLib/Validation.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/Validation.c
@@ -4,7 +4,7 @@
   multiple validation entries. A validation entry specifies a specific region in the
   target image buffer to validate against, a validation type to perform, and any
   necessary data to assist in the validation.
-  
+
   There currently exists five validation types:
   - Non-Zero: Validates that the specified region in the target image buffer is not all zero.
   - Content: Validates that the specified region in the target image buffer matches the content in the reference data.
@@ -100,9 +100,9 @@ EFI_STATUS
 PeCoffImageValidationNonZero (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
-)
+  )
 {
-  EFI_STATUS Status;
+  EFI_STATUS  Status;
 
   if (IsZeroBuffer ((UINT8 *)TargetImage + Hdr->Offset, Hdr->Size)) {
     DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%p: 0x%x is all 0s\n", __func__, (UINT8 *)TargetImage + Hdr->Offset, Hdr->Size));
@@ -112,8 +112,8 @@ PeCoffImageValidationNonZero (
 
   Status = EFI_SUCCESS;
 
-  Done:
-    return Status;
+Done:
+  return Status;
 }
 
 /**
@@ -130,13 +130,13 @@ PeCoffImageValidationNonZero (
 **/
 EFI_STATUS
 PeCoffImageValidationContent (
-  IN VOID                               *TargetImage,
-  IN IMAGE_VALIDATION_ENTRY_HEADER      *Hdr,
-  IN CONST IMAGE_VALIDATION_DATA_HEADER *ImageValidationHdr
-)
+  IN VOID                                *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER       *Hdr,
+  IN CONST IMAGE_VALIDATION_DATA_HEADER  *ImageValidationHdr
+  )
 {
-  IMAGE_VALIDATION_CONTENT *ContentHdr;
-  EFI_STATUS               Status;
+  IMAGE_VALIDATION_CONTENT  *ContentHdr;
+  EFI_STATUS                Status;
 
   ContentHdr = (IMAGE_VALIDATION_CONTENT *)Hdr;
   // Ensure "Content" in the header (TargetContent) does not overflow the Auxiliary file buffer.
@@ -161,8 +161,8 @@ PeCoffImageValidationContent (
 
   Status = EFI_SUCCESS;
 
-  Done:
-    return Status;
+Done:
+  return Status;
 }
 
 /**
@@ -172,7 +172,7 @@ PeCoffImageValidationContent (
     @param[in] TargetImage    The pointer to the target image buffer.
     @param[in] Hdr            The header of the validation entry.
     @param[in] PageTableBase  The base address of the page table.
-    
+
     @returns EFI_SUCCESS             The target image passes the validation.
     @returns EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
     @returns EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
@@ -183,7 +183,7 @@ PeCoffImageValidationMemAttr (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
   IN EFI_PHYSICAL_ADDRESS           PageTableBase
-)
+  )
 {
   UINT64                     MemAttr;
   IMAGE_VALIDATION_MEM_ATTR  *MemAttrHdr;
@@ -222,8 +222,8 @@ PeCoffImageValidationMemAttr (
 
   Status = EFI_SUCCESS;
 
-  Done:
-    return Status;
+Done:
+  return Status;
 }
 
 /**
@@ -243,13 +243,13 @@ PeCoffImageValidationSelfRef (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
   IN VOID                           *OriginalImageBaseAddress
-)
+  )
 {
-  IMAGE_VALIDATION_SELF_REF *SelfRefHdr;
-  EFI_STATUS Status;
-  EFI_PHYSICAL_ADDRESS AddrInTarget;
-  EFI_PHYSICAL_ADDRESS AddrInOrigin;
-  
+  IMAGE_VALIDATION_SELF_REF  *SelfRefHdr;
+  EFI_STATUS                 Status;
+  EFI_PHYSICAL_ADDRESS       AddrInTarget;
+  EFI_PHYSICAL_ADDRESS       AddrInOrigin;
+
   SelfRefHdr = (IMAGE_VALIDATION_SELF_REF *)Hdr;
   // For now, self reference is only valid for address type in x64 mode or below
   if (Hdr->Size > sizeof (EFI_PHYSICAL_ADDRESS)) {
@@ -259,7 +259,7 @@ PeCoffImageValidationSelfRef (
       __func__,
       SelfRefHdr,
       Hdr->Size
-    ));
+      ));
     Status = EFI_INVALID_PARAMETER;
     goto Done;
   }
@@ -276,17 +276,16 @@ PeCoffImageValidationSelfRef (
       Hdr,
       AddrInTarget,
       AddrInOrigin
-    ));
+      ));
     Status = EFI_SECURITY_VIOLATION;
     goto Done;
   }
 
   Status = EFI_SUCCESS;
 
-  Done:
-    return Status;
+Done:
+  return Status;
 }
-
 
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
@@ -303,9 +302,9 @@ EFI_STATUS
 PeCoffImageValidationPointer (
   IN VOID                           *TargetImage,
   IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
-)
+  )
 {
-  EFI_STATUS Status;
+  EFI_STATUS  Status;
 
   if (Hdr->Size > sizeof (UINTN)) {
     DEBUG ((DEBUG_ERROR, "%a: Current entry 0x%p is expected to be a pointer but has size 0x%x\n", __func__, Hdr, Hdr->Size));
@@ -321,6 +320,6 @@ PeCoffImageValidationPointer (
 
   Status = EFI_SUCCESS;
 
-  Done:
-    return Status;
+Done:
+  return Status;
 }

--- a/SeaPkg/Library/BasePeCoffValidationLib/Validation.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/Validation.c
@@ -1,0 +1,326 @@
+/** @file
+  Defines function definitions for validating a loaded PE/COFF image post execution
+  against an auxiliary file (defined in SeaAuxiliary.h) that contains auxiliary
+  multiple validation entries. A validation entry specifies a specific region in the
+  target image buffer to validate against, a validation type to perform, and any
+  necessary data to assist in the validation.
+  
+  There currently exists five validation types:
+  - Non-Zero: Validates that the specified region in the target image buffer is not all zero.
+  - Content: Validates that the specified region in the target image buffer matches the content in the reference data.
+  - MemAttr: Validates that the specified region in the target image buffer belongs to a user page that is mapped inside MM
+             and the page attributes match the requirements specified by the validation entry.
+  - SelfRef: Validates that the specified region in the target image buffer matches the content in the original image buffer as
+             specified by TargetOffset in the validation entry.
+  - Pointer: Validates that the specified region in the target image buffer is a pointer, and that the pointer is not NULL.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Uefi.h>
+#include <Base.h>
+#include <SeaAuxiliary.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PeCoffValidationLib.h>
+#include <Library/SafeIntLib.h>
+
+EFI_STATUS
+EFIAPI
+GetMemoryAttributes (
+  IN  EFI_PHYSICAL_ADDRESS  PageTableBase,
+  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN  UINT64                Length,
+  OUT UINT64                *Attributes
+  );
+
+/**
+  Helper function that will evaluate the page where the input address is located belongs to a
+  user page that is mapped inside MM.
+  @param  Address           Target address to be inspected.
+  @param  Size              Address range to be inspected.
+  @param  IsUserRange       Pointer to hold inspection result, TRUE if the region is in User pages, FALSE if
+                            the page is in supervisor pages. Should not be used if return value is not EFI_SUCCESS.
+  @return     The result of inspection operation.
+**/
+EFI_STATUS
+InspectTargetRangeAttribute (
+  IN  EFI_PHYSICAL_ADDRESS  PageTableBase,
+  IN  EFI_PHYSICAL_ADDRESS  Address,
+  IN  UINTN                 Size,
+  OUT UINT64                *MemAttribute
+  )
+{
+  EFI_STATUS            Status;
+  EFI_PHYSICAL_ADDRESS  AlignedAddress;
+  UINT64                Attributes;
+
+  if ((Address < EFI_PAGE_SIZE) || (Size == 0) || (MemAttribute == NULL)) {
+    Status = EFI_INVALID_PARAMETER;
+    goto Done;
+  }
+
+  AlignedAddress = ALIGN_VALUE (Address - EFI_PAGE_SIZE + 1, EFI_PAGE_SIZE);
+
+  // To cover head portion from "Address" alignment adjustment
+  Status = SafeUintnAdd (Size, Address - AlignedAddress, &Size);
+  if (EFI_ERROR (Status)) {
+    goto Done;
+  }
+
+  // To cover the tail portion of requested buffer range
+  Status = SafeUintnAdd (Size, EFI_PAGE_SIZE - 1, &Size);
+  if (EFI_ERROR (Status)) {
+    goto Done;
+  }
+
+  Size &= ~(EFI_PAGE_SIZE - 1);
+
+  // Go through page table and grab the entry attribute
+  Status = GetMemoryAttributes (PageTableBase, AlignedAddress, Size, &Attributes);
+  if (!EFI_ERROR (Status)) {
+    *MemAttribute = Attributes;
+    goto Done;
+  }
+
+Done:
+  return Status;
+}
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  is not a zero buffer.
+  @param[in] TargetImage  The pointer to the target image buffer.
+  @param[in] Hdr          The header of the validation entry.
+  @return EFI_SUCCESS             The target image passes the validation.
+  @return EFI_SECURITY_VIOLATION  The specified buffer in the target image is all zero.
+**/
+EFI_STATUS
+PeCoffImageValidationNonZero (
+  IN VOID                           *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+)
+{
+  EFI_STATUS Status;
+
+  if (IsZeroBuffer ((UINT8 *)TargetImage + Hdr->Offset, Hdr->Size)) {
+    DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%p: 0x%x is all 0s\n", __func__, (UINT8 *)TargetImage + Hdr->Offset, Hdr->Size));
+    Status = EFI_SECURITY_VIOLATION;
+    goto Done;
+  }
+
+  Status = EFI_SUCCESS;
+
+  Done:
+    return Status;
+}
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  is the same as the content in the reference data.
+
+  @param[in] TargetImage         The pointer to the target image buffer.
+  @param[in] Hdr                 The header of the validation entry.
+  @param[in] ImageValidationHdr  The pointer to the auxiliary file data buffer to assist.
+
+  @return EFI_SUCCESS             The target image passes the validation.
+  @return EFI_COMPROMISED_DATA    The content to match against overflows the auxiliary file.
+  @return EFI_SECURITY_VIOLATION  The specified buffer in the target image does not match the reference data.
+**/
+EFI_STATUS
+PeCoffImageValidationContent (
+  IN VOID                               *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER      *Hdr,
+  IN CONST IMAGE_VALIDATION_DATA_HEADER *ImageValidationHdr
+)
+{
+  IMAGE_VALIDATION_CONTENT *ContentHdr;
+  EFI_STATUS               Status;
+
+  ContentHdr = (IMAGE_VALIDATION_CONTENT *)Hdr;
+  // Ensure "Content" in the header (TargetContent) does not overflow the Auxiliary file buffer.
+  if ((UINT8 *)ContentHdr + sizeof (*ContentHdr) + Hdr->Size > (UINT8 *)ImageValidationHdr + ImageValidationHdr->Size) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Current entry range 0x%p: 0x%x exceeds reference data limit 0x%x\n",
+      __func__,
+      ContentHdr,
+      sizeof (*ContentHdr) + Hdr->Size,
+      (UINT8 *)ImageValidationHdr + ImageValidationHdr->Size
+      ));
+    Status = EFI_COMPROMISED_DATA;
+    goto Done;
+  }
+
+  if (CompareMem ((UINT8 *)TargetImage + Hdr->Offset, ContentHdr->TargetContent, Hdr->Size) != 0) {
+    DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%p: 0x%x does not match input content at 0x%p\n", __func__, ContentHdr, Hdr->Size, ContentHdr->TargetContent));
+    Status = EFI_SECURITY_VIOLATION;
+    goto Done;
+  }
+
+  Status = EFI_SUCCESS;
+
+  Done:
+    return Status;
+}
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  belongs to a user page that is mapped inside MM and teh page attributes match the requirements specified
+  by the validation entry.
+    @param[in] TargetImage    The pointer to the target image buffer.
+    @param[in] Hdr            The header of the validation entry.
+    @param[in] PageTableBase  The base address of the page table.
+    
+    @returns EFI_SUCCESS             The target image passes the validation.
+    @returns EFI_INVALID_PARAMETER   The validation entry has invalid must have and must not have attributes.
+    @returns EFI_INVALID_PARAMETER   The validation entry data size is invalid. It must be a pointer size.
+    @returns EFI_SECURITY_VIOLATION  The target image does not meet the memory attribute requirements.
+**/
+EFI_STATUS
+PeCoffImageValidationMemAttr (
+  IN VOID                           *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN EFI_PHYSICAL_ADDRESS           PageTableBase
+)
+{
+  UINT64                     MemAttr;
+  IMAGE_VALIDATION_MEM_ATTR  *MemAttrHdr;
+  EFI_PHYSICAL_ADDRESS       AddrInTarget;
+  EFI_STATUS                 Status;
+
+  MemAttrHdr = (IMAGE_VALIDATION_MEM_ATTR *)Hdr;
+  if ((MemAttrHdr->TargetMemoryAttributeMustHave == 0) && (MemAttrHdr->TargetMemoryAttributeMustNotHave == 0)) {
+    DEBUG ((DEBUG_ERROR, "%a: Current entry 0x%p has invalid must have 0x%x and must not have 0x%x\n", __func__, MemAttrHdr, MemAttrHdr->TargetMemoryAttributeMustHave, MemAttrHdr->TargetMemoryAttributeMustNotHave));
+    Status = EFI_INVALID_PARAMETER;
+    goto Done;
+  }
+
+  if (Hdr->Size > sizeof (AddrInTarget)) {
+    DEBUG ((DEBUG_ERROR, "%a: Current entry 0x%p has invalid size: 0x%x\n", __func__, Hdr, Hdr->Size));
+    Status = EFI_INVALID_PARAMETER;
+    goto Done;
+  }
+
+  AddrInTarget = 0;
+  CopyMem (&AddrInTarget, (UINT8 *)TargetImage + Hdr->Offset, Hdr->Size);
+  Status = InspectTargetRangeAttribute (PageTableBase, AddrInTarget, MemAttrHdr->TargetMemorySize, &MemAttr);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to read memory attribute of 0x%p: 0x%x for entry at 0x%p - %r\n", __func__, AddrInTarget, MemAttrHdr->TargetMemorySize, MemAttrHdr, Status));
+    goto Done;
+  }
+
+  // Check if the memory attributes of the target image meet the requirements
+  if (((MemAttr & MemAttrHdr->TargetMemoryAttributeMustHave) != MemAttrHdr->TargetMemoryAttributeMustHave) &&
+      ((MemAttr & MemAttrHdr->TargetMemoryAttributeMustNotHave) != 0))
+  {
+    DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%p: 0x%x attribute 0x%x violated aux file specification must have 0x%x and must not have 0x%x\n", __func__, Hdr, Hdr->Size, MemAttr, MemAttrHdr->TargetMemoryAttributeMustHave, MemAttrHdr->TargetMemoryAttributeMustNotHave));
+    Status = EFI_SECURITY_VIOLATION;
+    goto Done;
+  }
+
+  Status = EFI_SUCCESS;
+
+  Done:
+    return Status;
+}
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  matches the content in the original image buffer as specified by TargetOffset in the validation entry.
+
+  @param[in] TargetImage               The pointer to the target image buffer.
+  @param[in] Hdr                       The header of the validation entry.
+  @param[in] OriginalImageBaseAddress  The pointer to the original image buffer.
+
+  @return EFI_SUCCESS             The target image passes the validation.
+  @return EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @return EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
+**/
+EFI_STATUS
+PeCoffImageValidationSelfRef (
+  IN VOID                           *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN VOID                           *OriginalImageBaseAddress
+)
+{
+  IMAGE_VALIDATION_SELF_REF *SelfRefHdr;
+  EFI_STATUS Status;
+  EFI_PHYSICAL_ADDRESS AddrInTarget;
+  EFI_PHYSICAL_ADDRESS AddrInOrigin;
+  
+  SelfRefHdr = (IMAGE_VALIDATION_SELF_REF *)Hdr;
+  // For now, self reference is only valid for address type in x64 mode or below
+  if (Hdr->Size > sizeof (EFI_PHYSICAL_ADDRESS)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Current entry 0x%p is self reference type but not 64 bit value %d\n",
+      __func__,
+      SelfRefHdr,
+      Hdr->Size
+    ));
+    Status = EFI_INVALID_PARAMETER;
+    goto Done;
+  }
+
+  AddrInTarget = 0;
+  CopyMem (&AddrInTarget, (UINT8 *)TargetImage + Hdr->Offset, Hdr->Size);
+  AddrInOrigin = (EFI_PHYSICAL_ADDRESS)(UINTN)((UINT8 *)OriginalImageBaseAddress + SelfRefHdr->TargetOffset);
+
+  if (AddrInTarget != AddrInOrigin) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Current entry at 0x%p regarding 0x%x should self reference 0x%x\n",
+      __func__,
+      Hdr,
+      AddrInTarget,
+      AddrInOrigin
+    ));
+    Status = EFI_SECURITY_VIOLATION;
+    goto Done;
+  }
+
+  Status = EFI_SUCCESS;
+
+  Done:
+    return Status;
+}
+
+
+/**
+  Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
+  is a pointer, and that the pointer is not NULL.
+
+  @param[in] TargetImage               The pointer to the target image buffer.
+  @param[in] Hdr                       The header of the validation entry.
+
+  @return EFI_SUCCESS             The target image passes the validation.
+  @return EFI_INVALID_PARAMETER   The validation entry has invalid size.
+  @return EFI_SECURITY_VIOLATION  The target image does not match the content in the original image buffer.
+**/
+EFI_STATUS
+PeCoffImageValidationPointer (
+  IN VOID                           *TargetImage,
+  IN IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+)
+{
+  EFI_STATUS Status;
+
+  if (Hdr->Size > sizeof (UINTN)) {
+    DEBUG ((DEBUG_ERROR, "%a: Current entry 0x%p is expected to be a pointer but has size 0x%x\n", __func__, Hdr, Hdr->Size));
+    Status = EFI_INVALID_PARAMETER;
+    goto Done;
+  }
+
+  if ((UINT8 *)((UINT8 *)TargetImage + Hdr->Offset) == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Current entry 0x%p is a NULL ptr\n", __func__, Hdr));
+    Status = EFI_SECURITY_VIOLATION;
+    goto Done;
+  }
+
+  Status = EFI_SUCCESS;
+
+  Done:
+    return Status;
+}

--- a/SeaPkg/SeaPkg.dec
+++ b/SeaPkg/SeaPkg.dec
@@ -30,6 +30,7 @@
 [LibraryClasses]
   HashLibRaw|Include/Library/HashLibRaw.h
   PeCoffLibNegative|Include/Library/PeCoffLibNegative.h
+  PeCoffValidationLib|Include/Library/PeCoffValidationLib.h
   SeaManifestPublicationLib|Include/Library/SeaManifestPublicationLib.h
   StmLib|Include/Library/StmLib.h
   StmPlatformLib|Include/Library/StmPlatformLib.h

--- a/SeaPkg/SeaPkg.dsc
+++ b/SeaPkg/SeaPkg.dsc
@@ -34,6 +34,7 @@
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   UnitTestLib|UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
+  PeCoffValidationLib|SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf
 
 [LibraryClasses.common.PEIM]
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf

--- a/SeaPkg/SeaPkg.dsc
+++ b/SeaPkg/SeaPkg.dsc
@@ -91,6 +91,7 @@
   SeaPkg/Library/StmPlatformLibNull/StmPlatformLibNull.inf
   SeaPkg/Library/BaseSeaManifestPublicationLibNull/BaseSeaManifestPublicationLibNull.inf
   SeaPkg/Library/DxeSeaManifestPublicationLibConfigTable/DxeSeaManifestPublicationLibConfigTable.inf
+  SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf
 
 [Components.X64]
   SeaPkg/Core/Stm.inf {


### PR DESCRIPTION
## Description

Breaks away the image validation into a standalone library, exposing the validation functions to be easily testable.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Passed the TestApp

## Integration Instructions

Platforms will need to add `PeCoffValidationLib|SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf` to their DSC