### PR TITLE
MmSupervisorPkg/SmmCpuMemoryManagement: Print invalid address points

### DIFF
--- a/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
+++ b/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
@@ -1780,6 +1780,9 @@ CompareAddressPoint (
            ((MEMORY_ADDRESS_POINT *)Buffer2)->Type;
   }
 
+  DEBUG ((DEBUG_ERROR, "%a - Identical Address Point Detected!!!\n", __func__));
+  DEBUG ((DEBUG_ERROR, "Address(0x%0lx) Type(0x%x)\n", ((MEMORY_ADDRESS_POINT *)Buffer1)->Address, ((MEMORY_ADDRESS_POINT *)Buffer1)->Type));
+
   // This should not happen that resource hob has 2 identical address points
   ASSERT (FALSE);
   return 0;


### PR DESCRIPTION
## Description

If an address point is found to be invalid, print the address info
prior to asserting to improve debug.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Describe duplicate MMIO resources so the message will print.

## Integration Instructions

- N/A