### PR TITLE
[REBASE&FF] Add Pointer validation customization for `in_mseg`

### DIFF
--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -111,10 +111,13 @@ PeCoffImageValidationSelfRef (
 
 /**
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
-  is a pointer, and that the pointer is not NULL.
+  is a pointer, and that the pointer is not NULL. Will validate if the pointer is within the MSEG, which will
+  pass or fail based on the validation entry's `in_mseg` field.
 
   @param[in] TargetImage  The pointer to the target image buffer.
   @param[in] Hdr          The header of the validation entry.
+  @param[in] MsegBase     The base address of the MSEG.
+  @param[in] MsegSize     The size of the MSEG.
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
@@ -126,7 +129,9 @@ EFI_STATUS
 EFIAPI
 PeCoffImageValidationPointer (
   IN CONST VOID                           *TargetImage,
-  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN EFI_PHYSICAL_ADDRESS                 MsegBase,
+  IN UINTN                                MsegSize
   );
 
 #endif // PECOFF_VALIDATION_LIB_H_

--- a/SeaPkg/Include/SeaAuxiliary.h
+++ b/SeaPkg/Include/SeaAuxiliary.h
@@ -62,6 +62,11 @@ typedef struct {
   UINT32                           TargetOffset;
 } IMAGE_VALIDATION_SELF_REF;
 
+typedef struct {
+  IMAGE_VALIDATION_ENTRY_HEADER    Header;
+  UINT32                           InMseg;
+} IMAGE_VALIDATION_POINTER;
+
 #pragma pack()
 
 #endif // SEA_AUXILIARY_H_

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -130,6 +130,7 @@ such as not being null.
 
 ``` toml
 validation.type = "pointer"
+validation.in_mseg = true # Default: false
 ```
 
 ### config

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -158,7 +158,9 @@ impl <'a> ctx::TryIntoCtx<Endian> for &ImageValidationEntryHeader {
                     return Err(scroll::Error::Custom("SELF validation type must have an address".to_string()))
                 }
             },
-            ValidationType::Pointer => {},
+            ValidationType::Pointer{in_mseg} => {
+                this.gwrite(*in_mseg as u32, &mut offset)?;
+            },
         }
         Ok(offset)
     }
@@ -187,7 +189,7 @@ impl ImageValidationEntryHeader {
             ValidationType::Content{content} => content.len() as u32,
             ValidationType::MemAttr {..} => 24,
             ValidationType::Ref{..} => 4,
-            ValidationType::Pointer => 0,
+            ValidationType::Pointer{..} => 4,
         }
     }
 }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
@@ -146,7 +146,10 @@ pub enum ValidationType {
     Ref{reference: Option<String>, address: Option<u32>} = 4,
     /// Firmware will validate that the symbol is a pointer and is not null
     #[serde(alias = "POINTER", alias = "pointer")]
-    Pointer = 5,
+    Pointer{
+        #[serde(default = "Default::default")]
+        in_mseg: bool
+    } = 5,
 }
 
 impl Into<u32> for &ValidationType {


### PR DESCRIPTION
## Description

Adds a new customization to the pointer validation type that will validate if the pointer is in MSEG or not.

if `in_mseg` == `true`, then the pointer must be in MSEG
if `in_mseg` != `true`, then the pointer must *not* be in MSEG

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

Consumers must update any `Pointer` rules and set `in_mseg` if the pointer is expected to be in MSEG.

```toml
validation.type = "pointer"
validation.in_mseg = true
```
