### PR TITLE
gen_aux: Add rule coverage report

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
+++ b/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
@@ -155,6 +155,11 @@ class GenSeaArtifacts(IUefiHelperPlugin):
                 output_dir / "MmSupervisorCore.aux"
             )
 
+            shutil.copy2(
+                stm_build_dir / "MmSupervisorCore.json",
+                misc_dir / "MmSupervisorCore.json"
+            )
+
             # Copy over MmSupervisorCore artifacts
             shutil.copy2(
                 mm_supervisor_build_dir / "MmSupervisorCore.efi",

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
@@ -16,4 +16,5 @@ goblin = "0.8.0"
 pdb = "0.8.0"
 scroll = { version = "0.12.0", features = ["derive"] }
 serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.140"
 toml = "0.8.10"

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -177,7 +177,11 @@ impl ImageValidationEntryHeader {
         entry.offset = ((symbol.address as i64) + rule.offset.unwrap_or_default()) as u32;
         entry.size = rule.size.unwrap_or(symbol.size);
         entry.validation_type = rule.validation.clone();
-        entry.symbol = symbol.name.clone();
+        if let Some(ref field) = rule.field {
+            entry.symbol = format!("{}.{}", &rule.symbol, field);
+        } else {
+            entry.symbol = rule.symbol.clone();
+        }
         entry
     }
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -99,16 +99,19 @@ impl Default for ImageValidationDataHeader {
 /// 
 #[derive(Clone)]
 pub struct ImageValidationEntryHeader {
-    signature: u32,
+    pub signature: u32,
     /// Offset of the value in the original image.
-    offset: u32,
+    pub offset: u32,
     /// Size of the value in bytes.
-    size: u32,
+    pub size: u32,
     /// The type of validation to perform on the symbol. Contains the data
     /// necessary to perform the validation.
-    validation_type: ValidationType,
+    pub validation_type: ValidationType,
     /// Offset of the default value in the aux file.
-    offset_to_default: u32
+    pub offset_to_default: u32,
+    /// The symbol name that this entry is for. This is not written to the aux
+    /// file, but exists for debugging purposes.
+    pub symbol: String,
 }
 
 impl Default for ImageValidationEntryHeader {
@@ -118,7 +121,8 @@ impl Default for ImageValidationEntryHeader {
             offset: 0,
             size: 0,
             validation_type: ValidationType::default(),
-            offset_to_default: 0
+            offset_to_default: 0,
+            symbol: String::new(),
         }
     }
 }
@@ -173,6 +177,7 @@ impl ImageValidationEntryHeader {
         entry.offset = ((symbol.address as i64) + rule.offset.unwrap_or_default()) as u32;
         entry.size = rule.size.unwrap_or(symbol.size);
         entry.validation_type = rule.validation.clone();
+        entry.symbol = symbol.name.clone();
         entry
     }
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -16,9 +16,11 @@ use scroll::Pread;
 pub mod auxgen;
 pub mod util;
 pub mod validation;
+pub mod report;
 
 use auxgen::{Symbol, SymbolType, AuxBuilder};
 use validation::{ValidationRule, ValidationType};
+use report::CoverageReport;
 
 pub const POINTER_LENGTH: u64 = 8;
 
@@ -185,7 +187,10 @@ pub fn main() -> Result<()> {
                 println!("  {:?}", entry);
             }
         }
-    
+
+        let report = CoverageReport::build(&efi, &aux)?;
+
+        report.to_file(output.with_extension("json"))?;
         aux.to_file(output)?;
     }
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -1,0 +1,301 @@
+//! A module for generating a report showing the the coverage of the validation rules.
+//! 
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+use anyhow::{anyhow, Result};
+use serde::Serialize;
+
+use std::io::Write;
+use std::cmp::Ordering;
+
+use crate::{auxgen::{AuxFile, ImageValidationEntryHeader}, validation::ValidationType};
+
+/// A struct representing the coverage report for the firmware image.
+/// 
+/// This struct is serialized to a JSON file for easy viewing.
+#[derive(Serialize)]
+pub struct CoverageReport {
+    /// The total number of bytes that can be considered covered. e.g. the loaded image size.
+    coverable: String,
+    /// The total number of bytes that are considered covered under any circumstances.
+    covered: String,
+    /// The percentage of the total number of bytes that are covered.
+    covered_percent: String,
+    /// A list of segments of the loaded image and their coverage status.
+    segments: Vec<Segment>,
+}
+
+impl CoverageReport {
+    /// Generates a coverage report from the given image and auxiliary file.
+    pub fn build(image: &[u8], aux_file: &AuxFile) -> anyhow::Result<Self> {
+        let size_of_image = {
+            let pe = goblin::pe::PE::parse(image)?;
+            let optional_header = pe
+                .header
+                .optional_header
+                .ok_or(anyhow::anyhow!("No optional header found"))?;
+            optional_header.windows_fields.size_of_image
+        };
+
+        let mut segments = SegmentList::new(size_of_image);
+        segments.add_segments_from_image(image)?;
+        segments.add_segments_from_aux_entries(&aux_file.entries)?;
+
+        let padding_size = segments.get_size_by_reason("Padding");
+        let header_size = segments.get_size_by_reason("PE Header");
+        let covered_rule_size = segments.get_size(|seg| seg.reason.starts_with("Validation Rule") && seg.covered);
+        let covered_section = segments.get_size(|seg| seg.reason.starts_with("Section") && seg.covered);
+
+        let total_covered = covered_rule_size + covered_section;
+        let total_coverable = size_of_image - padding_size - header_size;
+
+        Ok(CoverageReport {
+            coverable: format!("{:#x}", total_coverable),
+            covered: format!("{:#x}", total_covered),
+            covered_percent: format!("{:.2}%", (total_covered as f32 / total_coverable as f32) * 100.0),
+            segments: segments.into_inner(),
+        })
+    }
+
+    /// Writes the report to a file
+    pub fn to_file(&self, path: std::path::PathBuf) -> anyhow::Result<()> {
+        let mut file = std::fs::File::create(path)?;
+        let buffer = serde_json::to_vec_pretty(&self)?;
+        file.write_all(&buffer)?;
+        Ok(())
+    }
+}
+
+/// A wrapper around a list of segments that allows for inserting new segments into the list.
+struct SegmentList {
+    size_of_image: u32,
+    segments: Vec<Segment>,
+}
+
+impl SegmentList {
+    /// Creates a new segment list with a single segment that spans the entire image.
+    fn new(size: u32) -> Self {
+        SegmentList {
+            size_of_image: size,
+            segments: vec![Segment::new(0, size, false, "".to_string())],
+        }
+    }
+
+    /// Consumes the list and returns the inner vector of segments.
+    pub fn into_inner(self) -> Vec<Segment> {
+        self.segments
+    }
+
+    fn get_size_by_reason(&self, reason: &str) -> u32
+    {
+        self.get_size(|seg| seg.reason == reason)
+    }
+
+    fn get_size(&self, filter: impl Fn(&&Segment) -> bool) -> u32
+    {
+        self.segments.iter().filter(filter).map(|seg| seg._end - seg._start).sum()
+    }
+
+    /// Adds segments to the report based off the PE image.
+    pub fn add_segments_from_image(&mut self, image: &[u8]) -> Result<()> {
+        self.add_ro_sections(image)?;
+        self.add_section_padding(image)?;
+        self.add_pe_header(image)?;
+        Ok(())
+    }
+
+    /// Adds a section (as one or more segments) if the section is read-only, including the padding at the end of the section.
+    fn add_ro_sections(&mut self, image: &[u8]) -> Result<()> {
+        let pe = goblin::pe::PE::parse(image)?;
+        let sections = pe.sections;
+
+        fn read(characteristics: u32) -> bool {
+            characteristics & 0x40000000 != 0
+        }
+
+        fn write(characteristics: u32) -> bool {
+            characteristics & 0x80000000 != 0
+        }
+
+        fn execute(characteristics: u32) -> bool {
+            characteristics & 0x20000000 != 0
+        }
+
+        for i in 0..sections.len() {
+            let section = &sections[i];
+            let next_section_start = if i + 1 < sections.len() {
+                sections[i + 1].virtual_address
+            } else {
+                self.size_of_image
+            };
+
+            let c = section.characteristics;
+            match (read(c), write(c), execute(c)) {
+                (true, false, false) => {
+                    self.insert(Segment::new(section.virtual_address, next_section_start, true, "Section: R".to_string()))?
+                },
+                (true, false, true) => {
+                    self.insert(Segment::new(section.virtual_address, next_section_start, true, "Section: RE".to_string()))?
+                }
+                (a, b, c) => {
+                    let mut s = String::new();
+                    if a { s.push('R'); }
+                    if b { s.push('W'); }
+                    if c { s.push('X'); }
+                    self.insert(Segment::new(section.virtual_address, next_section_start, false, format!("Section: {}", s)))?
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Finds the padding at the end of each section and adds it as a covered segment.
+    fn add_section_padding(&mut self, image: &[u8]) -> Result<()> {
+        let pe = goblin::pe::PE::parse(image)?;
+        let sections = pe.sections;
+
+        // Calculate the padding at the end of each section
+        for i in 0..sections.len() {
+            let section = &sections[i];
+            let next_section_start = if i + 1 < sections.len() {
+                sections[i + 1].virtual_address
+            } else {
+                self.size_of_image
+            };
+
+            let padding_start = section.virtual_size.min(section.size_of_raw_data) + section.virtual_address;
+            let padding_end = next_section_start;
+
+            self.insert(Segment::new(padding_start, padding_end, true, "Padding".to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Adds the PE header and any padding as covered segments.
+    fn add_pe_header(&mut self, image: &[u8]) -> Result<()> {
+        let pe = goblin::pe::PE::parse(image)?;
+        let header = pe.header.optional_header.ok_or(anyhow::anyhow!("No optional header found"))?;
+        let header_size = header.windows_fields.size_of_headers;
+        let start = pe.sections[0].virtual_address;
+
+        self.insert(Segment::new(0, header_size, true, "PE Header".to_string()))?;
+        self.insert(Segment::new(header_size, start, true, "Padding".to_string()))?;
+        Ok(())
+    }
+
+    /// Adds a list of image validation entries as covered segments.
+    pub fn add_segments_from_aux_entries(&mut self, entries: &[ImageValidationEntryHeader]) -> Result<()> {
+        for entry in entries.iter() {
+            self.insert(entry.into())?;
+        }
+        Ok(())
+    }
+
+    /// Inserts a new segment into the list, splitting any existing segments as necessary.
+    fn insert(&mut self, new: Segment)->Result<()> {
+        for i in 0..self.segments.len() {
+            let seg = self.segments[i].clone();
+            match (new._start.cmp(&seg._start), new._end.cmp(&seg._end)) {
+                // The segments are exactly the same
+                (Ordering::Equal, Ordering::Equal) => {
+                    self.segments[i] = new;
+                    return Ok(());
+                },
+                // The new segment is entirely contained within the old segment
+                (Ordering::Greater, Ordering::Less) => {
+                    let left = Segment::new(seg._start, new._start, seg.covered, seg.reason.clone());
+                    let right = Segment::new(new._end, seg._end, seg.covered, seg.reason.clone());
+                    self.segments[i] = left;
+                    self.segments.insert(i + 1, new);
+                    self.segments.insert(i + 2, right);
+                    return Ok(());
+                },
+                // The new and old segments start at the same address, but the new segment ends before the old segment
+                (Ordering::Equal, Ordering::Less) => {
+                    let right = Segment::new(new._end, seg._end, seg.covered, seg.reason.clone());
+                    self.segments[i] = new;
+                    self.segments.insert(i + 1, right);
+                    return Ok(());
+                },
+                // The new segment starts before the old segment, but ends at the same address
+                (Ordering::Greater, Ordering::Equal) => {
+                    let left = Segment::new(seg._start, new._start, seg.covered, seg.reason.clone());
+                    self.segments[i] = left;
+                    self.segments.insert(i + 1, new);
+                    return Ok(());
+                },
+                _ => continue,
+            }
+        }
+
+        println!("Failed to insert segment");
+        println!("This only happens if the segment to insert spans multiple existing segments.");
+        println!("Segment to insert: {:?}", new);
+        println!("Existing segments:");
+        for seg in self.segments.iter() {
+            println!("  {:?}", seg);
+        }
+        Err(anyhow!("Failed to insert segment."))
+    }
+}
+
+/// A segment of the image with metadata about its coverage status.
+#[derive(Serialize, Clone, Debug)]
+pub struct Segment  {
+    /// The symbol from the PDB file that this segment is associated with.
+    symbol: String,
+    /// A hex string representation of the start address of the segment.
+    start: String,
+    /// The start address of the segment as a u32.
+    #[serde(skip)]
+    _start: u32,
+    /// A hex string representation of the end address of the segment.
+    end: String,
+    /// The end address of the segment as a u32.
+    #[serde(skip)]
+    _end: u32,
+    /// A hex string representation of the size of the segment.
+    size: String,
+    /// Whether the segment is covered by a validation rule.
+    covered: bool,
+    /// The reason the segment is covered or not.
+    reason: String,
+}
+
+impl Segment {
+    /// Creates a new segment with the given start and end addresses, coverage status, and reason.
+    pub fn new(start: u32, end: u32, covered: bool, reason: String) -> Self {
+        Segment {
+            symbol: "".to_string(),
+            start: format!("{:#x}", start),
+            _start: start,
+            end: format!("{:#x}", end),
+            _end: end,
+            size: format!("{:#x}", end - start),
+            covered,
+            reason,
+        }
+    } 
+}
+
+impl From<&ImageValidationEntryHeader> for Segment {
+    fn from(header: &ImageValidationEntryHeader) -> Self {
+        let validation = &header.validation_type;
+        let rule: String = validation.into();
+        Segment {
+            symbol: header.symbol.clone(),
+            start: format!("{:#x}", header.offset),
+            _start: header.offset,
+            end: format!("{:#x}", header.offset + header.size),
+            _end: header.offset + header.size,
+            size: format!("{:#x}", header.size),
+            covered: *validation != ValidationType::None,
+            reason: format!("Validation Rule: {}", rule),
+        }
+    }
+}

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -268,8 +268,6 @@ pub struct Segment  {
     /// The end address of the segment as a u32.
     #[serde(skip)]
     _end: u32,
-    /// A hex string representation of the size of the segment.
-    size: String,
     /// Whether the segment is covered by a validation rule.
     covered: bool,
     /// The reason the segment is covered or not.
@@ -285,7 +283,6 @@ impl Segment {
             _start: start,
             end: format!("{:#x}", end),
             _end: end,
-            size: format!("{:#x}", end - start),
             covered,
             reason,
         }
@@ -302,7 +299,6 @@ impl From<&ImageValidationEntryHeader> for Segment {
             _start: header.offset,
             end: format!("{:#x}", header.offset + header.size),
             _end: header.offset + header.size,
-            size: format!("{:#x}", header.size),
             covered: *validation != ValidationType::None,
             reason: format!("Validation Rule: {}", rule),
         }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -25,6 +25,9 @@ pub struct CoverageReport {
     covered: String,
     /// The percentage of the total number of bytes that are covered.
     covered_percent: String,
+    coverable_by_rules: String,
+    covered_by_rules: String,
+    covered_by_rules_percent: String,
     /// A list of segments of the loaded image and their coverage status.
     segments: Vec<Segment>,
 }
@@ -52,11 +55,17 @@ impl CoverageReport {
 
         let total_covered = covered_rule_size + covered_section;
         let total_coverable = size_of_image - padding_size - header_size;
+        
+        let covered_by_rules = covered_rule_size;
+        let coverable_by_rules = total_coverable - covered_section;
 
         Ok(CoverageReport {
             coverable: format!("{:#x}", total_coverable),
             covered: format!("{:#x}", total_covered),
             covered_percent: format!("{:.2}%", (total_covered as f32 / total_coverable as f32) * 100.0),
+            covered_by_rules: format!("{:#x}", covered_by_rules),
+            coverable_by_rules: format!("{:#x}", coverable_by_rules),
+            covered_by_rules_percent: format!("{:.2}%", (covered_by_rules as f32 / coverable_by_rules as f32) * 100.0),
             segments: segments.into_inner(),
         })
     }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -25,8 +25,11 @@ pub struct CoverageReport {
     covered: String,
     /// The percentage of the total number of bytes that are covered.
     covered_percent: String,
+    /// The total number of bytes that can be considered covered by validation rules.
     coverable_by_rules: String,
+    /// The total number of bytes that are covered by validation rules.
     covered_by_rules: String,
+    /// The percentage of the total number of bytes that are covered by validation rules.
     covered_by_rules_percent: String,
     /// A list of segments of the loaded image and their coverage status.
     segments: Vec<Segment>,

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
@@ -116,8 +116,6 @@ pub fn add_symbol(map: &mut HashMap<String, crate::Symbol>, symbol: pdb::Symbol<
             let name = data.name.to_string().to_string();
             let type_index = None;
             let symbol_type = crate::SymbolType::Label;
-            
-            // Only add the symbol if it does not already exist in the map.
             map.entry(name.clone()).or_insert(crate::Symbol {
                 address,
                 size,

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
@@ -116,6 +116,8 @@ pub fn add_symbol(map: &mut HashMap<String, crate::Symbol>, symbol: pdb::Symbol<
             let name = data.name.to_string().to_string();
             let type_index = None;
             let symbol_type = crate::SymbolType::Label;
+            
+            // Only add the symbol if it does not already exist in the map.
             map.entry(name.clone()).or_insert(crate::Symbol {
                 address,
                 size,

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
@@ -122,7 +122,7 @@ impl From<&Symbol> for ValidationRule {
 /// Ref - IMAGE_VALIDATION_SELF_REF
 /// Pointer - IMAGE_VALIDATION_ENTRY_HEADER
 ///
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
 #[repr(u32)]
@@ -161,6 +161,19 @@ impl Into<u32> for &ValidationType {
             ValidationType::MemAttr{..} => 3,
             ValidationType::Ref{..} => 4,
             ValidationType::Pointer{..} => 5,
+        }
+    }
+}
+
+impl Into<String> for &ValidationType {
+    fn into(self) -> String {
+        match self {
+            ValidationType::None{..} => "None".to_string(),
+            ValidationType::NonZero{..} => "NonZero".to_string(),
+            ValidationType::Content{..} => "Content".to_string(),
+            ValidationType::MemAttr{..} => "MemAttr".to_string(),
+            ValidationType::Ref{..} => "Ref".to_string(),
+            ValidationType::Pointer{..} => "Pointer".to_string(),
         }
     }
 }


### PR DESCRIPTION
## Description

Adds an auto-generated json file containing data on sections of the `efi` image that have validation rules applied to it.

### Report Format

```json
{
  "coverable": "0x0",
  "coverd": "0x0",
  "covered_percent": "0.00%",
  "coverable_by_rules": "0x0",
  "covered_by_rules": "0x0",
  "covered_by_rules_percent": "0.00%",
  "segments": [
    {
      "symbol": "",
      "start": "0x0",
      "end": "0x0",
      "covered": true,
      "reason": "",
    }
  ]
}
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ensure auxfile generation works as expected.

## Integration Instructions

N/A