### PR TITLE
auxgen: Ignore labels for required symbols config

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -99,19 +99,16 @@ impl Default for ImageValidationDataHeader {
 /// 
 #[derive(Clone)]
 pub struct ImageValidationEntryHeader {
-    pub signature: u32,
+    signature: u32,
     /// Offset of the value in the original image.
-    pub offset: u32,
+    offset: u32,
     /// Size of the value in bytes.
-    pub size: u32,
+    size: u32,
     /// The type of validation to perform on the symbol. Contains the data
     /// necessary to perform the validation.
-    pub validation_type: ValidationType,
+    validation_type: ValidationType,
     /// Offset of the default value in the aux file.
-    pub offset_to_default: u32,
-    // The symbol name that this entry is for. This is not written to the aux
-    /// file, but exists for debugging purposes.
-    pub symbol: String,
+    offset_to_default: u32
 }
 
 impl Default for ImageValidationEntryHeader {
@@ -121,8 +118,7 @@ impl Default for ImageValidationEntryHeader {
             offset: 0,
             size: 0,
             validation_type: ValidationType::default(),
-            offset_to_default: 0,
-            symbol: String::new(),
+            offset_to_default: 0
         }
     }
 }
@@ -177,7 +173,6 @@ impl ImageValidationEntryHeader {
         entry.offset = ((symbol.address as i64) + rule.offset.unwrap_or_default()) as u32;
         entry.size = rule.size.unwrap_or(symbol.size);
         entry.validation_type = rule.validation.clone();
-        entry.symbol = symbol.name.clone();
         entry
     }
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -99,16 +99,19 @@ impl Default for ImageValidationDataHeader {
 /// 
 #[derive(Clone)]
 pub struct ImageValidationEntryHeader {
-    signature: u32,
+    pub signature: u32,
     /// Offset of the value in the original image.
-    offset: u32,
+    pub offset: u32,
     /// Size of the value in bytes.
-    size: u32,
+    pub size: u32,
     /// The type of validation to perform on the symbol. Contains the data
     /// necessary to perform the validation.
-    validation_type: ValidationType,
+    pub validation_type: ValidationType,
     /// Offset of the default value in the aux file.
-    offset_to_default: u32
+    pub offset_to_default: u32,
+    // The symbol name that this entry is for. This is not written to the aux
+    /// file, but exists for debugging purposes.
+    pub symbol: String,
 }
 
 impl Default for ImageValidationEntryHeader {
@@ -118,7 +121,8 @@ impl Default for ImageValidationEntryHeader {
             offset: 0,
             size: 0,
             validation_type: ValidationType::default(),
-            offset_to_default: 0
+            offset_to_default: 0,
+            symbol: String::new(),
         }
     }
 }
@@ -173,6 +177,7 @@ impl ImageValidationEntryHeader {
         entry.offset = ((symbol.address as i64) + rule.offset.unwrap_or_default()) as u32;
         entry.size = rule.size.unwrap_or(symbol.size);
         entry.validation_type = rule.validation.clone();
+        entry.symbol = symbol.name.clone();
         entry
     }
 
@@ -294,12 +299,14 @@ impl AuxBuilder {
         }
     }
 
-    /// Finds symbols that do not have a rule in the configuration file. Ignores symbols of type `Procedure` and
+    /// Finds symbols that do not have a rule in the configuration file. Ignores symbols of type `Procedure` or `Label` and
     /// any symbols in the `excluded_symbols` list in the configuration file (that filter is done before calling this function).
     pub fn find_symbols_with_no_rule(symbols: &Vec::<Symbol>, rules: &Vec<ValidationRule>) -> Vec<Symbol> {
+        const IGNORE_SYMBOL_TYPES: [SymbolType;2] = [SymbolType::Procedure, SymbolType::Label];
+
         let mut missing = Vec::new();
         for symbol in symbols {
-            if !rules.iter().any(|rule| rule.symbol == symbol.name || symbol.symbol_type == SymbolType::Procedure) {
+            if !rules.iter().any(|rule| rule.symbol == symbol.name || IGNORE_SYMBOL_TYPES.contains(&symbol.symbol_type)) {
                 missing.push(symbol.clone());
             }
         }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
@@ -65,7 +65,7 @@ pub fn add_symbol(map: &mut HashMap<String, crate::Symbol>, symbol: pdb::Symbol<
             let name = data.name.to_string().to_string();
             let type_index = None;
             let symbol_type = crate::SymbolType::Public;
-            map.entry(name.clone()).or_insert(crate::Symbol {
+            map.insert(name.clone(), crate::Symbol {
                 address,
                 size,
                 name,
@@ -102,7 +102,7 @@ pub fn add_symbol(map: &mut HashMap<String, crate::Symbol>, symbol: pdb::Symbol<
             let name = data.name.to_string().to_string();
             let type_index = Some(data.type_index);
             let symbol_type = crate::SymbolType::Procedure;
-            map.entry(name.clone()).or_insert( crate::Symbol {
+            map.insert(name.clone(), crate::Symbol {
                 address,
                 size,
                 name,


### PR DESCRIPTION
## Description

Ignores Label symbol for the "no_missing_rules" configuration value, as labels are just addresses in the code section. Not only are they a non-writeable section, but they are additionally not variables that can be manipulated. They are simply addresses in the code section.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated Label Symbols are no longer required if said symbol is missing a rule

## Integration Instructions

N/A - However users can remove labels from the excluded symbols path, or their rules if they wish.
