### PR TITLE
aux_gen: Fix bugs in tool

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -314,7 +314,13 @@ impl AuxBuilder {
                 missing.push(symbol.clone());
             }
         }
+
+        // Apply extra static filters for junk symbols
         missing
+            .into_iter()
+            .filter(|symbol| symbol.name != "")
+            .filter(|symbol| symbol.address != 0)
+            .collect()
     }
 
     /// Generates the aux file. By default, only rules specified in the

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -180,7 +180,7 @@ impl SegmentList {
                 self.size_of_image
             };
 
-            let padding_start = section.virtual_size.min(section.size_of_raw_data) + section.virtual_address;
+            let padding_start = section.virtual_size.max(section.size_of_raw_data) + section.virtual_address;
             let padding_end = next_section_start;
 
             self.insert(Segment::new(padding_start, padding_end, true, "Padding".to_string()))?;

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/util.rs
@@ -65,7 +65,7 @@ pub fn add_symbol(map: &mut HashMap<String, crate::Symbol>, symbol: pdb::Symbol<
             let name = data.name.to_string().to_string();
             let type_index = None;
             let symbol_type = crate::SymbolType::Public;
-            map.insert(name.clone(), crate::Symbol {
+            map.entry(name.clone()).or_insert(crate::Symbol {
                 address,
                 size,
                 name,
@@ -102,7 +102,7 @@ pub fn add_symbol(map: &mut HashMap<String, crate::Symbol>, symbol: pdb::Symbol<
             let name = data.name.to_string().to_string();
             let type_index = Some(data.type_index);
             let symbol_type = crate::SymbolType::Procedure;
-            map.insert(name.clone(), crate::Symbol {
+            map.entry(name.clone()).or_insert(crate::Symbol {
                 address,
                 size,
                 name,


### PR DESCRIPTION
## Description

Fixes the following bugs:

1. Incorrect padding by using min instead of max for calculating the loaded size of the section.
2. Incorrect priority of duplicate symbol names.

Applies the following enhancement:

1. Filter out symbols with empty name or 0x0 address.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Run on platform

## Integration Instructions

N/A