### PR TITLE
GenSeaArtifacts: Move aux to misc dir

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
+++ b/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
@@ -152,7 +152,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
             )
             shutil.copy2(
                 stm_build_dir / "MmSupervisorCore.aux",
-                output_dir / "MmSupervisorCore.aux"
+                misc_dir / "MmSupervisorCore.aux"
             )
 
             shutil.copy2(


### PR DESCRIPTION
## Description

Moves the auxiliary file used to compile the Stm to the Misc directory during final packaging, as it is not needed for the final platform build, but is good to have for debugging purposes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

Any expectation of a certain location for `MmSupervisorCore.aux` should be adjusted from its current location to `/Misc/*` or its usage should be removed entirely.
