### PR TITLE
Fixed issues with the pointer validation code

### DIFF
--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -38,7 +38,6 @@
 #include <Register/Intel/ArchitecturalMsr.h>
 #include <Register/Intel/StmApi.h>
 #include <Register/Intel/Cpuid.h>
-#include <x64/Vmx.h>
 
 /**
   Retrieves the PE or TE Header from a PE/COFF or TE image.

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -729,10 +729,8 @@ GetMsegBaseAndSize (
 {
   EFI_STATUS                         Status;
   MSR_IA32_SMM_MONITOR_CTL_REGISTER  SmmMonitorCtl;
-  CPUID_CACHE_PARAMS_EAX             CacheParamsEax;
   STM_HEADER                         *StmHeader;
   UINTN                              NumberOfCpus;
-  UINT32                             MaxStandardCpuIdIndex;
 
   //
   // Find the MSEG Base address
@@ -756,16 +754,8 @@ GetMsegBaseAndSize (
   //
   // Calculate the Minimum MSEG size
   //
-  StmHeader = (STM_HEADER *)(UINTN)((UINT32)AsmReadMsr64 (IA32_SMM_MONITOR_CTL_MSR_INDEX) & 0xFFFFF000);
-
-  AsmCpuid (CPUID_SIGNATURE, &MaxStandardCpuIdIndex, NULL, NULL, NULL);
-  if (MaxStandardCpuIdIndex >= CPUID_CACHE_PARAMS) {
-    AsmCpuidEx (CPUID_CACHE_PARAMS, 0, &CacheParamsEax.Uint32, NULL, NULL, NULL);
-
-    if (CacheParamsEax.Uint32 != 0) {
-      NumberOfCpus = CacheParamsEax.Bits.MaximumAddressableIdsForLogicalProcessors + 1;
-    }
-  }
+  StmHeader    = (STM_HEADER *)(UINTN)*MsegBase;
+  NumberOfCpus = StmHeader->CpuInfoHdr.NumberOfCpus;
 
   *MsegSize = (EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (StmHeader->SwStmHdr.StaticImageSize)) +
                StmHeader->SwStmHdr.AdditionalDynamicMemorySize +

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -422,6 +422,7 @@ PeCoffImageValidationPointer (
   EFI_STATUS                Status;
   IMAGE_VALIDATION_POINTER  *PointerHdr;
   BOOLEAN                   InMseg;
+  EFI_PHYSICAL_ADDRESS      AddrInTarget;
 
   if ((TargetImage == NULL) || (Hdr == NULL)) {
     DEBUG ((
@@ -460,7 +461,9 @@ PeCoffImageValidationPointer (
     goto Done;
   }
 
-  InMseg = ((UINTN)((UINT8 *)TargetImage + Hdr->Offset) >= MsegBase) && ((UINTN)((UINT8 *)TargetImage + Hdr->Offset) < MsegBase + MsegSize);
+  AddrInTarget = 0;
+  CopyMem (&AddrInTarget, (UINT8 *)TargetImage + Hdr->Offset, Hdr->Size);
+  InMseg = ((UINTN)AddrInTarget >= MsegBase - MsegSize) && ((UINTN)((UINT8 *)TargetImage + Hdr->Offset) < MsegBase);
   if ((BOOLEAN)PointerHdr->InMseg != InMseg) {
     DEBUG ((
       DEBUG_ERROR,

--- a/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -635,6 +635,7 @@ MmEndOfDxeEventNotify (
   StmHeader = (STM_HEADER *)(UINTN)MsegBase;
   LongRsp   = (VOID *)(UINTN)(MsegBase + StmHeader->HwStmHdr.EspOffset);
 
+  // Copy CPU information to the CPU_INFORMATION_HEADER
   StmHeader->CpuInfoHdr.NumberOfCpus = gMmst->NumberOfCpus;
   StmHeader->CpuInfoHdr.Signature = STM_CPU_INFORMATION_HEADER_SIGNATURE;
 

--- a/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -635,6 +635,9 @@ MmEndOfDxeEventNotify (
   StmHeader = (STM_HEADER *)(UINTN)MsegBase;
   LongRsp   = (VOID *)(UINTN)(MsegBase + StmHeader->HwStmHdr.EspOffset);
 
+  StmHeader->CpuInfoHdr.NumberOfCpus = gMmst->NumberOfCpus;
+  StmHeader->CpuInfoHdr.Signature = STM_CPU_INFORMATION_HEADER_SIGNATURE;
+
   for (Index = 0; Index < gMmst->NumberOfCpus; Index++) {
     Psd = (TXT_PROCESSOR_SMM_DESCRIPTOR *)((UINTN)gMmst->CpuSaveState[Index] - SMRAM_SAVE_STATE_MAP_OFFSET + TXT_SMM_PSD_OFFSET);
     DEBUG ((DEBUG_INFO, "Index=%d  Psd=%p  Rsdp=%p\n", Index, Psd, NULL));

--- a/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -637,7 +637,7 @@ MmEndOfDxeEventNotify (
 
   // Copy CPU information to the CPU_INFORMATION_HEADER
   StmHeader->CpuInfoHdr.NumberOfCpus = gMmst->NumberOfCpus;
-  StmHeader->CpuInfoHdr.Signature = STM_CPU_INFORMATION_HEADER_SIGNATURE;
+  StmHeader->CpuInfoHdr.Signature    = STM_CPU_INFORMATION_HEADER_SIGNATURE;
 
   for (Index = 0; Index < gMmst->NumberOfCpus; Index++) {
     Psd = (TXT_PROCESSOR_SMM_DESCRIPTOR *)((UINTN)gMmst->CpuSaveState[Index] - SMRAM_SAVE_STATE_MAP_OFFSET + TXT_SMM_PSD_OFFSET);

--- a/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -636,7 +636,7 @@ MmEndOfDxeEventNotify (
   LongRsp   = (VOID *)(UINTN)(MsegBase + StmHeader->HwStmHdr.EspOffset);
 
   // Copy CPU information to the CPU_INFORMATION_HEADER
-  StmHeader->CpuInfoHdr.NumberOfCpus = gMmst->NumberOfCpus;
+  StmHeader->CpuInfoHdr.NumberOfCpus = (UINT32)gMmst->NumberOfCpus;
   StmHeader->CpuInfoHdr.Signature    = STM_CPU_INFORMATION_HEADER_SIGNATURE;
 
   for (Index = 0; Index < gMmst->NumberOfCpus; Index++) {


### PR DESCRIPTION
## Description

The pointer validation entry type has some issues with the validation logic.
1. It doesn't correctly increment with the entry list iteration leading to us point to nonvalid memory.
2. The calculation for the MSEG region was incorrect and was providing a random address for BASE and the incorrect number of CPU cores.
3. The target address was incorrectly being set to the location of symbol in the MM Supervisor image.  It has been updated to use the address of pointer so we can correctly judge if it's in or outside MSEG.

This changes address both of these issues by casting the entry type when incrementing to address (1) and then using the correct data structures to calculate the MSEG region.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Intel physical platform.  The validation process correctly gets MSEG.

## Integration Instructions

N/A