### PR TITLE
Fix MSEG boundary check

### DIFF
--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -463,7 +463,7 @@ PeCoffImageValidationPointer (
 
   AddrInTarget = 0;
   CopyMem (&AddrInTarget, (UINT8 *)TargetImage + Hdr->Offset, Hdr->Size);
-  InMseg = ((UINTN)AddrInTarget >= MsegBase - MsegSize) && ((UINTN)((UINT8 *)TargetImage + Hdr->Offset) < MsegBase);
+  InMseg = ((UINTN)AddrInTarget >= MsegBase) && ((UINTN)AddrInTarget < MsegBase + MsegSize);
   if ((BOOLEAN)PointerHdr->InMseg != InMseg) {
     DEBUG ((
       DEBUG_ERROR,


### PR DESCRIPTION
## Description

The boundary check fix was lost between the testing branch and PR branch.  This PR changes the boundary check to be the correct range and so we use the correct target address.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Intel Physical platform.  The range and target address were correct.

## Integration Instructions

N/A
