### PR TITLE
aux_gen: Auto generate rules for padding

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -478,6 +478,7 @@ impl AuxBuilder {
                     address: segment.start() as u32,
                     type_info: TypeInfo::one(size as u64, None),
                     symbol_type: SymbolType::None,
+                    section_characteristics: SectionCharacteristics::default(),
                 });
                 rule
             })

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -456,7 +456,7 @@ impl AuxBuilder {
     }
 
     /// Auto generates additional Content rules for padding that is present in the image.
-    fn auto_generate_rules(&self, report: CoverageReport) -> anyhow::Result<Vec<ImageValidationEntryHeader>> {
+    fn auto_generate_entry_headers(&self, report: CoverageReport) -> anyhow::Result<Vec<ImageValidationEntryHeader>> {
         let mut entry_headers = Vec::new();
 
         let rules: Vec<ValidationRule> = report.segments()
@@ -558,7 +558,7 @@ impl AuxBuilder {
             &self.get_symbols()?
         )?;
 
-        entry_headers.extend(self.auto_generate_rules(report)?);
+        entry_headers.extend(self.auto_generate_entry_headers(report)?);
 
         let aux = self._generate(entry_headers, key_symbols)?;
         

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -56,7 +56,7 @@ pub struct Args {
 
 /// A struct that represents an signature/address pair to be added to the
 /// auxiliary file header.
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct KeySymbol {
     /// The symbol name to calculate the offset of.
     pub symbol: Option<String>,


### PR DESCRIPTION
## Description

While developing the coverage report raw data, it was noted that some spaces between symbols in the .data section were not associated with any symbols in the PDB. It was determined that this was padding in the symbols themselves which work to align them in the file. This pull request does the following things:

1. Cleans up the final build into multiple separate functions
2. Generates a content validation rule (of all zero) for any byte ranges not assocaited with a symbol
3. Generates a content validation rule (of all zeros) for any padding between sections, that is in a section that is both Read and Write.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
