### PR TITLE
gen_aux: Move array configuration to an 'array' parent

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -65,8 +65,8 @@ validation.type = 'Required[String]'
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
 - `symbol`: Determines the address and size for the rule
 - `field`: Updates the address and size to be that of the field, rather than the symbol itself.
-- `array.index`: If the symbol is a array, only apply the rule to the specified index.
-- `array.sentinel`: If the symbol is a array, apply content rule to only the final rule such that its content must be all zeros
+- `array.index`: Only apply the rule to the specified index of the array.
+- `array.sentinel`: Apply content rule to only the final rule such that its content must be all zeros.
 - `offset`: Updates the address to `symbol.address + offset`. Offset can be negative. Providing an offset requires that the
 `size` is also provided, as the size can no longer be automatically calculated
 - `size`: Overrides the size calculated by `symbol` or `rule`.

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -55,8 +55,8 @@ comes with the following standard options:
 scope = 'Optional[String]'
 symbol = 'Required[String]'
 field = 'Optional[String]'
-index = 'Optional[Int]'
-sentinel = 'Optional[Boolean]'
+array.index = 'Optional[Int]'
+array.sentinel = 'Optional[Boolean]'
 offset = 'Optional[Int]'
 size = 'Optional[Int]'
 validation.type = 'Required[String]'
@@ -65,8 +65,8 @@ validation.type = 'Required[String]'
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
 - `symbol`: Determines the address and size for the rule
 - `field`: Updates the address and size to be that of the field, rather than the symbol itself.
-- `index`: If the symbol is a array, only apply the rule to the specified index.
-- `sentinel`: If the symbol is a array, apply content rule to only the final rule such that its content must be all zeros
+- `array.index`: If the symbol is a array, only apply the rule to the specified index.
+- `array.sentinel`: If the symbol is a array, apply content rule to only the final rule such that its content must be all zeros
 - `offset`: Updates the address to `symbol.address + offset`. Offset can be negative. Providing an offset requires that the
 `size` is also provided, as the size can no longer be automatically calculated
 - `size`: Overrides the size calculated by `symbol` or `rule`.

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -188,6 +188,10 @@ impl ImageValidationEntryHeader {
             return Err(anyhow::anyhow!("Invalid Rule Configuration: Symbol {} is not an array, but the rule specifies configuration for an array.", symbol.name));
         }
 
+        if !rule.array.sentinel && rule.array.index.is_some() {
+            return Err(anyhow::anyhow!("Invalid Rule Configuration: Symbol {}: Array configuration `sentinel` and `index` cannot be combined.", symbol.name));
+        }
+
         if let Some(index) = rule.array.index {
             if index >= element_count {
                 return Err(

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/auxgen.rs
@@ -188,7 +188,7 @@ impl ImageValidationEntryHeader {
             return Err(anyhow::anyhow!("Invalid Rule Configuration: Symbol {} is not an array, but the rule specifies configuration for an array.", symbol.name));
         }
 
-        if !rule.array.sentinel && rule.array.index.is_some() {
+        if rule.array.sentinel && rule.array.index.is_some() {
             return Err(anyhow::anyhow!("Invalid Rule Configuration: Symbol {}: Array configuration `sentinel` and `index` cannot be combined.", symbol.name));
         }
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
@@ -25,14 +25,9 @@ pub struct ValidationRule {
     /// symbol, if the symbol is a class, that the validation should be
     /// performed on.
     pub field: Option<String>,
-    /// If the symbol is an array, this is the index to apply the validation to.
-    /// If not specified, the validation is applied to the entire array.
-    pub index: Option<u64>,
-    /// If the symbol is an array, then the last element is a sentinel value, thus
-    /// a validation rule of "content" of all zeros is applied instead of the
-    /// specified rule.
+    /// Configuration applied to the symbol if it is an array.
     #[serde(default)]
-    pub sentinel: bool,
+    pub array: ArrayConfig,
     /// The type of validation to be performed on the symbol.
     pub validation: ValidationType,
     /// An optional field that can be used to specify an offset from the symbol
@@ -55,8 +50,7 @@ impl ValidationRule {
         ValidationRule {
             symbol,
             field: None,
-            index: None,
-            sentinel: false,
+            array: ArrayConfig::default(),
             validation: ValidationType::None,
             offset: None,
             size: None,
@@ -107,14 +101,24 @@ impl From<&Symbol> for ValidationRule {
         ValidationRule {
             symbol: symbol.name.clone(),
             field: None,
-            index: None,
-            sentinel: false,
+            array: ArrayConfig::default(),
             validation: ValidationType::Content{ content: 0xDEADBEEFu32.to_le_bytes().to_vec() },
             offset: None,
             size: Some(2),
             scope: None,
         }
     }
+}
+
+/// A struct representing the configuration for a symbol that is an array.
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct ArrayConfig {
+    /// Specifies that the last index in the array is a sentinel value, thus creating a different
+    /// validation rule for the last index, Content of all zeros.
+    pub sentinel: bool,
+    /// The index to apply the validation to. If this is not set, the validation
+    /// is applied to the entire array.
+    pub index: Option<u64>,
 }
 
 /// An enum representing the type of validation to be performed on the symbol


### PR DESCRIPTION
## Description

Changes the following configuration example:

``` toml
# old
[[rule]]
symbol = "mysymbol"
validation.type = "content"
index = 3

# new
[[rule]]
symbol = "mysymbol"
validation.type = "content"
array.index = 3
```

``` toml
#old
[[rule]]
symbol = "mysymbol"
validation.type = "content"
sentinel = true

#new
[[rule]]
symbol = "mysymbol"
validation.type = "content"
array.sentinel = true
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ensured invalid usage of the configuration results in an error.

## Integration Instructions

Switch the following configuration values:

- `sentinel` -> `array.sentinel`
- `index` -> `array.index`
