### PR TITLE
Remove/Modify some global variables

### DIFF
--- a/MmSupervisorPkg/Core/FwVol/FwVol.c
+++ b/MmSupervisorPkg/Core/FwVol/FwVol.c
@@ -111,6 +111,7 @@ Returns:
       TotalSize = TotalSize + FileSize;
     }
   } while (!EFI_ERROR (Status));
+
   // If by the time we get here this FV is outside of MMRAM, copy it MMRAM
   // It will be marked as CPL3 RO XP before entering MMI
   Status = MmAllocatePages (
@@ -124,6 +125,7 @@ Returns:
     DEBUG ((DEBUG_ERROR, "Allocating for FwVol out of resources - %r!\n", Status));
     goto Done;
   }
+
   FileHeader  = NULL;
   BufferIndex = 0;
   do {
@@ -137,6 +139,7 @@ Returns:
         FreePages (InnerFvHeader, EFI_SIZE_TO_PAGES (TotalSize));
         goto Done;
       }
+
       InnerFileHeader = (EFI_FFS_FILE_HEADER *)((UINT8 *)InnerFvHeader + BufferIndex);
       BufferIndex     = BufferIndex + FileSize;
       Status          = FfsFindSectionData (EFI_SECTION_PE32, InnerFileHeader, &Pe32Data, &Pe32DataSize);

--- a/MmSupervisorPkg/Core/FwVol/FwVol.c
+++ b/MmSupervisorPkg/Core/FwVol/FwVol.c
@@ -24,19 +24,6 @@ typedef struct {
 } FFS_DRIVER_CACHE_LIST;
 
 //
-// List of file types supported by dispatcher
-//
-EFI_FV_FILETYPE  mMmFileTypes[] = {
-  // Traditional modules are restricted to load under MU's standalone MM environment
-  // EFI_FV_FILETYPE_MM,
-  EFI_FV_FILETYPE_MM_STANDALONE,
-  //
-  // Note: DXE core will process the FV image file, so skip it in MM core
-  // EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE
-  //
-};
-
-//
 // List of firmware volume headers whose containing firmware volumes have been
 // parsed and added to the mFwDriverList.
 //
@@ -90,7 +77,6 @@ Returns:
   UINTN                       Pe32DataSize;
   VOID                        *Depex;
   UINTN                       DepexSize;
-  UINTN                       Index;
   EFI_FIRMWARE_VOLUME_HEADER  *InnerFvHeader;
   KNOWN_FWVOL                 *KnownFwVol;
   UINTN                       TotalSize;
@@ -113,60 +99,55 @@ Returns:
     return EFI_SUCCESS;
   }
 
-  for (Index = 0; Index < sizeof (mMmFileTypes) / sizeof (mMmFileTypes[0]); Index++) {
-    DEBUG ((DEBUG_INFO, "Check MmFileTypes - 0x%x\n", mMmFileTypes[Index]));
-    FileType   = mMmFileTypes[Index];
-    FileHeader = NULL;
-    TotalSize  = 0;
-    do {
-      Status = FfsFindNextFile (FileType, FwVolHeader, &FileHeader);
-      if (!EFI_ERROR (Status)) {
-        FileSize = 0;
-        CopyMem (&FileSize, FileHeader->Size, sizeof (FileHeader->Size));
-        TotalSize = TotalSize + FileSize;
-      }
-    } while (!EFI_ERROR (Status));
-
-    // If by the time we get here this FV is outside of MMRAM, copy it MMRAM
-    // It will be marked as CPL3 RO XP before entering MMI
-    Status = MmAllocatePages (
-               AllocateAnyPages,
-               EfiRuntimeServicesCode,
-               EFI_SIZE_TO_PAGES (TotalSize),
-               (EFI_PHYSICAL_ADDRESS *)&InnerFvHeader
-               );
-    DEBUG ((DEBUG_INFO, "%a Allocating for discovered ffs address: 0x%p, pages: 0x%x\n", __FUNCTION__, InnerFvHeader, EFI_SIZE_TO_PAGES (TotalSize)));
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "Allocating for FwVol out of resources - %r!\n", Status));
-      goto Done;
+  DEBUG ((DEBUG_INFO, "Check MmFileTypes - 0x%x\n", EFI_FV_FILETYPE_MM_STANDALONE));
+  FileType   = EFI_FV_FILETYPE_MM_STANDALONE;
+  FileHeader = NULL;
+  TotalSize  = 0;
+  do {
+    Status = FfsFindNextFile (FileType, FwVolHeader, &FileHeader);
+    if (!EFI_ERROR (Status)) {
+      FileSize = 0;
+      CopyMem (&FileSize, FileHeader->Size, sizeof (FileHeader->Size));
+      TotalSize = TotalSize + FileSize;
     }
-
-    FileHeader  = NULL;
-    BufferIndex = 0;
-    do {
-      Status = FfsFindNextFile (FileType, FwVolHeader, &FileHeader);
-      if (!EFI_ERROR (Status)) {
-        FileSize = 0;
-        CopyMem (&FileSize, FileHeader->Size, sizeof (FileHeader->Size));
-        Status = MmCopyMemToMmram ((UINT8 *)InnerFvHeader + BufferIndex, FileHeader, FileSize);
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_ERROR, "Copying FFS from FV failed - %r!\n", Status));
-          FreePages (InnerFvHeader, EFI_SIZE_TO_PAGES (TotalSize));
-          goto Done;
-        }
-
-        InnerFileHeader = (EFI_FFS_FILE_HEADER *)((UINT8 *)InnerFvHeader + BufferIndex);
-        BufferIndex     = BufferIndex + FileSize;
-        Status          = FfsFindSectionData (EFI_SECTION_PE32, InnerFileHeader, &Pe32Data, &Pe32DataSize);
-        DEBUG ((DEBUG_INFO, "Find PE data - 0x%x\n", Pe32Data));
-        DepexStatus = FfsFindSectionData (EFI_SECTION_MM_DEPEX, InnerFileHeader, &Depex, &DepexSize);
-        if (!EFI_ERROR (DepexStatus)) {
-          // Set the FV header to be NULL here since the original header will not be available anyway.
-          MmAddToDriverList (NULL, Pe32Data, Pe32DataSize, Depex, DepexSize, &InnerFileHeader->Name);
-        }
-      }
-    } while (!EFI_ERROR (Status));
+  } while (!EFI_ERROR (Status));
+  // If by the time we get here this FV is outside of MMRAM, copy it MMRAM
+  // It will be marked as CPL3 RO XP before entering MMI
+  Status = MmAllocatePages (
+             AllocateAnyPages,
+             EfiRuntimeServicesCode,
+             EFI_SIZE_TO_PAGES (TotalSize),
+             (EFI_PHYSICAL_ADDRESS *)&InnerFvHeader
+             );
+  DEBUG ((DEBUG_INFO, "%a Allocating for discovered ffs address: 0x%p, pages: 0x%x\n", __FUNCTION__, InnerFvHeader, EFI_SIZE_TO_PAGES (TotalSize)));
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Allocating for FwVol out of resources - %r!\n", Status));
+    goto Done;
   }
+  FileHeader  = NULL;
+  BufferIndex = 0;
+  do {
+    Status = FfsFindNextFile (FileType, FwVolHeader, &FileHeader);
+    if (!EFI_ERROR (Status)) {
+      FileSize = 0;
+      CopyMem (&FileSize, FileHeader->Size, sizeof (FileHeader->Size));
+      Status = MmCopyMemToMmram ((UINT8 *)InnerFvHeader + BufferIndex, FileHeader, FileSize);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Copying FFS from FV failed - %r!\n", Status));
+        FreePages (InnerFvHeader, EFI_SIZE_TO_PAGES (TotalSize));
+        goto Done;
+      }
+      InnerFileHeader = (EFI_FFS_FILE_HEADER *)((UINT8 *)InnerFvHeader + BufferIndex);
+      BufferIndex     = BufferIndex + FileSize;
+      Status          = FfsFindSectionData (EFI_SECTION_PE32, InnerFileHeader, &Pe32Data, &Pe32DataSize);
+      DEBUG ((DEBUG_INFO, "Find PE data - 0x%x\n", Pe32Data));
+      DepexStatus = FfsFindSectionData (EFI_SECTION_MM_DEPEX, InnerFileHeader, &Depex, &DepexSize);
+      if (!EFI_ERROR (DepexStatus)) {
+        // Set the FV header to be NULL here since the original header will not be available anyway.
+        MmAddToDriverList (NULL, Pe32Data, Pe32DataSize, Depex, DepexSize, &InnerFileHeader->Name);
+      }
+    }
+  } while (!EFI_ERROR (Status));
 
   // Group all temporarily allocated buffer into a linked list, they will be frees at ready to lock event
   CurrentCacheNode = AllocateZeroPool (sizeof (FFS_DRIVER_CACHE_LIST));

--- a/MmSupervisorPkg/Core/Mem/HeapGuard.c
+++ b/MmSupervisorPkg/Core/Mem/HeapGuard.c
@@ -1219,7 +1219,7 @@ SetAllGuardPages (
   INTN     Level;
   UINTN    Index;
   BOOLEAN  OnGuarding;
-  UINTN   LevelShift;
+  UINTN    LevelShift;
 
   LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
 

--- a/MmSupervisorPkg/Core/Mem/HeapGuard.c
+++ b/MmSupervisorPkg/Core/Mem/HeapGuard.c
@@ -266,9 +266,7 @@ FindGuardedMemoryMap (
   UINTN   Index;
   UINTN   Size;
   UINTN   BitsToUnitEnd;
-  UINTN   LevelShift;
-
-  LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
+  UINTN   LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
 
   //
   // Adjust current map table depth according to the address to access
@@ -1219,9 +1217,7 @@ SetAllGuardPages (
   INTN     Level;
   UINTN    Index;
   BOOLEAN  OnGuarding;
-  UINTN    LevelShift;
-
-  LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
+  UINTN    LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
 
   if ((mGuardedMemoryMap == 0) ||
       (mMapLevel == 0) ||
@@ -1370,9 +1366,7 @@ DumpGuardedMemoryBitmap (
   CHAR8   String[GUARDED_HEAP_MAP_ENTRY_BITS + 1];
   CHAR8   *Ruler1;
   CHAR8   *Ruler2;
-  UINTN   LevelShift;
-
-  LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
+  UINTN   LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
 
   if ((mGuardedMemoryMap == 0) ||
       (mMapLevel == 0) ||

--- a/MmSupervisorPkg/Core/Mem/HeapGuard.c
+++ b/MmSupervisorPkg/Core/Mem/HeapGuard.c
@@ -41,10 +41,8 @@ GLOBAL_REMOVE_IF_UNREFERENCED UINT64  mGuardedMemoryMap = 0;
 GLOBAL_REMOVE_IF_UNREFERENCED UINTN  mMapLevel = 1;
 
 //
-// Shift and mask for each level of map table
+// Mask for each level of map table
 //
-GLOBAL_REMOVE_IF_UNREFERENCED UINTN  mLevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH]
-  = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
 GLOBAL_REMOVE_IF_UNREFERENCED UINTN  mLevelMask[GUARDED_HEAP_MAP_TABLE_DEPTH]
   = GUARDED_HEAP_MAP_TABLE_DEPTH_MASKS;
 
@@ -268,6 +266,9 @@ FindGuardedMemoryMap (
   UINTN   Index;
   UINTN   Size;
   UINTN   BitsToUnitEnd;
+  UINTN   LevelShift;
+
+  LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
 
   //
   // Adjust current map table depth according to the address to access
@@ -276,7 +277,7 @@ FindGuardedMemoryMap (
          mMapLevel < GUARDED_HEAP_MAP_TABLE_DEPTH &&
          RShiftU64 (
            Address,
-           mLevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH - mMapLevel - 1]
+           LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH - mMapLevel - 1]
            ) != 0)
   {
     if (mGuardedMemoryMap != 0) {
@@ -313,7 +314,7 @@ FindGuardedMemoryMap (
       *GuardMap = MapMemory;
     }
 
-    Index    = (UINTN)RShiftU64 (Address, mLevelShift[Level]);
+    Index    = (UINTN)RShiftU64 (Address, LevelShift[Level]);
     Index   &= mLevelMask[Level];
     GuardMap = (UINT64 *)(UINTN)((*GuardMap) + Index * sizeof (UINT64));
   }
@@ -1218,6 +1219,9 @@ SetAllGuardPages (
   INTN     Level;
   UINTN    Index;
   BOOLEAN  OnGuarding;
+  UINTN   LevelShift;
+
+  LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
 
   if ((mGuardedMemoryMap == 0) ||
       (mMapLevel == 0) ||
@@ -1227,7 +1231,7 @@ SetAllGuardPages (
   }
 
   CopyMem (Entries, mLevelMask, sizeof (Entries));
-  CopyMem (Shifts, mLevelShift, sizeof (Shifts));
+  CopyMem (Shifts, LevelShift, sizeof (Shifts));
 
   SetMem (Tables, sizeof (Tables), 0);
   SetMem (Addresses, sizeof (Addresses), 0);
@@ -1366,6 +1370,9 @@ DumpGuardedMemoryBitmap (
   CHAR8   String[GUARDED_HEAP_MAP_ENTRY_BITS + 1];
   CHAR8   *Ruler1;
   CHAR8   *Ruler2;
+  UINTN   LevelShift;
+
+  LevelShift[GUARDED_HEAP_MAP_TABLE_DEPTH] = GUARDED_HEAP_MAP_TABLE_DEPTH_SHIFTS;
 
   if ((mGuardedMemoryMap == 0) ||
       (mMapLevel == 0) ||
@@ -1387,7 +1394,7 @@ DumpGuardedMemoryBitmap (
   DEBUG ((HEAP_GUARD_DEBUG_LEVEL, "                  %a\r\n", Ruler2));
 
   CopyMem (Entries, mLevelMask, sizeof (Entries));
-  CopyMem (Shifts, mLevelShift, sizeof (Shifts));
+  CopyMem (Shifts, LevelShift, sizeof (Shifts));
 
   SetMem (Indices, sizeof (Indices), 0);
   SetMem (Tables, sizeof (Tables), 0);

--- a/MmSupervisorPkg/Core/Mem/PageTbl.c
+++ b/MmSupervisorPkg/Core/Mem/PageTbl.c
@@ -844,11 +844,10 @@ SmiDefaultPFHandler (
   }
 
   //
-  // If execute-disable is enabled, set NX bit
+  // Execute-disable is enabled, set NX bit
   //
-  if (mXdEnabled) {
-    PageAttribute |= IA32_PG_NX;
-  }
+  PageAttribute |= IA32_PG_NX;
+
 
   for (Index = 0; Index < NumOfPages; Index++) {
     PageTable  = PageTableTop;

--- a/MmSupervisorPkg/Core/Mem/PageTbl.c
+++ b/MmSupervisorPkg/Core/Mem/PageTbl.c
@@ -848,7 +848,6 @@ SmiDefaultPFHandler (
   //
   PageAttribute |= IA32_PG_NX;
 
-
   for (Index = 0; Index < NumOfPages; Index++) {
     PageTable  = PageTableTop;
     UpperEntry = NULL;

--- a/MmSupervisorPkg/Core/Mem/SmmProfile.c
+++ b/MmSupervisorPkg/Core/Mem/SmmProfile.c
@@ -115,7 +115,6 @@ InitPaging (
   CpuFlushTlb ();
   DEBUG ((DEBUG_INFO, "Patch page table done!\n"));
 
-
   PERF_FUNCTION_END ();
 }
 

--- a/MmSupervisorPkg/Core/Mem/SmmProfile.c
+++ b/MmSupervisorPkg/Core/Mem/SmmProfile.c
@@ -25,11 +25,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 BOOLEAN  mXdSupported = TRUE;
 
 //
-// The flag indicates if execute-disable is enabled on processor.
-//
-BOOLEAN  mXdEnabled = FALSE;
-
-//
 // The flag indicates if BTS is supported by processor.
 //
 BOOLEAN  mBtsSupported = TRUE;
@@ -119,10 +114,7 @@ InitPaging (
   //
   CpuFlushTlb ();
   DEBUG ((DEBUG_INFO, "Patch page table done!\n"));
-  //
-  // Set execute-disable flag
-  //
-  mXdEnabled = TRUE;
+
 
   PERF_FUNCTION_END ();
 }

--- a/MmSupervisorPkg/Core/Mem/SmmProfile.h
+++ b/MmSupervisorPkg/Core/Mem/SmmProfile.h
@@ -47,5 +47,4 @@ GetCpuIndex (
 //
 extern BOOLEAN  mXdSupported;
 
-
 #endif // _SMM_PROFILE_H_

--- a/MmSupervisorPkg/Core/Mem/SmmProfile.h
+++ b/MmSupervisorPkg/Core/Mem/SmmProfile.h
@@ -46,9 +46,6 @@ GetCpuIndex (
 // The flag indicates if execute-disable is supported by processor.
 //
 extern BOOLEAN  mXdSupported;
-//
-// The flag indicates if execute-disable is enabled on processor.
-//
-extern BOOLEAN  mXdEnabled;
+
 
 #endif // _SMM_PROFILE_H_

--- a/MmSupervisorPkg/Core/Relocate/Relocate.c
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.c
@@ -1086,9 +1086,9 @@ SetupSmiEntryExit (
   }
 
   mSmmCpl3StackArrayBase = (UINTN)Cpl3Stacks;
-  #if FeaturePcdGet (PcdMmSupervisorTestEnable)
-  mSmmCpl3StackArrayEnd  = mSmmCpl3StackArrayBase + gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus * mSmmStackSize - 1;
-  #endif
+ #if FeaturePcdGet (PcdMmSupervisorTestEnable)
+  mSmmCpl3StackArrayEnd = mSmmCpl3StackArrayBase + gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus * mSmmStackSize - 1;
+ #endif
 
   //
   // Initialize IDT

--- a/MmSupervisorPkg/Core/Relocate/Relocate.c
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.c
@@ -42,7 +42,9 @@ UINTN  mSmmStackArrayEnd;
 UINTN  mSmmStackSize;
 
 UINTN  mSmmCpl3StackArrayBase;
+#if FeaturePcdGet (PcdMmSupervisorTestEnable)
 UINTN  mSmmCpl3StackArrayEnd;
+#endif
 
 UINTN    mSmmShadowStackSize;
 BOOLEAN  mCetSupported = TRUE;
@@ -1084,7 +1086,9 @@ SetupSmiEntryExit (
   }
 
   mSmmCpl3StackArrayBase = (UINTN)Cpl3Stacks;
+  #if FeaturePcdGet (PcdMmSupervisorTestEnable)
   mSmmCpl3StackArrayEnd  = mSmmCpl3StackArrayBase + gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus * mSmmStackSize - 1;
+  #endif
 
   //
   // Initialize IDT

--- a/MmSupervisorPkg/Core/Relocate/Relocate.h
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.h
@@ -248,7 +248,9 @@ extern UINTN                 mSmmStackArrayBase;
 extern UINTN                 mSmmStackArrayEnd;
 extern UINTN                 mSmmStackSize;
 extern UINTN                 mSmmCpl3StackArrayBase;
+#if FeaturePcdGet (PcdMmSupervisorTestEnable)
 extern UINTN                 mSmmCpl3StackArrayEnd;
+#endif
 extern SMM_CPU_SEMAPHORES    mSmmCpuSemaphores;
 extern UINTN                 mSemaphoreSize;
 extern SPIN_LOCK             *mPFLock;

--- a/MmSupervisorPkg/Core/Relocate/Relocate.h
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.h
@@ -249,7 +249,7 @@ extern UINTN                 mSmmStackArrayEnd;
 extern UINTN                 mSmmStackSize;
 extern UINTN                 mSmmCpl3StackArrayBase;
 #if FeaturePcdGet (PcdMmSupervisorTestEnable)
-extern UINTN                 mSmmCpl3StackArrayEnd;
+extern UINTN  mSmmCpl3StackArrayEnd;
 #endif
 extern SMM_CPU_SEMAPHORES    mSmmCpuSemaphores;
 extern UINTN                 mSemaphoreSize;

--- a/MmSupervisorPkg/Core/Test/PagingAudit.c
+++ b/MmSupervisorPkg/Core/Test/PagingAudit.c
@@ -224,7 +224,9 @@ StackDumpHandler (
   CommBuffer->SupvStackBaseAddr = mSmmStackArrayBase;
   CommBuffer->SupvStackSize     = mSmmStackArrayEnd - mSmmStackArrayBase + 1;
   CommBuffer->UserStackBaseAddr = mSmmCpl3StackArrayBase;
+  #if FeaturePcdGet (PcdMmSupervisorTestEnable)
   CommBuffer->UserStackSize     = mSmmCpl3StackArrayEnd - mSmmCpl3StackArrayBase + 1;
+  #endif
 }
 
 /**

--- a/MmSupervisorPkg/Core/Test/PagingAudit.c
+++ b/MmSupervisorPkg/Core/Test/PagingAudit.c
@@ -224,9 +224,9 @@ StackDumpHandler (
   CommBuffer->SupvStackBaseAddr = mSmmStackArrayBase;
   CommBuffer->SupvStackSize     = mSmmStackArrayEnd - mSmmStackArrayBase + 1;
   CommBuffer->UserStackBaseAddr = mSmmCpl3StackArrayBase;
-  #if FeaturePcdGet (PcdMmSupervisorTestEnable)
-  CommBuffer->UserStackSize     = mSmmCpl3StackArrayEnd - mSmmCpl3StackArrayBase + 1;
-  #endif
+ #if FeaturePcdGet (PcdMmSupervisorTestEnable)
+  CommBuffer->UserStackSize = mSmmCpl3StackArrayEnd - mSmmCpl3StackArrayBase + 1;
+ #endif
 }
 
 /**


### PR DESCRIPTION
## Description

Some global variables exist that are unnecessary because they're values are constant or they're only used in testing scenarios.  This change removes the unnecessary variables and adds guards around the globals that are used for testing so they only are in builds which enable the testing PCD.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Physical platform.  Behavior remains the same with or without this change.

## Integration Instructions

N/A