### PR TITLE
gen_aux: Provide default value for sentinel

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
@@ -115,6 +115,7 @@ impl From<&Symbol> for ValidationRule {
 pub struct ArrayConfig {
     /// Specifies that the last index in the array is a sentinel value, thus creating a different
     /// validation rule for the last index, Content of all zeros.
+    #[serde(default)]
     pub sentinel: bool,
     /// The index to apply the validation to. If this is not set, the validation
     /// is applied to the entire array.


### PR DESCRIPTION
## Description

Previously, if `index` was specified, then sentinel was required to be specified I did not indicate that the default value should be used if it is missing. This is fixed in this PR.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
