### PR TITLE
gen_aux: Ignore symbols outside of read/write section

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -136,6 +136,11 @@ pub fn main() -> Result<()> {
     let address_map = pdb.address_map()?;
     let type_information = pdb.type_information()?;
     let debug_information = pdb.debug_information()?;
+    let sections = pdb.sections()?.unwrap_or_default();
+    let sections = sections.iter().map(|section| {
+        let range = section.virtual_address..section.virtual_address + section.virtual_size;
+        (range, section.characteristics)
+    }).collect::<Vec<_>>();
 
     let mut raw_symbol_iter = symbol_table.iter();
     let mut parsed_symbols: HashMap<String, Symbol> = HashMap::new();
@@ -146,19 +151,18 @@ pub fn main() -> Result<()> {
         let module_info = pdb.module_info(&module)?.unwrap();
         let mut symbols = module_info.symbols()?;
         while let Some(symbol) = symbols.next()? {
-            util::add_symbol(&mut parsed_symbols, symbol, &address_map, &type_information)?;
+            util::add_symbol(&mut parsed_symbols, symbol, &address_map, &type_information, &*sections)?;
         }
     }
 
     // Add symbols from the global scope
     while let Some(symbol) = raw_symbol_iter.next()? {
-        util::add_symbol(&mut parsed_symbols, symbol, &address_map, &type_information)?;
+        util::add_symbol(&mut parsed_symbols, symbol, &address_map, &type_information, &*sections)?;
     }
     if args.generate_config {
-        let sections = pdb.sections()?.unwrap_or_default();
         let rules: Vec<ValidationRule> = parsed_symbols
             .values()
-            .filter(|symbol| symbol.in_readonly_section(&sections))
+            .filter(|symbol| symbol.in_read_write_section())
             .map(|symbol| symbol.into())
             .collect();
 


### PR DESCRIPTION
## Description

If `no_missing_rules = true` is in the configuration file, we abort the execution of the tool when we find a symbol in the pdb that does not have a corresponding rule in the same configuration file. This is to prevent a new symbol from being introduced in the binary without the maintainers knowing, so that they can create a new rule for this symbol.

This change updates this logic to be aware of the section that the symbol resides in, and only aborts execution if the missing symbol is in a section that is both `read` and `write`. Otherwise, the symbol is filtered out.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Validated that removing a symbol from the configuration file that references a symbol in the `.data` section continues to result in a build error.
- Validated that removing a symbol from the configuration file that references a symbol in the `.rdata` section does not result in a build error.

## Integration Instructions

N/A
