### PR TITLE
gen_aux: Deny unknown config file fields

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/main.rs
@@ -57,6 +57,7 @@ pub struct Args {
 /// A struct that represents an signature/address pair to be added to the
 /// auxiliary file header.
 #[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct KeySymbol {
     /// The symbol name to calculate the offset of.
     pub symbol: Option<String>,
@@ -97,6 +98,7 @@ impl std::fmt::Debug for KeySymbol {
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// An option that if true, will generate a validation entry of 
     /// verification type NONE for every symbol without a rule in the config
@@ -114,6 +116,7 @@ pub struct Config {
 
 /// Configuration options available in the config file.
 #[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ConfigFile {
     #[serde(alias = "config", default = "Config::default")]
     pub config: Config,

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/validation.rs
@@ -18,6 +18,7 @@ use crate::Symbol;
 /// used to run the appropriate validation on the symbol in the firmware, and
 /// also revert the symbol to it's original value.
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct ValidationRule {
     /// The symbol that the rule is associated with.
     pub symbol: String,


### PR DESCRIPTION
## Description

Disables the ability to put unexpected fields in top level fields the following tables: `[[KeySymbol]]`, `[[rule]]`, `[config]`, and the top level table of the file itself.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated that the file is properly parsed as is, and that putting miscellaneous data in these tables causes the parser to fail.

## Integration Instructions

N/A
