### PR TITLE
[Rebase & FF] Protect read-only data

### DIFF
--- a/SeaPkg/Core/Runtime/SeaResponderReport.c
+++ b/SeaPkg/Core/Runtime/SeaResponderReport.c
@@ -29,6 +29,7 @@
 #include <Library/HashLib.h>
 #include <Library/HashLibRaw.h>
 #include <Library/SecurePolicyLib.h>
+#include <Library/PeCoffValidationLib.h>
 
 #include "StmRuntimeUtil.h"
 
@@ -134,6 +135,12 @@ VerifyAndHashImage (
   InternalCopy = AllocatePages (
                    EFI_SIZE_TO_PAGES (ImageSize + EFI_PAGE_SIZE - 1)
                    );
+
+  Status = PeCoffInspectImageMemory (ImageBase, ImageSize, PageTableBase);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: PeCoffInspectImageMemory failed - %r\n", __func__, Status));
+    goto Exit;
+  }
 
   //
   // Get information about the image being loaded

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -132,4 +132,22 @@ PeCoffImageValidationPointer (
   IN UINTN                                MsegSize
   );
 
+/**
+  Inspect the PE/COFF image to check if it is valid.
+
+  @param ImageBase      The base address of the image.
+  @param ImageSize      The size of the image.
+  @param PageTableBase  The base address of the page table.
+
+  @return EFI_STATUS    The status of the inspection.
+                        EFI_SUCCESS if the image is valid.
+**/
+EFI_STATUS
+EFIAPI
+PeCoffInspectImageMemory (
+  IN EFI_PHYSICAL_ADDRESS  ImageBase,
+  IN UINT64                ImageSize,
+  IN UINT64                PageTableBase
+  );
+
 #endif // PECOFF_VALIDATION_LIB_H_

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -711,7 +711,6 @@ GetAlignedVmcsSize (
 }
 
 /**
-  Gets the MSEG base from the MSR and calculates the MSEG size.
 
   @param[out] MsegBase  The MSEG base address.
   @param[out] MsegSize  The MSEG size.


### PR DESCRIPTION
## Description

The read-only data section was never protected with the existing implementation.

This change adds the extra layer of protection to the read-only data section to prevent unintentional tampering.

The SEA validation routine is also updated to incorporate the memory attribute change.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change was tested on QEMU Q35 virtual platform and passed test application.

## Integration Instructions

N/A