### PR TITLE
aux_gen: properly calculate array length

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/type_info.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/type_info.rs
@@ -135,7 +135,8 @@ impl TypeInfo {
             TypeData::Array(arr) => {
                 let total_size = arr.dimensions[0] as u64;
                 let element = TypeInfo::from_type_index(info, arr.element_type)?;
-                TypeInfo::many(element.element_size(), total_size / element.element_size(), element.type_id())            }
+                TypeInfo::many(element.element_size(), total_size / element.element_size(), element.type_id())
+            }
             pdb::TypeData::Union(union) => {
                 TypeInfo::one(union.size, Some(index))
             }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/type_info.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/type_info.rs
@@ -135,8 +135,7 @@ impl TypeInfo {
             TypeData::Array(arr) => {
                 let total_size = arr.dimensions[0] as u64;
                 let element = TypeInfo::from_type_index(info, arr.element_type)?;
-                TypeInfo::many(element.total_size(), total_size / element.total_size(), element.type_id())
-            }
+                TypeInfo::many(element.element_size(), total_size / element.element_size(), element.type_id())            }
             pdb::TypeData::Union(union) => {
                 TypeInfo::one(union.size, Some(index))
             }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/type_info.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/type_info.rs
@@ -133,6 +133,10 @@ impl TypeInfo {
                 TypeInfo::one(0, Some(index))
             }
             TypeData::Array(arr) => {
+                // The recursive nature of `TypeInfo::from_type_index` flattens n-dimensional arrays into a single
+                // dimension. This is because for each dimension, `element.total_size()` is the size of the current
+                // dimension. By using `element.element_size()` instead, we bubble up the size of the true element
+                // type, which is ultimately divided by the total size of the symbol.
                 let total_size = arr.dimensions[0] as u64;
                 let element = TypeInfo::from_type_index(info, arr.element_type)?;
                 TypeInfo::many(element.element_size(), total_size / element.element_size(), element.type_id())


### PR DESCRIPTION
## Description

A bug was introduced in the code that calculates the total element count of an array because it did not consider the case for when the symbol is a multi-dimensional array. This is because the `total_size` function returns the total size of the element in the array, which when working with a multi-dimensional array, is the size of the row (array), instead of the underlying element.

To resolve this issue, we instead calculate the total element count by using the `element_size()` function, which returns the size of the underlying type instead. Due to this recursive nature of `TypeInfo::from_type_index`, this is ultimately the actual element type, even if the symbol is a 2, 3, 4, etc. dimensional array.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated a symbol that is a 2-Demensional array now has entries generated equal to MxN.

## Integration Instructions

N/A
