### PR TITLE
Fix bug around updating the StmHeader in MSEG

### DIFF
--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -730,7 +730,6 @@ GetMsegBaseAndSize (
   EFI_STATUS                         Status;
   MSR_IA32_SMM_MONITOR_CTL_REGISTER  SmmMonitorCtl;
   STM_HEADER                         *StmHeader;
-  UINTN                              NumberOfCpus;
 
   //
   // Find the MSEG Base address
@@ -754,12 +753,9 @@ GetMsegBaseAndSize (
   //
   // Calculate the Minimum MSEG size
   //
-  StmHeader    = (STM_HEADER *)(UINTN)*MsegBase;
-  NumberOfCpus = StmHeader->CpuInfoHdr.NumberOfCpus;
+  StmHeader = (STM_HEADER *)(UINTN)*MsegBase;
 
-  *MsegSize = (EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (StmHeader->SwStmHdr.StaticImageSize)) +
-               StmHeader->SwStmHdr.AdditionalDynamicMemorySize +
-               (StmHeader->SwStmHdr.PerProcDynamicMemorySize + GetAlignedVmcsSize () * 2) * NumberOfCpus);
+  *MsegSize = StmHeader->CpuInfoHdr.MsegSize;
 
   Status = EFI_SUCCESS;
 


### PR DESCRIPTION
## Description

Fix a bug where the MSR_IA32_SMM_MONITOR_CTL MSR was being overwritten and the StmHeader information was being lost.  Now the code updates the mMsegBase variable which is eventually written into the MSR_IA32_SMM_MONITOR_CTL  MSR.  Additionally, all Cpu core count references now pull directly from the HOB data that was already being stored as a global.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on an Intel Physical platform

## Integration Instructions

N/A