### PR TITLE
Update self ref validation to use the original image for validation

### DIFF
--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -91,9 +91,8 @@ PeCoffImageValidationMemAttr (
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
   matches the content in the original image buffer as specified by TargetOffset in the validation entry.
 
-  @param[in] TargetImage               The pointer to the target image buffer.
-  @param[in] Hdr                       The header of the validation entry.
   @param[in] OriginalImageBaseAddress  The pointer to the original image buffer.
+  @param[in] Hdr                       The header of the validation entry.
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
@@ -104,9 +103,8 @@ PeCoffImageValidationMemAttr (
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationSelfRef (
-  IN CONST VOID                           *TargetImage,
+  IN CONST VOID                           *OriginalImageBaseAddress,
   IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
-  IN CONST VOID                           *OriginalImageBaseAddress
   );
 
 /**

--- a/SeaPkg/Include/Library/PeCoffValidationLib.h
+++ b/SeaPkg/Include/Library/PeCoffValidationLib.h
@@ -104,7 +104,7 @@ EFI_STATUS
 EFIAPI
 PeCoffImageValidationSelfRef (
   IN CONST VOID                           *OriginalImageBaseAddress,
-  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
   );
 
 /**

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -884,7 +884,7 @@ PeCoffImageDiffValidation (
         NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)((IMAGE_VALIDATION_MEM_ATTR *)ImageValidationEntryHdr + 1);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_SELF_REF:
-        Status                      = PeCoffImageValidationSelfRef (OriginalImageBaseAddress, ImageValidationEntryHdr, OriginalImageBaseAddress);
+        Status                      = PeCoffImageValidationSelfRef (OriginalImageBaseAddress, ImageValidationEntryHdr);
         NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)((IMAGE_VALIDATION_SELF_REF *)ImageValidationEntryHdr + 1);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_POINTER:

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -884,7 +884,7 @@ PeCoffImageDiffValidation (
         NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)((IMAGE_VALIDATION_MEM_ATTR *)ImageValidationEntryHdr + 1);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_SELF_REF:
-        Status                      = PeCoffImageValidationSelfRef (TargetImage, ImageValidationEntryHdr, OriginalImageBaseAddress);
+        Status                      = PeCoffImageValidationSelfRef (OriginalImageBaseAddress, ImageValidationEntryHdr, OriginalImageBaseAddress);
         NextImageValidationEntryHdr = (IMAGE_VALIDATION_ENTRY_HEADER *)((IMAGE_VALIDATION_SELF_REF *)ImageValidationEntryHdr + 1);
         break;
       case IMAGE_VALIDATION_ENTRY_TYPE_POINTER:

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -463,7 +463,7 @@ PeCoffImageValidationPointer (
 
   AddrInTarget = 0;
   CopyMem (&AddrInTarget, (UINT8 *)TargetImage + Hdr->Offset, Hdr->Size);
-  InMseg = ((UINTN)AddrInTarget >= MsegBase - MsegSize) && ((UINTN)AddrInTarget < MsegBase);
+  InMseg = ((UINTN)AddrInTarget >= MsegBase) && ((UINTN)AddrInTarget < MsegBase + MsegSize);
   if ((BOOLEAN)PointerHdr->InMseg != InMseg) {
     DEBUG ((
       DEBUG_ERROR,

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -315,7 +315,7 @@ Done:
   Validates a specific region in the target image buffer denoted by [Hdr->Offset: Hdr->Offset + Hdr->Size]
   matches the content in the original image buffer as specified by TargetOffset in the validation entry.
 
-  @param[in] TargetImage               The pointer to the target image buffer.
+  @param[in] OriginalImageBaseAddress  The pointer to the original image buffer.
   @param[in] Hdr                       The header of the validation entry.
 
   @retval EFI_SUCCESS             The target image passes the validation.

--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -317,7 +317,6 @@ Done:
 
   @param[in] TargetImage               The pointer to the target image buffer.
   @param[in] Hdr                       The header of the validation entry.
-  @param[in] OriginalImageBaseAddress  The pointer to the original image buffer.
 
   @retval EFI_SUCCESS             The target image passes the validation.
   @retval EFI_INVALID_PARAMETER   One of the input parameters is a null pointer.
@@ -328,9 +327,8 @@ Done:
 EFI_STATUS
 EFIAPI
 PeCoffImageValidationSelfRef (
-  IN CONST VOID                           *TargetImage,
-  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr,
-  IN CONST VOID                           *OriginalImageBaseAddress
+  IN CONST VOID                           *OriginalImageBaseAddress,
+  IN CONST IMAGE_VALIDATION_ENTRY_HEADER  *Hdr
   )
 {
   IMAGE_VALIDATION_SELF_REF  *SelfRefHdr;
@@ -338,14 +336,13 @@ PeCoffImageValidationSelfRef (
   EFI_PHYSICAL_ADDRESS       AddrInTarget;
   EFI_PHYSICAL_ADDRESS       AddrInOrigin;
 
-  if ((TargetImage == NULL) || (Hdr == NULL) || (OriginalImageBaseAddress == NULL)) {
+  if ((Hdr == NULL) || (OriginalImageBaseAddress == NULL)) {
     DEBUG ((
       DEBUG_ERROR,
-      "%a: At least one invalid input parameter: TargetImage 0x%p, Hdr 0x%p, OriginalImageBaseAddress 0x%p\n",
+      "%a: At least one invalid input parameter: OriginalImageBaseAddress 0x%p, Hdr 0x%p\n",
       __func__,
-      TargetImage,
-      Hdr,
-      OriginalImageBaseAddress
+      OriginalImageBaseAddress,
+      Hdr
       ));
     Status = EFI_INVALID_PARAMETER;
     goto Done;
@@ -372,7 +369,7 @@ PeCoffImageValidationSelfRef (
   }
 
   AddrInTarget = 0;
-  CopyMem (&AddrInTarget, (UINT8 *)TargetImage + Hdr->Offset, Hdr->Size);
+  CopyMem (&AddrInTarget, (UINT8 *)OriginalImageBaseAddress + Hdr->Offset, Hdr->Size);
   AddrInOrigin = (EFI_PHYSICAL_ADDRESS)(UINTN)((UINT8 *)OriginalImageBaseAddress + SelfRefHdr->TargetOffset);
 
   if (AddrInTarget != AddrInOrigin) {


### PR DESCRIPTION
## Description

Update self ref validation to use the original image for validation.  This avoids the issue where the relocation code changes the target image contents that we're trying to validate leading to a failure in the rules validation.  Instead we use the original image to validate the pointer.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on an Intel Physical platform.  The previously failing rules now pass.

## Integration Instructions

N/A