### PR TITLE
initial commit

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
@@ -28,3 +28,4 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.140"
 simple_logger = { version = "5.0.0", default-features = false }
 toml = "0.8.10"
+regex = "1"

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -62,6 +62,7 @@ field = 'Optional[String]'
 array.index = 'Optional[Int]'|'Optional[Array[Int;2]]'
 array.sentinel = 'Optional[Boolean]'
 validation.type = 'Required[String]'
+reviewed-by = 'Optional[Array[String]]'
 ```
 
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
@@ -71,6 +72,8 @@ validation.type = 'Required[String]'
 - `array.sentinel`: Apply content rule to only the final rule such that its content must be all zeros.
 - `validation.type`: The type of validation to perform on this symbol. Different values may also require additional configuration
 settings in the `[[rule]]`.
+- `reviewed-by`: A list of reviewers using git sign-off format of `First Last <email>`. This value is passed through to
+the final report.
 
 #### Validation Type: None
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -440,6 +440,10 @@ pub struct Segment {
     covered: bool,
     /// The reason the segment is covered or not.
     reason: String,
+    /// The people associated with reviewing this segment.
+    /// 
+    /// This field is only used when the segment is covered by a validation rule.
+    reviewers: Vec<String>,
 }
 
 impl Segment {
@@ -453,6 +457,7 @@ impl Segment {
             _end: end,
             covered,
             reason,
+            reviewers: Vec::new(),
         }
     }
 
@@ -486,6 +491,7 @@ impl Segment {
             _end: entry.offset + entry.size,
             covered: true,
             reason: format!("Validation Rule: {}", rule),
+            reviewers: metadata.reviewers_from_address(&entry.offset).unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION
## Description

Adds a new entry, `reviewed-by` to `[[rule]]` entry in the configuration file that gets passed to the final aux file report.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

Consumers can add `reviewed-by` entries to each rule, which is an array of git sign-off format signatures.
