### PR TITLE
aux_gen: Add new `guid` rule to `[[rule]]`

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
@@ -29,3 +29,4 @@ serde_json = "1.0.140"
 simple_logger = { version = "5.0.0", default-features = false }
 toml = "0.8.10"
 regex = "1"
+r-efi = "5.2.0"

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -140,6 +140,16 @@ validation.type = "pointer"
 validation.in_mseg = true # Default: false
 ```
 
+#### Validation Type: Guid
+
+The guid validation type verifies that a symbol representing a guid is the expected guid value. Behind the scenes,
+this rule simply generates a `Content` rule of the bytes, but does the conversion for you.
+
+``` toml
+validation.type = "guid"
+validation.guid = [0x0, 0x0, 0x0, [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]]
+```
+
 ### config
 
 The below configuration options reside in a top level `[config]` section of the configuration file.

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -327,6 +327,9 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
                 address: self.find_symbol(reference).address,
             }),
             Validation::Pointer { in_mseg } => Ok(ValidationType::Pointer { in_mseg: *in_mseg }),
+            Validation::Guid { guid } => Ok(ValidationType::Content {
+                content: guid.as_bytes().to_vec(),
+            }),
         }
     }
 


### PR DESCRIPTION
## Description

Adds a new rule, `guid`, that generates a `content` validation entry header in the aux file.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated that the generated aux file is the same exact file when replacing a content rule with the guid rule.

## Integration Instructions

Consumers can now use `validation.type = "guid"` with a `guild` field of [a, b, c, [d0, d1, d2, d3, d4, d5, d6, d7]

```toml
[[rule]]
symbol = "MyGuid"
validation.type = "guid"
validation.content = [0x0, 0x0, 0x0, [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]]
```
