### PR TITLE
Add an image dump when encountering a validation error

### DIFF
--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -926,6 +926,8 @@ PeCoffImageDiffValidation (
     }
 
     if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Validation Error! Dumping MmSupervisor Image\n"));
+      DUMP_HEX (DEBUG_ERROR, 0, OriginalImageBaseAddress, TargetImageSize, "    ");
       break;
     }
 


### PR DESCRIPTION
## Description

Add an image dump when encountering a validation error in BasePeCoffLibNegative.  This image can be used to debug what symbols are not being correctly validated.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on an Intel physical platform.  The image is dumped as expected when a failure occurs.

## Integration Instructions

N/A