### PR TITLE
Integrate override changes from Stmm core

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -252,6 +252,7 @@ extern UINTN                             mMmHobSize;
 extern VOID                              *mInternalCommBufferCopy[MM_OPEN_BUFFER_CNT];
 extern SMM_SUPV_SECURE_POLICY_DATA_V1_0  *FirmwarePolicy;
 extern SMM_SUPV_SECURE_POLICY_DATA_V1_0  *MemPolicySnapshot;
+extern EFI_MM_SYSTEM_TABLE               *mMemoryAllocationMmst;
 
 /**
   Called to initialize the memory service.

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -11,9 +11,7 @@
 ##
 
 # release/202502
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 3f2b83f1253dc1f8cd8f71a1c6823a38 | 2025-04-12T14-48-24 | 6a19361b3a5c70a4779011d1dd35490e3b87dcc4
-# dev/202405
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | fcc0084f42574f4331ad258e53381c93 | 2025-01-27T21-27-02 | f54f113b0b84eb2fec245b97aad60545ba7a554b
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 887d09c7b82217d50d0b0cf311290739 | 2025-05-23T09-22-55 | a0369d2113577ca80280fb1eeafe3dc7c536d5d8
 # Secure
 #Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 6967cd9168f4e96b0df5067c87ad9bc3 | 2025-01-30T00-05-01 | 564d4055cdf6801ee0c7264a4510748131d3165e
 # Non-Secure
@@ -237,6 +235,7 @@
   gMmSupervisorPolicyFileGuid                   ## CONSUMES
   gMmPagingAuditMmiHandlerGuid                  ## SOMETIMES_CONSUMES
   gEfiHobMemoryAllocModuleGuid
+  gEfiMmPeiMmramMemoryReserveGuid
 
 [BuildOptions.common]
   #Subsystem version will be used as MmSupervisor driver version

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
@@ -11,7 +11,7 @@
 # This module contains an instance of protocol/handle from StandaloneMmCore and pool memory + guard management from PiSmmCore.
 
 # release/202502
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 3f2b83f1253dc1f8cd8f71a1c6823a38 | 2025-04-12T14-48-24 | 6a19361b3a5c70a4779011d1dd35490e3b87dcc4
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 887d09c7b82217d50d0b0cf311290739 | 2025-05-23T09-22-55 | a0369d2113577ca80280fb1eeafe3dc7c536d5d8
 # Dev/202405
 #Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | fcc0084f42574f4331ad258e53381c93 | 2025-01-27T21-27-02 | f54f113b0b84eb2fec245b97aad60545ba7a554b
 # Release/202405


### PR DESCRIPTION
## Description

This change adds the cherry-pick commits from
https://github.com/microsoft/mu_basecore/commit/3791438b70592b9ed11071a7739f534170786994#diff-1f895d21640680d5b49ff8e3f5055f7dac2ac7afa2448aa7c932d09c5388580f

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change is being tested.

## Integration Instructions

Update to at least `a0369d2113577ca80280fb1eeafe3dc7c536d5d8` of basecore.
