### PR TITLE
MmSupervisorPkg: MmSupervisorCore consume PcdMigrateTemporaryRamFirmwareVolumes.

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -203,6 +203,8 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSmiHandlerProfilePropertyMask       ## CONSUMES
   gMmSupervisorPkgTokenSpaceGuid.PcdMmSupervisorPrintPortsMaxSize       ## CONSUMES
   gMmSupervisorPkgTokenSpaceGuid.PcdMmSupervisorExceptionStackSize      ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateTemporaryRamFirmwareVolumes   ## CONSUMES
+
 
 [FixedPcd.X64]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmRestrictedMemoryAccess        ## CONSUMES


### PR DESCRIPTION

## Description


A platform has the ability to set PcdMigrateTemporaryRamFirmwareVolumes which tells the PEI core to migrate Firmware volumes from the flash part into system memory after gEfiPeiMemoryDiscoveredPpiGuid is installed.

When this happens, the platform may decide to leave the original EFI_HOB_TYPE_FVs in place, and expect consumers to switch to using EFI_HOB_TYPE_FV2.

Add the capability to consume EFI_HOB_TYPE_FV2 when this PCD is set. Also update the Hob consuming code to ensure that the length field of Length field of EFI_HOB_FIRMWARE_VOLUME/EFI_HOB_FIRMWARE_VOLUME2 is non zero before attempting to access/consume data from the hob.


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Testing on a platform which set PcdMigrateTemporaryRamFirmwareVolumes to True.

## Integration Instructions
No integration necessary.