### PR TITLE
MmSupervisorPkg: Add missing MmCoreDataHobGuid.

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -236,6 +236,7 @@
   gMmPagingAuditMmiHandlerGuid                  ## SOMETIMES_CONSUMES
   gEfiHobMemoryAllocModuleGuid
   gEfiMmPeiMmramMemoryReserveGuid
+  gMmCoreDataHobGuid
 
 [BuildOptions.common]
   #Subsystem version will be used as MmSupervisor driver version


### PR DESCRIPTION

## Description

MmSupervisorCore relies on the gMmCoreDataHobGuid, but it is not explicit in the need for it in the INF.

Add the gMmCoreDataHobGuid to explicitly define the dependency.

Fixes the GUID being drop in https://github.com/microsoft/mu_feature_mm_supv/commit/0a59afaeb812d8241a0a760d4aed87ddd289c103.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Found while integrating into a new platform. Build failed due to unresolved external,
but build passed after adding guid to dependency.

## Integration Instructions

No integration necessary.