### PR TITLE
aux_gen: Add remarks config to [[rule]]

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -63,6 +63,7 @@ array.index = 'Optional[Int]'|'Optional[Array[Int;2]]'
 array.sentinel = 'Optional[Boolean]'
 validation.type = 'Required[String]'
 reviewed-by = 'Optional[Array[String]]'
+remarks = 'Optional[String]'
 ```
 
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
@@ -74,6 +75,7 @@ reviewed-by = 'Optional[Array[String]]'
 settings in the `[[rule]]`.
 - `reviewed-by`: A list of reviewers using git sign-off format of `First Last <email>`. This value is passed through to
 the final report.
+- `remarks`: Additional context to this rule / symbol and why the validation type was selected.
 
 #### Validation Type: None
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
@@ -10,8 +10,8 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 use std::ops::RangeInclusive;
 
-use serde::{Deserialize, Serialize};
 use r_efi::efi::Guid;
+use serde::{Deserialize, Serialize};
 
 /// The configuration file for generating an auxiliary file.
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -102,6 +102,9 @@ pub struct Rule {
         deserialize_with = "deserialize_reviewers"
     )]
     pub reviewers: Vec<String>,
+    /// Any additional remarks / context for the rule.
+    #[serde(default)]
+    pub remarks: String,
 }
 
 fn deserialize_reviewers<'de, D>(deserializer: D) -> core::result::Result<Vec<String>, D::Error>
@@ -245,9 +248,12 @@ pub enum Validation {
     #[serde(rename = "guid")]
     Guid {
         /// The GUID to validate against.
-        #[serde(deserialize_with = "deserialize_guid", serialize_with = "serialize_guid")]
+        #[serde(
+            deserialize_with = "deserialize_guid",
+            serialize_with = "serialize_guid"
+        )]
         guid: Guid,
-    }
+    },
 }
 
 /// A custom deserializer for a [Guid].

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -451,6 +451,8 @@ pub struct Segment {
     ///
     /// This field is only used when the segment is covered by a validation rule.
     reviewers: Vec<String>,
+    /// Comments about the segment.
+    remarks: String,
 }
 
 impl Segment {
@@ -465,6 +467,7 @@ impl Segment {
             covered,
             reason,
             reviewers: Vec::new(),
+            remarks: String::new(),
         }
     }
 
@@ -491,19 +494,20 @@ impl Segment {
     ) -> Self {
         let validation = &entry.validation_type;
         let rule = validation.to_string();
+        let (symbol, reviewers, remarks) = metadata.context_from_address(&entry.offset).map_or(
+            ("Symbol Padding".to_string(), vec![], "".to_string()),
+            |c| (c.name.clone(), c.reviewers.clone(), c.remarks.clone()),
+        );
         Segment {
-            symbol: metadata
-                .name_from_address(&entry.offset)
-                .unwrap_or("Symbol Padding".to_string()),
+            symbol,
             start: format!("{:#x}", entry.offset),
             _start: entry.offset,
             end: format!("{:#x}", entry.offset + entry.size),
             _end: entry.offset + entry.size,
             covered: true,
             reason: format!("Validation Rule: {}", rule),
-            reviewers: metadata
-                .reviewers_from_address(&entry.offset)
-                .unwrap_or_default(),
+            reviewers,
+            remarks,
         }
     }
 }

--- a/SeaPkg/Tools/GenSeaArtifacts/test_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/test_aux/src/main.rs
@@ -117,7 +117,8 @@ fn main() -> Result<()> {
         .iter()
         .map(|entry| {
             let name = metadata
-                .name_from_address(&entry.offset)
+                .context_from_address(&entry.offset)
+                .map(|c| c.name.clone())
                 .unwrap_or("Padding".to_string());
             (name, entry)
         })


### PR DESCRIPTION
## Description

Adds a new, optional, field to the [[rule]] portion of the configuration file for generating an aux. This field allows users to add additional remarks / comments / context around the rule. This metadata is transfered to the raw data json coverage report.

```toml
[[rule]]
remarks = "I am adding a remark"
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated the remarks is transfered to the raw data json coverage report.

## Integration Instructions

N/A
