### PR TITLE
[REBASE&FF] SeaPkg: Auxiliary file cherry-picks

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
@@ -28,3 +28,4 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.140"
 simple_logger = { version = "5.0.0", default-features = false }
 toml = "0.8.10"
+regex = "1"

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/bin/create_config.rs"
 [dependencies]
 anyhow = "1.0.80"
 clap = { version = "4.5.1", features = ["derive"] }
+chrono = "0.4"
 goblin = "0.8.0"
 log = "0.4.27"
 pdb = "0.8.0"

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/Cargo.toml
@@ -29,3 +29,4 @@ serde_json = "1.0.140"
 simple_logger = { version = "5.0.0", default-features = false }
 toml = "0.8.10"
 regex = "1"
+r-efi = "5.2.0"

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -63,6 +63,7 @@ array.index = 'Optional[Int]'|'Optional[Array[Int;2]]'
 array.sentinel = 'Optional[Boolean]'
 validation.type = 'Required[String]'
 reviewed-by = 'Optional[Array[String]]'
+remarks = 'Optional[String]'
 ```
 
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
@@ -74,6 +75,7 @@ reviewed-by = 'Optional[Array[String]]'
 settings in the `[[rule]]`.
 - `reviewed-by`: A list of reviewers using git sign-off format of `First Last <email>`. This value is passed through to
 the final report.
+- `remarks`: Additional context to this rule / symbol and why the validation type was selected.
 
 #### Validation Type: None
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -63,6 +63,7 @@ array.index = 'Optional[Int]'|'Optional[Array[Int;2]]'
 array.sentinel = 'Optional[Boolean]'
 validation.type = 'Required[String]'
 reviewed-by = 'Optional[Array[String]]'
+last-reviewed = 'Optional[String]'
 remarks = 'Optional[String]'
 ```
 
@@ -75,6 +76,7 @@ remarks = 'Optional[String]'
 settings in the `[[rule]]`.
 - `reviewed-by`: A list of reviewers using git sign-off format of `First Last <email>`. This value is passed through to
 the final report.
+- `last-reviewed`: The date this rule was last reviewed, with the format YYYY-MM-DD.
 - `remarks`: Additional context to this rule / symbol and why the validation type was selected.
 
 #### Validation Type: None

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -62,6 +62,7 @@ field = 'Optional[String]'
 array.index = 'Optional[Int]'|'Optional[Array[Int;2]]'
 array.sentinel = 'Optional[Boolean]'
 validation.type = 'Required[String]'
+reviewed-by = 'Optional[Array[String]]'
 ```
 
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
@@ -71,6 +72,8 @@ validation.type = 'Required[String]'
 - `array.sentinel`: Apply content rule to only the final rule such that its content must be all zeros.
 - `validation.type`: The type of validation to perform on this symbol. Different values may also require additional configuration
 settings in the `[[rule]]`.
+- `reviewed-by`: A list of reviewers using git sign-off format of `First Last <email>`. This value is passed through to
+the final report.
 
 #### Validation Type: None
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -140,6 +140,16 @@ validation.type = "pointer"
 validation.in_mseg = true # Default: false
 ```
 
+#### Validation Type: Guid
+
+The guid validation type verifies that a symbol representing a guid is the expected guid value. Behind the scenes,
+this rule simply generates a `Content` rule of the bytes, but does the conversion for you.
+
+``` toml
+validation.type = "guid"
+validation.guid = [0x0, 0x0, 0x0, [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]]
+```
+
 ### config
 
 The below configuration options reside in a top level `[config]` section of the configuration file.

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/bin/create_config.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/bin/create_config.rs
@@ -44,8 +44,9 @@ fn main() -> Result<()> {
         .iter()
     {
         buffer.push_str(&format!(
-            "[[rule]]\nsymbol = \"{}\"\nvalidation.type = \"none\"\n\n",
-            segment.symbol()
+            "[[rule]]\nsymbol = \"{}\"\nvalidation.type = \"none\"\nlast-reviewed = \"{}\"\n\n",
+            segment.symbol(),
+            chrono::Local::now().format("%Y-%m-%d")
         ))
     }
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
@@ -102,9 +102,35 @@ pub struct Rule {
         deserialize_with = "deserialize_reviewers"
     )]
     pub reviewers: Vec<String>,
+    /// The date [YYYY-MM-DD] when the rule was last reviewed.
+    #[serde(
+        default,
+        rename = "last-reviewed",
+        deserialize_with = "deserialize_date"
+    )]
+    pub last_reviewed: String,
     /// Any additional remarks / context for the rule.
     #[serde(default)]
     pub remarks: String,
+}
+
+fn deserialize_date<'de, D>(deserializer: D) -> core::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{Deserialize, Error};
+
+    let date: String = String::deserialize(deserializer)?;
+    // Validate the date format YYYY-MM-DD
+    if !regex::Regex::new(r"^\d{4}-\d{2}-\d{2}$")
+        .unwrap()
+        .is_match(&date)
+    {
+        return Err(D::Error::custom(
+            "Invalid date format. Expected YYYY-MM-DD.",
+        ));
+    }
+    Ok(date)
 }
 
 fn deserialize_reviewers<'de, D>(deserializer: D) -> core::result::Result<Vec<String>, D::Error>

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
@@ -10,8 +10,8 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 use std::ops::RangeInclusive;
 
-use serde::{Deserialize, Serialize};
 use r_efi::efi::Guid;
+use serde::{Deserialize, Serialize};
 
 /// The configuration file for generating an auxiliary file.
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -102,6 +102,9 @@ pub struct Rule {
         deserialize_with = "deserialize_reviewers"
     )]
     pub reviewers: Vec<String>,
+    /// Any additional remarks / context for the rule.
+    #[serde(default)]
+    pub remarks: String,
 }
 
 fn deserialize_reviewers<'de, D>(deserializer: D) -> core::result::Result<Vec<String>, D::Error>
@@ -245,9 +248,12 @@ pub enum Validation {
     #[serde(rename = "guid")]
     Guid {
         /// The GUID to validate against.
-        #[serde(deserialize_with = "deserialize_guid", serialize_with = "serialize_guid")]
+        #[serde(
+            deserialize_with = "deserialize_guid",
+            serialize_with = "serialize_guid"
+        )]
         guid: Guid,
-    }
+    },
 }
 
 /// A custom deserializer for a [Guid].

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
@@ -94,6 +94,34 @@ pub struct Rule {
     pub array: Option<Array>,
     /// The type of validation to be performed on the symbol.
     pub validation: Validation,
+    /// People associated with reviewing this rule.
+    #[serde(
+        default,
+        rename = "reviewed-by",
+        deserialize_with = "deserialize_reviewers"
+    )]
+    pub reviewers: Vec<String>,
+}
+
+fn deserialize_reviewers<'de, D>(deserializer: D) -> core::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{Deserialize, Error};
+
+    let reviewers: Vec<String> = Vec::deserialize(deserializer)?;
+    let re =
+        regex::Regex::new(r"^[A-Z][a-z]+(?: [A-Z][a-z]+)* <[^<>@]+@[^<>@]+\.[^<>@]+>$").unwrap();
+
+    for reviewer in &reviewers {
+        if !re.is_match(reviewer) {
+            return Err(D::Error::custom(
+                "Invalid reviewer format. Expected `[F]irst [L]ast <email>`.",
+            ));
+        }
+    }
+
+    Ok(reviewers)
 }
 
 /// Configuration for a symbol that is an array of an underlying type.

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -24,14 +24,16 @@ const POINTER_LENGTH: u64 = 8;
 pub struct Context {
     pub name: String,
     pub reviewers: Vec<String>,
+    pub last_reviewed: String,
     pub remarks: String,
 }
 
 impl Context {
-    fn new(name: String, reviewers: Vec<String>, remarks: String) -> Self {
+    fn new(name: String, reviewers: Vec<String>, last_reviewed: String, remarks: String) -> Self {
         Context {
             name,
             reviewers,
+            last_reviewed,
             remarks,
         }
     }
@@ -165,7 +167,12 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
             }
             self.context_map.insert(
                 entry.offset,
-                Context::new(name, rule.reviewers.clone(), rule.remarks.clone()),
+                Context::new(
+                    name,
+                    rule.reviewers.clone(),
+                    rule.last_reviewed.clone(),
+                    rule.remarks.clone(),
+                ),
             );
 
             ret.push((entry, default));

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -327,6 +327,9 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
                 address: self.find_symbol(reference).address,
             }),
             Validation::Pointer { in_mseg } => Ok(ValidationType::Pointer { in_mseg: *in_mseg }),
+            Validation::Guid { guid } => Ok(ValidationType::Content {
+                content: guid.as_bytes().to_vec(),
+            }),
         }
     }
 

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -451,6 +451,8 @@ pub struct Segment {
     ///
     /// This field is only used when the segment is covered by a validation rule.
     reviewers: Vec<String>,
+    /// Comments about the segment.
+    remarks: String,
 }
 
 impl Segment {
@@ -465,6 +467,7 @@ impl Segment {
             covered,
             reason,
             reviewers: Vec::new(),
+            remarks: String::new(),
         }
     }
 
@@ -491,19 +494,20 @@ impl Segment {
     ) -> Self {
         let validation = &entry.validation_type;
         let rule = validation.to_string();
+        let (symbol, reviewers, remarks) = metadata.context_from_address(&entry.offset).map_or(
+            ("Symbol Padding".to_string(), vec![], "".to_string()),
+            |c| (c.name.clone(), c.reviewers.clone(), c.remarks.clone()),
+        );
         Segment {
-            symbol: metadata
-                .name_from_address(&entry.offset)
-                .unwrap_or("Symbol Padding".to_string()),
+            symbol,
             start: format!("{:#x}", entry.offset),
             _start: entry.offset,
             end: format!("{:#x}", entry.offset + entry.size),
             _end: entry.offset + entry.size,
             covered: true,
             reason: format!("Validation Rule: {}", rule),
-            reviewers: metadata
-                .reviewers_from_address(&entry.offset)
-                .unwrap_or_default(),
+            reviewers,
+            remarks,
         }
     }
 }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -451,6 +451,8 @@ pub struct Segment {
     ///
     /// This field is only used when the segment is covered by a validation rule.
     reviewers: Vec<String>,
+    /// The date the segment was last reviewed.
+    last_reviewed: String,
     /// Comments about the segment.
     remarks: String,
 }
@@ -467,6 +469,7 @@ impl Segment {
             covered,
             reason,
             reviewers: Vec::new(),
+            last_reviewed: String::new(),
             remarks: String::new(),
         }
     }
@@ -494,10 +497,23 @@ impl Segment {
     ) -> Self {
         let validation = &entry.validation_type;
         let rule = validation.to_string();
-        let (symbol, reviewers, remarks) = metadata.context_from_address(&entry.offset).map_or(
-            ("Symbol Padding".to_string(), vec![], "".to_string()),
-            |c| (c.name.clone(), c.reviewers.clone(), c.remarks.clone()),
-        );
+        let (symbol, reviewers, last_reviewed, remarks) =
+            metadata.context_from_address(&entry.offset).map_or(
+                (
+                    "Symbol Padding".to_string(),
+                    Default::default(),
+                    Default::default(),
+                    Default::default(),
+                ),
+                |c| {
+                    (
+                        c.name.clone(),
+                        c.reviewers.clone(),
+                        c.last_reviewed.clone(),
+                        c.remarks.clone(),
+                    )
+                },
+            );
         Segment {
             symbol,
             start: format!("{:#x}", entry.offset),
@@ -507,6 +523,7 @@ impl Segment {
             covered: true,
             reason: format!("Validation Rule: {}", rule),
             reviewers,
+            last_reviewed,
             remarks,
         }
     }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/report.rs
@@ -447,6 +447,10 @@ pub struct Segment {
     covered: bool,
     /// The reason the segment is covered or not.
     reason: String,
+    /// The people associated with reviewing this segment.
+    ///
+    /// This field is only used when the segment is covered by a validation rule.
+    reviewers: Vec<String>,
 }
 
 impl Segment {
@@ -460,6 +464,7 @@ impl Segment {
             _end: end,
             covered,
             reason,
+            reviewers: Vec::new(),
         }
     }
 
@@ -496,6 +501,9 @@ impl Segment {
             _end: entry.offset + entry.size,
             covered: true,
             reason: format!("Validation Rule: {}", rule),
+            reviewers: metadata
+                .reviewers_from_address(&entry.offset)
+                .unwrap_or_default(),
         }
     }
 }

--- a/SeaPkg/Tools/GenSeaArtifacts/test_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/test_aux/src/main.rs
@@ -117,7 +117,8 @@ fn main() -> Result<()> {
         .iter()
         .map(|entry| {
             let name = metadata
-                .name_from_address(&entry.offset)
+                .context_from_address(&entry.offset)
+                .map(|c| c.name.clone())
                 .unwrap_or("Padding".to_string());
             (name, entry)
         })


### PR DESCRIPTION
## Description

Cherry-picks aux-gen commits from the `add_seapkg_pecoffneglib_core_cnt_2405` branch that do the following:

1. Updates `test-aux` tool to include a `--scope` argument, allowing the filtering of rules to be applied during aux generation.
2. Adds a `reviewed-by` field to the `[[rule]]` section of the aux gen configuration file.
3. Adds a `guid` validation type to the `[[rule]]` section of the aux gen configuration file.
4. Adds a `remarks` field to the `[[rule]]` section of the aux gen configuration file.
5. Adds a `last-reviewed` field to the `[[rule]]` section of the aux gen configuration file.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local testing for each PR.

## Integration Instructions

All new fields are optional, so no integration is necessary, though these new features can start to be used.
