### PR TITLE
Remove PCI related content from this repository

### DIFF
--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -28,8 +28,6 @@
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
-  PciLib|MdePkg/Library/BasePciLibPciExpress/BasePciLibPciExpress.inf
-  PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
   CacheMaintenanceLib|MdePkg/Library/BaseCacheMaintenanceLibNull/BaseCacheMaintenanceLibNull.inf

--- a/MmSupervisorPkg/MmSupervisorPkg.dsc
+++ b/MmSupervisorPkg/MmSupervisorPkg.dsc
@@ -52,6 +52,7 @@
   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
   PanicLib|MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf
   StackCheckLib|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+  TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
 
 [LibraryClasses.IA32]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -59,11 +60,9 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
-  TimerLib|PcAtChipsetPkg/Library/AcpiTimerLib/PeiAcpiTimerLib.inf
 
 [LibraryClasses.X64.PEIM]
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
-  TimerLib|PcAtChipsetPkg/Library/AcpiTimerLib/BaseAcpiTimerLib.inf
 
 [LibraryClasses.X64]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -91,7 +90,6 @@
   SmmCpuFeaturesLib|UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.inf
   SmmCpuPlatformHookLib|UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.inf
   HwResetSystemLib|PcAtChipsetPkg/Library/ResetSystemLib/ResetSystemLib.inf
-  TimerLib|PcAtChipsetPkg/Library/AcpiTimerLib/StandaloneMmAcpiTimerLib.inf
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibStandaloneMm.inf
   SmmPolicyGateLib|MmSupervisorPkg/Library/SmmPolicyGateLib/SmmPolicyGateLib.inf
   MemLib|MmSupervisorPkg/Library/MmSupervisorMemLib/MmSupervisorCoreMemLib.inf

--- a/SeaPkg/Core/Init/Paging.c
+++ b/SeaPkg/Core/Init/Paging.c
@@ -15,11 +15,6 @@
 #include "StmInit.h"
 #include <Library/SafeIntLib.h>
 
-#define BUS_FROM_PCIE_ADDRESS(PcieAddress)       (UINT8)(((UINTN)(PcieAddress) & 0x0FF00000) >> 20)
-#define DEVICE_FROM_PCIE_ADDRESS(PcieAddress)    (UINT8)(((UINTN)(PcieAddress) & 0x000F8000) >> 15)
-#define FUNCTION_FROM_PCIE_ADDRESS(PcieAddress)  (UINT8)(((UINTN)(PcieAddress) & 0x00007000) >> 12)
-#define REGISTER_FROM_PCIE_ADDRESS(PcieAddress)  (UINT16)((UINTN)(PcieAddress) & 0x00000FFF)
-
 #define PAGE_PROGATE_BITS  (BIT0 | BIT1 | BIT2 | BIT3 | BIT4 | BIT5)
 
 #define PAGING_4K_MASK  0xFFF

--- a/SeaPkg/Core/Stm.h
+++ b/SeaPkg/Core/Stm.h
@@ -19,7 +19,6 @@
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/IoLib.h>
-#include <Library/PciLib.h>
 #include <Library/SynchronizationLib.h>
 #include <Library/DebugLib.h>
 #include <Library/StmPlatformLib.h>
@@ -27,7 +26,6 @@
 #include <Library/MemoryAllocationLib.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/MemoryMappedConfigurationSpaceAccessTable.h>
-#include <IndustryStandard/Pci.h>
 #include <Protocol/DebugSupport.h>
 #include <Register/StmApi.h>
 #include <Register/Intel/StmApiInternal.h>
@@ -55,9 +53,6 @@
 #define STM_SIZE_TO_PAGES(a)  (((a) >> STM_PAGE_SHIFT) + (((a) & STM_PAGE_MASK) ? 1 : 0))
 
 #define STM_PAGES_TO_SIZE(a)  ( (a) << STM_PAGE_SHIFT)
-
-#define PCI_EXPRESS_ADDRESS(Bus, Device, Function, Offset) \
-  (((Offset) & 0xfff) | (((Function) & 0x07) << 12) | (((Device) & 0x1f) << 15) | (((Bus) & 0xff) << 20))
 
 #pragma pack (push, 1)
 

--- a/SeaPkg/Core/Stm.inf
+++ b/SeaPkg/Core/Stm.inf
@@ -58,7 +58,6 @@
   BaseLib
   BaseMemoryLib
   IoLib
-  PciLib
   SynchronizationLib
   DebugLib
   StmLib

--- a/SeaPkg/SeaPkg.dsc
+++ b/SeaPkg/SeaPkg.dsc
@@ -25,8 +25,6 @@
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
-  PciLib|MdePkg/Library/BasePciLibPciExpress/BasePciLibPciExpress.inf
-  PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
   RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
   RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
   StackCheckFailureHookLib|MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf


### PR DESCRIPTION
## Description

This change is meant to remove the direct reliance on PCI related content because the code in this repository does not use it directly, thus not introducing unneeded dependencies.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is not a functional change.

## Integration Instructions

N/A