### PR TITLE
[BACKPORT][REBASE&FF] Setup repository for Rust CI

### DIFF
--- a/.azurepipelines/Windows-VS.yml
+++ b/.azurepipelines/Windows-VS.yml
@@ -33,3 +33,18 @@ extends:
         Pkgs: 'SeaPkg'
         Targets: 'DEBUG,RELEASE,NO-TARGET,NOOPT'
         ArchList: $(arch_list)
+    extra_jobs:
+      # Add a job to build the tools in the SeaPkg workspace in std
+      - job: CargoCmds
+        displayName: Workspace Cargo STD Build Commands
+        pool:
+          vmImage: windows-latest
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: true
+          - template: Steps/RustSetupSteps.yml@mu_devops
+          - template: Steps/RustCargoSteps.yml@mu_devops
+            parameters:
+              test_command: cargo test
+              build_command: cargo build

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ __pycache__/
 /Common
 /MU_BASECORE
 _TEMP_*/
+
+# Rust specific ignores
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+members = [
+    "SeaPkg/Tools/GenSeaArtifacts/gen_aux",
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+channel = "1.84.0"
+
+[tools]
+cargo-make = "0.37.24"
+cargo-tarpaulin = "0.31.5"
+cargo-release = "0.25.12"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,23 @@
+# rustfmt (and cargo fmt) will automatically pick up this config when run in the workspace.
+
+# Note that some items are included here set to their default values. This is to explicitly
+# reveal settings for more common options.
+
+# Keep these options sorted in ascending order to ease lookup with rustfmt documentation.
+
+edition = "2021"                 # This would normally be picked up from Cargo.toml if not specified here
+enum_discrim_align_threshold = 8 # Vertically align enum discriminants
+force_explicit_abi = true        # Always print the ABI for extern items (e.g. extern {... will become extern "C" {...)
+hard_tabs = false                # Always uses spaces for indentation and alignment
+max_width = 120                  # The maximum width of each line
+merge_derives = false            # Do not merge derives into a single line (leave to author discretion).
+imports_granularity = "Crate"    # Merge imports from a single crate into separate statements.
+newline_style = "Windows"        # Always use Windows line endings '\r\n'
+reorder_impl_items = false       # Do not force where type and const before macros and methods in impl blocks.
+reorder_imports = true           # Do reorder import and extern crate statements alphabetically for readability.
+reorder_modules = true           # Do reorder mod declarations alphabetically for readability.
+struct_field_align_threshold = 8 # Vertically align struct fields
+tab_spaces = 4                   # Use 4 spaces for indentation (Rust default).
+unstable_features = false        # Do not use unstable rustfmt features.
+use_small_heuristics = "Max"     # Set all granular width settings to the same as max_width (do not use heuristics)
+wrap_comments = false            # Leave comment formatting to author's discretion


### PR DESCRIPTION
## Description

Backport of #507 into `add_seapkg_pecoffneglib_core_cnt_2405`

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
