### PR TITLE
Fix override validations to keep them in sync with MU release/202502

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -13,12 +13,12 @@
 # release/202502
 #Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 887d09c7b82217d50d0b0cf311290739 | 2025-05-23T09-22-55 | a0369d2113577ca80280fb1eeafe3dc7c536d5d8
 # Secure
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 6967cd9168f4e96b0df5067c87ad9bc3 | 2025-01-30T00-05-01 | 564d4055cdf6801ee0c7264a4510748131d3165e
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 8fe771a8b6f0e46bb563d2491c9eb10e | 2025-07-25T21-04-21 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 # Non-Secure
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 6967cd9168f4e96b0df5067c87ad9bc3 | 2025-01-30T00-05-25 | 564d4055cdf6801ee0c7264a4510748131d3165e
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 8fe771a8b6f0e46bb563d2491c9eb10e | 2025-07-25T21-04-21 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 
 #Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 4db1640daa92830eafef49cff474b792 | 2025-04-12T14-55-03 | 6a19361b3a5c70a4779011d1dd35490e3b87dcc4
-#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 8a2e0cba770931bcc8f3e706859b3478 | 2025-04-12T14-55-46 | 6a19361b3a5c70a4779011d1dd35490e3b87dcc4
+#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 74f77f7353733f32e136e79be24e75c9 | 2025-07-25T21-33-16 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 [Defines]
   INF_VERSION                    = 0x0001001A
   BASE_NAME                      = MmSupervisorCore

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.inf
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.inf
@@ -18,7 +18,7 @@
   ENTRY_POINT                    = MmDxeSupportEntry
 
 # dev/202502, release/202502
-#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | 543dbed87ae6f1d70ad0e768e14f956d | 2025-04-30T03-41-09 | 98c0a2cbb2469f058cd075b2b1118e222855e6c8
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | 15b4ceb0a19a407293662f8da4e7a8a3 | 2025-07-25T21-03-08 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 
 #
 # The following information is for reference only and not required by the build tools.

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.inf
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.inf
@@ -18,7 +18,7 @@
   ENTRY_POINT                    = MmIplPeiEntry
 
 # dev/202502, release/202502
-#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | 543dbed87ae6f1d70ad0e768e14f956d | 2025-04-30T03-41-09 | 98c0a2cbb2469f058cd075b2b1118e222855e6c8
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | 15b4ceb0a19a407293662f8da4e7a8a3 | 2025-07-25T21-32-28 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 
 #Override : 00000002 | MdeModulePkg/Universal/CapsulePei/CapsulePei.inf | 21106e057e22a548508f22875b3c2124 | 2024-08-28T17-14-15 | 0a17aa9da5ebde81bd5e2053ce4df5ff9dedf45c
 

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
@@ -12,12 +12,12 @@
 
 # release/202502
 #Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 887d09c7b82217d50d0b0cf311290739 | 2025-05-23T09-22-55 | a0369d2113577ca80280fb1eeafe3dc7c536d5d8
-# Dev/202405
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | fcc0084f42574f4331ad258e53381c93 | 2025-01-27T21-27-02 | f54f113b0b84eb2fec245b97aad60545ba7a554b
-# Release/202405
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 6967cd9168f4e96b0df5067c87ad9bc3 | 2025-02-18T23-53-24 | ea000218a1be694999a087d8f12cfb3400a82556
+# Secure
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 8fe771a8b6f0e46bb563d2491c9eb10e | 2025-07-25T21-04-21 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
+# Non-Secure
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 8fe771a8b6f0e46bb563d2491c9eb10e | 2025-07-25T21-04-21 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 
-#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 8a2e0cba770931bcc8f3e706859b3478 | 2025-04-12T15-03-15 | 6a19361b3a5c70a4779011d1dd35490e3b87dcc4
+#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 74f77f7353733f32e136e79be24e75c9 | 2025-07-25T21-33-16 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 
 [Defines]
   INF_VERSION                    = 0x0001001A


### PR DESCRIPTION
## Description

Fix override validations to keep the code in sync with MU release/202502

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local CI build works now.

## Integration Instructions

NA
