### PR TITLE
SmmCpuFeaturesLib: Tweak MSEG error handling logic

### DIFF
--- a/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/SeaPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -277,14 +277,14 @@ DiscoverSmiEntryInFvHobs (
               break;
             }
 
+            SeaResponderFound = TRUE;
+
             Status = LoadMonitor ((EFI_PHYSICAL_ADDRESS)(UINTN)RawBinFileData, SeaBinSize);
             // Moving the buffer like size field to our local variable
             if (EFI_ERROR (Status)) {
               DEBUG ((DEBUG_ERROR, "[%a]   Failed to load SEA [%g] in FV at 0x%p of %x bytes - %r.\n", __FUNCTION__, &gSeaBinFileGuid, FileHeader, FileHeader->Size, Status));
-              break;
+              goto Done;
             }
-
-            SeaResponderFound = TRUE;
           }
 
           if (MmiEntryFound && SeaResponderFound) {


### PR DESCRIPTION
## Description

Right now, if MSEG is too small the error message gets buried behind an irrelevant message about not being able to find required SEA entries in present FVs:

```
MSEG too small.  Min MSEG Size = 00204000  Current MSEG Size = 00200000
  StmHeader->SwStmHdr.StaticImageSize             = 0001D5A0
  StmHeader->SwStmHdr.AdditionalDynamicMemorySize = 00146000
  StmHeader->SwStmHdr.PerProcDynamicMemorySize    = 00008000
  VMCS Size                                       = 00001000
  Max CPUs                                        = 00000010
  StmHeader->HwStmHdr.Cr3Offset                   = 0001E000
[DiscoverSmiEntryInFvHobs]   Failed to load SEA [E7F9ABC2-61A6-4AF3-A00F-1150CC6EFE20]
  in FV at 0x6D7E4C98 of 6D7E4CAC bytes - Buffer Too Small.
[DiscoverSmiEntryInFvHobs] Found FV HOB referencing FV at 0x6C0CD000. Size is 0x9F000.
[DiscoverSmiEntryInFvHobs]   FV GUID = {1B5C27FE-F01C-4FBC-AEAE-341B2E992A17}.
[DiscoverSmiEntryInFvHobs] Found FV HOB referencing FV at 0x6BDB0000. Size is 0x185E78.
[DiscoverSmiEntryInFvHobs] Found FV HOB referencing FV at 0x6C21D000. Size is 0xA52EA0.
[DiscoverSmiEntryInFvHobs]   FV GUID = {A881D567-6CB0-4EEE-8435-2E72D33E45B5}.
[DiscoverSmiEntryInFvHobs]   Required entries for SEA not found in any FV.

ASSERT_EFI_ERROR (Status = Not Found)
ASSERT [MmSupervisorCore] SeaPkg\Library\SmmCpuFeaturesLib\SmmStm.c(387): !(((INTN)(RETURN_STATUS)(Status)) < 0)
```

That's misleading in the MSEG is too small case because the required entries were indeed found but failed to load.

This change modifies the logic such that the load function fails earlier with the MSEG too small error as the error message for this case.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Make MSEG size too small and inspect debug message before and after the change.

## Integration Instructions

- N/A