### PR TITLE
Integrate CVE 2025-3770 (Safe Handling of IDT on SMM Entry)

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -17,7 +17,7 @@
 # Non-Secure
 #Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 8fe771a8b6f0e46bb563d2491c9eb10e | 2025-07-25T21-04-21 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 
-#Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 4db1640daa92830eafef49cff474b792 | 2025-04-12T14-55-03 | 6a19361b3a5c70a4779011d1dd35490e3b87dcc4
+#Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 893482d99df7281b751ba1d536449089 | 2025-08-18T14-36-04 | 62220125fdc9fa3a2963ac6eb41e4468e121a848
 #Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 74f77f7353733f32e136e79be24e75c9 | 2025-07-25T21-33-16 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 [Defines]
   INF_VERSION                    = 0x0001001A

--- a/MmSupervisorPkg/Core/Relocate/SmiEntry.nasm
+++ b/MmSupervisorPkg/Core/Relocate/SmiEntry.nasm
@@ -113,7 +113,11 @@ ProtFlatMode:
     mov eax, strict dword 0               ; source operand will be patched
 ASM_PFX(gPatchSmiCr3):
     mov     cr3, rax
-    mov     eax, 0x100E68                ; as cr4.PGE is not set here, refresh cr3
+    mov     eax, 0x100E28                ; as cr4.PGE is not set here, refresh cr3
+                                         ; Set SMEP and UMIP.
+                                         ; Do not assume that IDT.limit is loaded with a zero value upon SMM entry.
+                                         ; Delay enabling Machine Check Exceptions in SMM until after the SMM IDT
+                                         ; has been reloaded.
 
     mov     cl, strict byte 0            ; source operand will be patched
 ASM_PFX(gPatch5LevelPagingNeeded):
@@ -203,6 +207,10 @@ SmiHandlerIdtrAbsAddr:
     mov     gs, eax
     mov     ax, [rbx + DSC_SS]
     mov     ss, eax
+
+    mov     rax, cr4                    ; enable MCE
+    bts     rax, 6
+    mov     cr4, rax
 
     mov     rbx, [rsp + 0x8]             ; rbx <- CpuIndex
 

--- a/SeaPkg/MmiEntrySea/MmiEntrySea.inf
+++ b/SeaPkg/MmiEntrySea/MmiEntrySea.inf
@@ -10,8 +10,8 @@
 #
 ##
 
-# Track release/202405 
-#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 4db1640daa92830eafef49cff474b792 | 2025-04-12T04-32-07 | 6a19361b3a5c70a4779011d1dd35490e3b87dcc4
+# Track release/202502
+#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | 893482d99df7281b751ba1d536449089 | 2025-08-18T14-36-42 | 62220125fdc9fa3a2963ac6eb41e4468e121a848
 
 [Defines]
   INF_VERSION                    = 0x0001001A

--- a/SeaPkg/MmiEntrySea/MmiEntrySea.nasmb
+++ b/SeaPkg/MmiEntrySea/MmiEntrySea.nasmb
@@ -94,7 +94,11 @@ BITS 64
 ProtFlatMode:
     mov     eax, [rdi + FIXUP32_CR3_OFFSET - _SmiEntryPoint + 0x8000]    ; source operand will be populated at loading time
     mov     cr3, rax
-    mov     eax, 0x100E68                ; as cr4.PGE is not set here, refresh cr3
+    mov     eax, 0x100E28                ; as cr4.PGE is not set here, refresh cr3
+                                         ; Set SMEP and UMIP.
+                                         ; Do not assume that IDT.limit is loaded with a zero value upon SMM entry.
+                                         ; Delay enabling Machine Check Exceptions in SMM until after the SMM IDT
+                                         ; has been reloaded.
 
     mov     cl, [rdi + FIXUP8_m5LevelPagingNeeded - _SmiEntryPoint + 0x8000]      ; source operand will be patched
     cmp     cl, 0
@@ -180,6 +184,10 @@ Base:
     mov     gs, eax
     mov     ax, [rbx + DSC_SS]
     mov     ss, eax
+
+    mov     rax, cr4                    ; enable MCE
+    bts     rax, 6
+    mov     cr4, rax
 
     mov     rbx, [rsp + 0x8]             ; rbx <- CpuIndex
 


### PR DESCRIPTION
## Description

Updates comments around MM Supervisor-specific bits (SMEP and UMIP) set in CR4 and integrates the changes from edk2 commit:

d2d8d38ee08c5e602fb092f940dfecc1f5a4eb38

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- MM Supervisor physical platform boot
- Q35 boot

## Integration Instructions

- N/A