### PR TITLE
Do not include zeroed data in aux file

### DIFF
--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -937,9 +937,15 @@ PeCoffImageDiffValidation (
       break;
     }
 
-    // We should not do this when the above validation fails
-    CopyMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, (UINT8 *)ImageValidationHdr + ImageValidationEntryHdr->OffsetToDefault, ImageValidationEntryHdr->Size);
+    // If OffsetToDefault is MAX_UINT32, then zero the memory rather that copy
+    if (ImageValidationEntryHdr->OffsetToDefault == MAX_UINT32) {
+      ZeroMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryHdr->Size);
+    } else {
+      // We should not do this when the above validation fails
+      CopyMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, (UINT8 *)ImageValidationHdr + ImageValidationEntryHdr->OffsetToDefault, ImageValidationEntryHdr->Size);
+    }
 
+    
     ImageValidationEntryHdr = NextImageValidationEntryHdr;
   }
 

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -937,15 +937,14 @@ PeCoffImageDiffValidation (
       break;
     }
 
-    // If OffsetToDefault is MAX_UINT32, then zero the memory rather that copy
+    // We should not do this when the above validation fails
     if (ImageValidationEntryHdr->OffsetToDefault == MAX_UINT32) {
+      // If OffsetToDefault is MAX_UINT32, then zero the memory rather that copy
       ZeroMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryHdr->Size);
     } else {
-      // We should not do this when the above validation fails
       CopyMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, (UINT8 *)ImageValidationHdr + ImageValidationEntryHdr->OffsetToDefault, ImageValidationEntryHdr->Size);
     }
 
-    
     ImageValidationEntryHdr = NextImageValidationEntryHdr;
   }
 


### PR DESCRIPTION
## Description

When generating the auxiliary file, we create a default value for each validation entry. Most of the time, this default value is all zeros. In a test case, over 7K worth of default values were all zeros.

This commit updates the aux file generation to not include default values that are all zeros. Instead, we set the OffsetToDefault field to MAX_UINT32. At runtime, when the reversion to default is done, if the OffsetToDefault field is MAX_UINT32, we zero the memory instead of copying from the aux file.

This change reduces the binary size of the aux file from 23KB to 15 KB for one private use case.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
