### PR TITLE
[2405] MmSupervisorPkg: Add MM Supv Comm Protocol callback for version publication

### DIFF
--- a/MmSupervisorPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
+++ b/MmSupervisorPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md
@@ -305,7 +305,9 @@ flash drivers, SW MMI dispatcher drivers, etc.
     <LibraryClasses>
       NULL|StandaloneMmPkg/Library/VariableMmDependency/VariableMmDependency.inf
       # Note: This library can be linked against any DXE_DRIVER or DXE_RUNTIME_DRIVER in the platform. It is an
-      #       optional library that publishes a UEFI variable with MM Supervisor information.
+      #       optional library that publishes a UEFI variable with MM Supervisor information. It requires that
+      #       an instance of gEdkiiVariablePolicyProtocolGuid (and gMmSupervisorCommunicationProtocolGuid) be
+      #       produced in order to publish the variable.
       NULL|MmSupervisorPkg/Library/DxeMmSupervisorVersionPublicationLib/DxeMmSupervisorVersionPublicationLib.inf
   }
 !endif


### PR DESCRIPTION
## Description

Add a protocol notification on gMmSupervisorCommunicationProtocolGuid to account for all protocol dependencies to publish the supervsior version UEFI variable.

---

2405 cherry-pick from https://github.com/microsoft/mu_feature_mm_supv/pull/524.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI and platform integration build
- Verify the UEFI variable is published after both protocols are produced

## Integration Instructions

N/A - The same requirements as before
