### PR TITLE
SeaPkg/test_aux: Add offset and size columns to results table

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/test_aux/src/main.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/test_aux/src/main.rs
@@ -386,29 +386,56 @@ fn display_results_summary(results: &[(String, &ImageValidationEntryHeader, Stat
 fn display_results_table(results: &[(String, &ImageValidationEntryHeader, Status)]) {
     // Calculate the max width of each column
     let c1 = results.iter().map(|(s, _, _)| s.len()).max().unwrap_or(0);
-    let c2 = "Test Type".len().max(
+    let c2 = "Offset".len().max(
+        results
+            .iter()
+            .map(|(_, entry, _)| format!("0x{:X}", entry.offset).len())
+            .max()
+            .unwrap_or(0),
+    );
+    let c3 = "Size".len().max(
+        results
+            .iter()
+            .map(|(_, entry, _)| format!("0x{:X}", entry.size).len())
+            .max()
+            .unwrap_or(0),
+    );
+    let c4 = "Test Type".len().max(
         results
             .iter()
             .map(|(_, entry, _)| entry.validation_type.to_string().len())
             .max()
             .unwrap_or(0),
     );
-    let c3 = results
-        .iter()
-        .map(|(_, _, s)| format!("{}", PrettyStatus(*s)).len())
-        .max()
-        .unwrap_or(0);
+    let c5 = "Status".len().max(
+        results
+            .iter()
+            .map(|(_, _, s)| PrettyStatus(*s).to_string().len())
+            .max()
+            .unwrap_or(0),
+    );
 
     // print the table
     println!(
-        "| {:c1$} | {:c2$} | {:c3$} |",
-        "Name", "Test Type", "Status"
+        "| {:c1$} | {:c2$} | {:c3$} | {:c4$} | {:c5$} |",
+        "Name", "Offset", "Size", "Test Type", "Status"
     );
-    println!("| {:-<c1$} | {:-<c2$} | {:-<c3$} |", "", "", "");
+    println!(
+        "| {:-<c1$} | {:-<c2$} | {:-<c3$} | {:-<c4$} | {:-<c5$} |",
+        "", "", "", "", ""
+    );
     for (name, hdr, result) in results {
         let status = PrettyStatus(*result).to_string();
         let test_type = hdr.validation_type.to_string();
-        println!("| {:c1$} | {:c2$} | {:c3$} |", name, test_type, status);
+        let offset = format!("0x{:X}", hdr.offset);
+        let size = format!("0x{:X}", hdr.size);
+        println!(
+            "| {:c1$} | {:c2$} | {:c3$} | {:c4$} | {:c5$} |",
+            name, offset, size, test_type, status
+        );
     }
-    println!("| {:-<c1$} | {:-<c2$} | {:-<c3$} |", "", "", "");
+    println!(
+        "| {:-<c1$} | {:-<c2$} | {:-<c3$} | {:-<c4$} | {:-<c5$} |",
+        "", "", "", "", ""
+    );
 }


### PR DESCRIPTION
## Description

When given a failure like the following:

> "PeCoffImageValidationMemAttr: Current entry 0x7BE13270 has invalid " "size of 0x68, max is 0x8"

It is convenient to have the offset and size printed in the symbol result list. You can quickly verify the offset against other sources and confirm the size matches what is reported in the error.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Reviewed the `test-aux` results table after the change:

> Short snippet:
> ```
> | Name                                                         | Offset  | Size  | Test Type | Status  |
> | ------------------------------------------------------------ | ------- | ----- | --------- | ------- |
> | gcSmiIdtr.Base                                               | 0x36002 | 0x8   | MemAttr   | SUCCESS |
> | gcSmiIdtr.Limit                                              | 0x36000 | 0x2   | Content   | SUCCESS |
> | gMmCoreMmst.MmStartupThisAp                                  | 0x36360 | 0x8   | Ref       | SUCCESS |
> | gMmCoreMmst.CurrentlyExecutingCpu                            | 0x36368 | 0x8   | None      | SUCCESS |
> | gMmCoreMmst.NumberOfCpus                                     | 0x36370 | 0x8   | NonZero   | SUCCESS |
> | gMmCoreMmst.CpuSaveStateSize                                 | 0x36378 | 0x8   | MemAttr   | SUCCESS |
> | gMmCoreMmst.CpuSaveState                                     | 0x36380 | 0x8   | MemAttr   | SUCCESS |
> ```

## Integration Instructions

- N/A