### PR TITLE
SeaPkg: Remove Tpm2DebugLib.

### DIFF
--- a/SeaPkg/SeaPkg.dsc
+++ b/SeaPkg/SeaPkg.dsc
@@ -66,7 +66,6 @@
   HashLib|SeaPkg/Library/HashLibTpm2Raw/HashLibTpm2Raw.inf
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmStandaloneMm.inf
-  Tpm2DebugLib|SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf
   MemoryAllocationLib|SeaPkg/Library/SimpleMemoryAllocationLib/SimpleMemoryAllocationLib.inf
   TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf


### PR DESCRIPTION

## Description

With the tear down of dev branches, Tpm2DebugLib was removed. Update SeaPkg to deal with removal of Tpm2DebugLib for CI build.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local CI.

## Integration Instructions
Integration follows mu_tiano_plus requirements.
If a platform DSC contained a Tpm2DebugLib instance, it should be removed.