### PR TITLE
Update MM Supervisor version to v19.001

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -24,7 +24,7 @@
   BASE_NAME                      = MmSupervisorCore
   FILE_GUID                      = 4E4C89DC-A452-4B6B-B183-F16A2A223733
   MODULE_TYPE                    = MM_CORE_STANDALONE
-  VERSION_STRING                 = 19.000
+  VERSION_STRING                 = 19.001
   PI_SPECIFICATION_VERSION       = 0x00010032
   ENTRY_POINT                    = MmSupervisorMain
 
@@ -32,8 +32,8 @@
   #Major: major version is one or two digits from 0 to 99
   #Minor: minor version is four digits, the first 3 digits are the minor number, the last digit is the flag
   #flag=9 represents RELEASE version, flag=8 represents DEBUG version, flag=0~7 represents test version
-  RELEASE_DRIVER_VERSION   = 19.0009
-  DEBUG_DRIVER_VERSION     = 19.0008
+  RELEASE_DRIVER_VERSION   = 19.0019
+  DEBUG_DRIVER_VERSION     = 19.0018
   #SPL value definition: SPL version = Major.Minor, SPL value = (Major << 16 | Minor)
   #Major: major value is an UINT16 number in decimal from 0 to 65535
   #Minor: minor value is an UINT16 number in decimal from 0 to 65535

--- a/MmSupervisorPkg/MmSupervisorPkg.dec
+++ b/MmSupervisorPkg/MmSupervisorPkg.dec
@@ -13,7 +13,7 @@
   DEC_SPECIFICATION              = 0x0001001A
   PACKAGE_NAME                   = MmSupervisorPkg
   PACKAGE_GUID                   = 2DCA2E5C-4696-4613-943F-DFE5F6941C34
-  PACKAGE_VERSION                = 19.000
+  PACKAGE_VERSION                = 19.001
 
 [Includes]
   Include


### PR DESCRIPTION
## Description

Matches the current GitHub release version.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI

## Integration Instructions

- No changes required. MM Supervisor version will be updated.