### PR TITLE
SeaPkg: ImageValidation: Make aux rule debugging easier

### DIFF
--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -889,10 +889,10 @@ PeCoffImageDiffValidation (
 
     DEBUG ((
       DEBUG_INFO,
-      "%a: Evaluating symbol at offset=0x%x in the target image with rule type=0x%x\n",
+      "%a: Evaluating symbol at offset: 0x%x in the target image with rule type: 0x%x\n",
       __func__,
       ImageValidationEntryHdr->Offset,
-      ImageValidationEntryHdr->ValidationType,
+      ImageValidationEntryHdr->ValidationType
       ));
 
     // All validation has been updated to reference the original image.  PeCoffLoaderRevertRelocateImage will


### PR DESCRIPTION
## Description

Adds a debug log message before each image validation rule runs that logs the offset of the symbol in the target image. This offset is directly indexable in the json file that gets generated with each aux.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A