### PR TITLE
Fixing failing unit test for not populating correct `MessageLength`

### DIFF
--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
@@ -184,7 +184,8 @@ VerifyMemPolicy (
 /**
   This helper function preps the shared CommBuffer for use by the test step.
 
-  @param[out] CommBuffer   Returns a pointer to the CommBuffer for the test step to use.
+  @param[out] CommBuffer      Returns a pointer to the CommBuffer for the test step to use.
+  @param[in]  AdditionalSize  Additional size needed in the CommBuffer for test-specific data.
 
   @retval     EFI_SUCCESS         CommBuffer initialized and ready to use.
   @retval     EFI_ABORTED         Some error occurred.


### PR DESCRIPTION
## Description

This change fixes a bug in the unit test where the `MessageLength` for the corresponding MMI request is not being properly populated, causing the test case to fail on the pipeline.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

The test passed on QEMU Q35 platform.

## Integration Instructions

N/A