### PR TITLE
SeaPkg: GenSeaArtifacts: Update scroll versions

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_manifest/Cargo.toml
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_manifest/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5.1", features = ["derive"] }
-scroll = { version = "0.12.0", features = ["derive"] }
+scroll = { version = "0.13.0", features = ["derive"] }
 
 # Hashing
 hex = "0.4.3"

--- a/SeaPkg/Tools/GenSeaArtifacts/test_aux/Cargo.toml
+++ b/SeaPkg/Tools/GenSeaArtifacts/test_aux/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0.98"
 clap = { version = "4.5.37", features = ["derive"] }
 GenAux = { path = "../gen_aux"}
 r-efi = "5.2.0"
-scroll = { version = "0.12.0", features = ["derive"] }
+scroll = { version = "0.13.0", features = ["derive"] }
 serde = { version = "1.0.197", features = ["derive"] }
 sha2 = "0.10.8"
 toml = "0.8.10"


### PR DESCRIPTION
## Description

This change updates the scroll versions inside the Cargo.toml files for both test_aux and gen_manifest.

This is to be consistent with the scroll version specified in other modules.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on the platform and fixed the build break.

## Integration Instructions

N/A
