### PR TITLE
Fixing CLANGPDB build for unresolved `invd` function

### DIFF
--- a/MmSupervisorPkg/Library/BaseLibSysCall/BaseLib.inf
+++ b/MmSupervisorPkg/Library/BaseLibSysCall/BaseLib.inf
@@ -79,7 +79,6 @@
   X64/CpuPause.nasm| MSFT
   X64/DisableInterrupts.c| MSFT
   X64/FlushCacheLine.nasm| MSFT
-  X64/Invd.c | MSFT
   X64/Wbinvd.c| MSFT
   X64/Mwait.nasm| MSFT
   X64/Monitor.nasm| MSFT
@@ -91,6 +90,7 @@
   X64/TdVmcall.c
   X64/TdProbe.c
 
+  X64/Invd.c
   X64/Non-existing.c
   Math64.c
   Unaligned.c
@@ -133,3 +133,4 @@
 
 [BuildOptions]
 #  DEBUG_*_*_CC_FLAGS  = /FAcs
+


### PR DESCRIPTION
## Description

The previous fix only covered the case of MSFT compiler. However, as EDK2 starts to expand the support to CLANGPDB, the fix does not provide the same coverage. This change removes the original specifier to cover all compilers.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Pipeline build passes.

## Integration Instructions

N/A
