### PR TITLE
MmSupervisorPkg: Add DXE_CORE to MmSupervisorUnblockMemoryLibDxe

### DIFF
--- a/MmSupervisorPkg/Library/MmSupervisorUnblockMemoryLib/MmSupervisorUnblockMemoryLibDxe.inf
+++ b/MmSupervisorPkg/Library/MmSupervisorUnblockMemoryLib/MmSupervisorUnblockMemoryLibDxe.inf
@@ -16,7 +16,7 @@
   FILE_GUID                      = 22807895-5CA2-456D-9288-23433E9F06F5
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = MmUnblockMemoryLib|DXE_DRIVER DXE_RUNTIME_DRIVER
+  LIBRARY_CLASS                  = MmUnblockMemoryLib|DXE_DRIVER DXE_RUNTIME_DRIVER DXE_CORE
 
 #
 #  VALID_ARCHITECTURES           = X64


### PR DESCRIPTION
## Description

Adds `DXE_CORE` as an allowable link module type for the `MmSupervisorUnblockMemoryLibDxe` library instance.

This enables other linked libraries to the DXE Core to be able to unblock memory. This instance links against `UefiBootServicesTableLib` to get the boot services table. `gBS` will be populated by the DXE Core when it calls `ProcessLibraryConstructorList()`.

Autogen places library constructors for linked DXE Core libraries in dependency order (since they're ordered by DAG in BaseTools). This orders `UefiBootServicesTableLib` prior to
`MmSupervisorUnblockMemoryLibDxe` which would be prior to any other DXE Core linked library that uses `MmMmUnblockMemoryLib`.

At this moment, this is used for an advanced logger DXE core library instance to set up an End of DXE notify that unblocks memory for a new logger buffer.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Link against DXE Core
- Call `MmUnblockMemoryRequest()` from an End of DXE notification function

## Integration Instructions

- N/A