### PR TITLE
MmSupervisorPkg: Fix buffer size calculation for MmiManage()

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -591,6 +591,8 @@ MmEntryPoint (
           goto Cleanup;
         }
 
+        BufferSize -= CommHeaderSize;
+
         Status = MmiManage (
                    (EFI_GUID *)((UINT8 *)CommunicateHeader + CommGuidOffset),
                    NULL,


### PR DESCRIPTION
## Description

The supervisor communication channel size calculation changed from:

```
  BufferSize = CommunicateHeader->MessageLength;
```

To:

```
  BufferSize = OFFSET_OF(..., Data) + CommunicateHeader->MessageLength;
```

This new calculation includes the header size in BufferSize, but the header needed to be subtracted from `BufferSize` before passing it `MmiManage()` since it expects only the message data size, not the total buffer size including the header.

This caused `MmiManage()` to read/write beyond the actual message data.

This was addressed by subtracting `CommHeaderSize` before calling `MmiManage()`, restoring the original behavior where `MmiManage()` receives only the message data size.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Boot QemuQ35Pkg with a MM unblock request made in DXE that failed before the change and passes after

## Integration Instructions

- N/A