### PR TITLE
SeaPkg: Add SmrrLib and use in SmmCpuFeaturesLib

### DIFF
--- a/SeaPkg/Include/Library/SmrrLib.h
+++ b/SeaPkg/Include/Library/SmrrLib.h
@@ -1,0 +1,82 @@
+/** @file
+  This library abstracts SMRR configuration in SMM.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMRR_LIB_H_
+#define SMRR_LIB_H_
+
+/**
+  Disable SMRRs.
+
+**/
+VOID
+EFIAPI
+SmmrLibSmmrDisable (
+  VOID
+  );
+
+/**
+  Reenable SMRRs.
+
+**/
+VOID
+EFIAPI
+SmmrLibSmmrReenable (
+  VOID
+  );
+
+/**
+  SMRR configuration entry point for each CPU on SMM rendezvous.
+
+  @param[in] CpuIndex  The index of the CPU that has entered SMM.  The value
+                       must be between 0 and the NumberOfCpus field in the
+                       System Management System Table (SMST).
+**/
+VOID
+EFIAPI
+SmrrLibRendezvousEntry (
+  IN UINTN  CpuIndex
+  );
+
+/**
+  Called by the monarch CPU after all CPUs have processed their first SMI and relocated
+  SMBASE into a buffer in SMRAM.
+
+**/
+VOID
+EFIAPI
+SmrrLibInitAfterRelocation (
+  VOID
+  );
+
+/**
+  Called during the very first SMI to initialize SMRR configuration.
+
+  @param[in]    SmrrBase   The base address of SMRR.
+  @param[in]    SmrrSize   The size of SMRR.
+  @param[in]    IsMonarch  TRUE if this CPU is the monarch.
+
+**/
+VOID
+EFIAPI
+SmrrLibInitializeOnFirstSmi (
+  IN UINT32   SmrrBase,
+  IN UINT32   SmrrSize,
+  IN BOOLEAN  IsMonarch
+  );
+
+/**
+  Called before the first SMI to initialize SMRR configuration.
+
+**/
+VOID
+EFIAPI
+SmrrLibInitialization (
+  VOID
+  );
+
+#endif

--- a/SeaPkg/Library/BaseSmrrLibNull/BaseSmrrLibNull.c
+++ b/SeaPkg/Library/BaseSmrrLibNull/BaseSmrrLibNull.c
@@ -1,0 +1,97 @@
+/** @file
+  Null instance of the SMRR Library
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+
+/**
+  Disable SMRRs.
+
+**/
+VOID
+EFIAPI
+SmmrLibSmmrDisable (
+  VOID
+  )
+{
+  return;
+}
+
+/**
+  Reenable SMRRs.
+
+**/
+VOID
+EFIAPI
+SmmrLibSmmrReenable (
+  VOID
+  )
+{
+  return;
+}
+
+/**
+  SMRR configuration entry point for each CPU on SMM rendezvous.
+
+  @param[in] CpuIndex  The index of the CPU that has entered SMM.  The value
+                       must be between 0 and the NumberOfCpus field in the
+                       System Management System Table (SMST).
+**/
+VOID
+EFIAPI
+SmrrLibRendezvousEntry (
+  IN UINTN  CpuIndex
+  )
+{
+  return;
+}
+
+/**
+  Called by the monarch CPU after all CPUs have processed their first SMI and relocated
+  SMBASE into a buffer in SMRAM.
+
+**/
+VOID
+EFIAPI
+SmrrLibInitAfterRelocation (
+  VOID
+  )
+{
+  return;
+}
+
+/**
+  Called during the very first SMI to initialize SMRR configuration.
+
+  @param[in]    SmrrBase   The base address of SMRR.
+  @param[in]    SmrrSize   The size of SMRR.
+  @param[in]    IsMonarch  TRUE if this CPU is the monarch.
+
+**/
+VOID
+EFIAPI
+SmrrLibInitializeOnFirstSmi (
+  IN UINT32   SmrrBase,
+  IN UINT32   SmrrSize,
+  IN BOOLEAN  IsMonarch
+  )
+{
+  return;
+}
+
+/**
+  Called before the first SMI to initialize SMRR configuration.
+
+**/
+VOID
+EFIAPI
+SmrrLibInitialization (
+  VOID
+  )
+{
+  return;
+}

--- a/SeaPkg/Library/BaseSmrrLibNull/BaseSmrrLibNull.inf
+++ b/SeaPkg/Library/BaseSmrrLibNull/BaseSmrrLibNull.inf
@@ -1,0 +1,24 @@
+
+## @file
+# Null instance of the SMRR Library
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION     = 1.27
+  BASE_NAME       = BaseSmrrLibNull
+  FILE_GUID       = FBBB1CEA-83BB-483E-A442-1A667CF2EB87
+  VERSION_STRING  = 1.0
+  MODULE_TYPE     = BASE
+  LIBRARY_CLASS   = SmrrLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[Sources]
+  BaseSmrrLibNull.c
+

--- a/SeaPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
+++ b/SeaPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
@@ -16,6 +16,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
+#include <Library/SmrrLib.h>
 
 /**
   The constructor function for the common MM library instance with STM.

--- a/SeaPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
+++ b/SeaPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
@@ -30,6 +30,7 @@ SmmCpuFeaturesSmmRelocationComplete (
   VOID
   )
 {
+  SmrrLibInitAfterRelocation ();
 }
 
 /**

--- a/SeaPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLibStm.inf
+++ b/SeaPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLibStm.inf
@@ -44,6 +44,7 @@
   MemoryAllocationLib
   DebugLib
   MmServicesTableLib
+  SmrrLib
   TpmMeasurementLib
 
 [Guids]

--- a/SeaPkg/SeaPkg.dec
+++ b/SeaPkg/SeaPkg.dec
@@ -32,6 +32,7 @@
   PeCoffLibNegative|Include/Library/PeCoffLibNegative.h
   PeCoffValidationLib|Include/Library/PeCoffValidationLib.h
   SeaManifestPublicationLib|Include/Library/SeaManifestPublicationLib.h
+  SmrrLib|Include/Library/SmrrLib.h
   StmLib|Include/Library/StmLib.h
   StmPlatformLib|Include/Library/StmPlatformLib.h
 

--- a/SeaPkg/SeaPkg.dsc
+++ b/SeaPkg/SeaPkg.dsc
@@ -33,6 +33,7 @@
   UnitTestLib|UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
   PeCoffValidationLib|SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf
+  SmmrLib|SeaPkg/Library/BaseSmrrLibNull/BaseSmrrLibNull.inf
   StackCheckLib|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
 
 [LibraryClasses.common.PEIM]
@@ -87,6 +88,7 @@
   SeaPkg/Library/BaseSeaManifestPublicationLibNull/BaseSeaManifestPublicationLibNull.inf
   SeaPkg/Library/DxeSeaManifestPublicationLibConfigTable/DxeSeaManifestPublicationLibConfigTable.inf
   SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf
+  SeaPkg/Library/BaseSmrrLibNull/BaseSmrrLibNull.inf
 
 [Components.X64]
   SeaPkg/Core/Stm.inf {


### PR DESCRIPTION
## Description

Some SMRR configuration relies on resources that are not fully described in discovered public documentation.

To allow for flexibility in SMRR configuration, add a new library class called SmrrLib is added that allows a SeaPkg integrating platform to provide platform-specific SMRR configuration.

The SeaPkg SmmCpuFeaturesLib instance is updated to use the SmrrLib for SMRR configuration.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- SeaPkg build and CI
- Verify SMRR configuration with "SMM Security Configuration Tests" HSTI using the platform-specific (non-null) SmrrLib instance

## Integration Instructions

If building SEA create a platform-specific instance of SmrrLib that configures SMRRs securely. This is linked against `SmmCpuFeaturesLib` (the `SeaPkg` instance) which is linked against `MmSupervisorCore` to prevent requiring user mode MM policy from needing to unblock SMRR MSRs and allowing the library to program SMRRs on all cores.