### PR TITLE
MmSupervisorPkg: Resolve uninitialized variable in V3 communication flow

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -574,6 +574,11 @@ MmEntryPoint (
         if (CompareGuid (&(CommunicateHeader->HeaderGuid), &gEfiMmCommunicateHeaderV3Guid)) {
           DEBUG ((DEBUG_ERROR, "V3 Communication for supervisor channel is not supported!\n"));
           ASSERT (FALSE);
+          mMmCommunicationBufferStatus.IsCommBufferValid = FALSE;
+          mMmCommunicationBufferStatus.TalkToSupervisor  = FALSE;
+          mMmCommunicationBufferStatus.ReturnBufferSize  = 0;
+          mMmCommunicationBufferStatus.ReturnStatus      = EFI_UNSUPPORTED;
+          goto Cleanup;
         } else {
           CommGuidOffset = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, HeaderGuid);
           CommHeaderSize = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data);


### PR DESCRIPTION
## Description

The code introduced in commiit f157378 trigers `sometimes-uninitialized` in the CLANGPDBG build because `BufferSize` is not initialized in a code path.

The code currently relies on ASSERT exclusively. This change adds error handling similar to other locations in the function to account for the case when asserts are disabled.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CLANGPDB build

## Integration Instructions

- N/A