### PR TITLE
SupvCore: Ignore Memory Type Info Resource Desc HOB

### DIFF
--- a/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
+++ b/MmSupervisorPkg/Core/Mem/SmmCpuMemoryManagement.c
@@ -7,6 +7,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <PiMm.h>
 #include <SmmSecurePolicy.h>
+#include <Guid/MemoryTypeInformation.h>
 #include <Guid/MmCommonRegion.h>
 #include <Guid/MmProtectedRegion.h>
 #include <Guid/MmSupvUnblockRegion.h>
@@ -1803,7 +1804,8 @@ SkipResourceDescriptor (
 {
   if ((ResourceDesc == NULL) ||
       (ResourceDesc->ResourceType == EFI_RESOURCE_IO) ||
-      (ResourceDesc->ResourceType == EFI_RESOURCE_IO_RESERVED))
+      (ResourceDesc->ResourceType == EFI_RESOURCE_IO_RESERVED) ||
+      CompareGuid (&ResourceDesc->Owner, &gEfiMemoryTypeInformationGuid))
   {
     return TRUE;
   }

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -238,6 +238,7 @@
   gMmPagingAuditMmiHandlerGuid                  ## SOMETIMES_CONSUMES
   gEfiHobMemoryAllocModuleGuid
   gEfiMmPeiMmramMemoryReserveGuid
+  gEfiMemoryTypeInformationGuid
 
   gEfiMmCommunicateHeaderV3Guid                 ## CONSUMES
 


### PR DESCRIPTION
## Description

DXE can receive a resource descriptor HOB that is owned by gEfiMemoryTypeInformationGuid to report where the memory bins should be located. This HOB will overlap with another resource descriptor HOB that describes system memory.

MM Supv should ignore this resource descriptor HOB when processing HOBs, it is expected to overlap and MM Supv doesn't need any of the bin information.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 and a physical Intel platform using the Resource Descriptor HOB owned by gEfiMemoryTypeInformationGuid.

## Integration Instructions

N/A.
