### PR TITLE
MmSupervisorPkg,SeaPkg: Update override hash for PiSmmCpuDxeSmm

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -18,7 +18,7 @@
 #Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 8fe771a8b6f0e46bb563d2491c9eb10e | 2025-07-25T21-04-21 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
 
 # release/202511
-#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | ea775929a0fefbc273af9f081b397f43 | 2026-01-23T16-30-00 | 60efc6d51c056bb9dcd9fbdc3f26fbdf0ca14355 
+#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | b2b837cadad1c2282a7562585679f21b | 2026-03-09T22-12-25 | 5bf68b66296329fe0b8050dc217ef2a6af17476f
 # release/202502
 #Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | cdec6e3cae1fb9ea6b40885aa3ac7317 | 2025-09-30T17-01-30 | 22a192411052c19a6556e6f092e3d2c72c023e2b
 

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/X64/X64Entry.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/X64/X64Entry.c
@@ -16,8 +16,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugAgentLib.h>
 #include "Common/CommonHeader.h"
 
-#define EXCEPTION_VECTOR_NUMBER  0x22
-
 #define IA32_PG_P   BIT0
 #define IA32_PG_RW  BIT1
 #define IA32_PG_PS  BIT7
@@ -37,7 +35,7 @@ typedef struct _PAGE_FAULT_CONTEXT {
 
 typedef struct _PAGE_FAULT_IDT_TABLE {
   PAGE_FAULT_CONTEXT          PageFaultContext;
-  IA32_IDT_GATE_DESCRIPTOR    IdtEntryTable[EXCEPTION_VECTOR_NUMBER];
+  IA32_IDT_GATE_DESCRIPTOR    IdtEntryTable[X86_CPU_INTERRUPT_NUM];
 } PAGE_FAULT_IDT_TABLE;
 
 /**
@@ -239,9 +237,9 @@ _ModuleEntryPoint (
   //
   // Setup X64 IDT table
   //
-  ZeroMem (PageFaultIdtTable.IdtEntryTable, sizeof (IA32_IDT_GATE_DESCRIPTOR) * EXCEPTION_VECTOR_NUMBER);
+  ZeroMem (PageFaultIdtTable.IdtEntryTable, sizeof (IA32_IDT_GATE_DESCRIPTOR) * X86_CPU_INTERRUPT_NUM);
   X64Idtr.Base  = (UINTN)PageFaultIdtTable.IdtEntryTable;
-  X64Idtr.Limit = (UINT16)(sizeof (IA32_IDT_GATE_DESCRIPTOR) * EXCEPTION_VECTOR_NUMBER - 1);
+  X64Idtr.Limit = (UINT16)(sizeof (IA32_IDT_GATE_DESCRIPTOR) * X86_CPU_INTERRUPT_NUM - 1);
   AsmWriteIdtr ((IA32_DESCRIPTOR *)&X64Idtr);
 
   //

--- a/SeaPkg/MmiEntrySea/MmiEntrySea.inf
+++ b/SeaPkg/MmiEntrySea/MmiEntrySea.inf
@@ -11,7 +11,8 @@
 ##
 
 # release/202511
-#Override : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | ea775929a0fefbc273af9f081b397f43 | 2026-01-09T03-04-02 | 90bd8f57b29398fda07843b9b99857b7bd08a82b
+#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | b2b837cadad1c2282a7562585679f21b | 2026-03-09T22-12-25 | 5bf68b66296329fe0b8050dc217ef2a6af17476f
+
 [Defines]
   INF_VERSION                    = 0x0001001A
   BASE_NAME                      = MmEntrySea


### PR DESCRIPTION

## Description
PiSmmCpuDxeSmm has moved to using 256 IDT entries, instead of 0x22.

Update MmSupervisor to follow by using 256 IDT entries.

Update for https://github.com/microsoft/mu_basecore/pull/1686

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Booted Q35 to windows with change.

## Integration Instructions
No integration necessary.