### PR TITLE
Update overrides for 2502 and 2511

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -10,22 +10,35 @@
 #
 ##
 
-# release/202511
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 2d0cfa04356a3778273ce8aaf123fbdd | 2026-01-23T16-28-14 | 60efc6d51c056bb9dcd9fbdc3f26fbdf0ca14355
-# release/202502
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 887d09c7b82217d50d0b0cf311290739 | 2025-05-23T09-22-55 | a0369d2113577ca80280fb1eeafe3dc7c536d5d8
-# Secure
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 8fe771a8b6f0e46bb563d2491c9eb10e | 2025-07-25T21-04-21 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
+# release/202511 (Non Secure)
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 2d0cfa04356a3778273ce8aaf123fbdd | 2026-03-23T19-03-02 | 18e13b478f0dc2279ad2956ff4c95c41e56c6efb
+# release/202511 (Secure)
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 2d0cfa04356a3778273ce8aaf123fbdd | 2026-03-23T19-03-36 | 1617810253e428d5455fe5fdb304789416564fa3
 
-# release/202511
-#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | b2b837cadad1c2282a7562585679f21b | 2026-03-09T22-12-25 | 5bf68b66296329fe0b8050dc217ef2a6af17476f
-# release/202502
-#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | cdec6e3cae1fb9ea6b40885aa3ac7317 | 2025-09-30T17-01-30 | 22a192411052c19a6556e6f092e3d2c72c023e2b
+# release/202502 (Non Secure)
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | c80945fbcea5c11226d4f179c83292f2 | 2026-03-23T19-21-41 | 40548b12d821a8bce209f8b5559c3b230b226d50
+# release/202502 (Secure)
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | c80945fbcea5c11226d4f179c83292f2 | 2026-03-23T19-22-00 | 7d97213090cae9b9fa2d8d40e26eedf6949b9178
 
-# release/202511
-#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 0a403969919049fff1ee3f261a660f68 | 2026-01-23T16-33-32 | 60efc6d51c056bb9dcd9fbdc3f26fbdf0ca14355
-# release/202502
-#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 74f77f7353733f32e136e79be24e75c9 | 2025-07-25T21-33-16 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
+# release/202511 (Non Secure)
+#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | b2b837cadad1c2282a7562585679f21b | 2026-03-23T19-04-12 | 18e13b478f0dc2279ad2956ff4c95c41e56c6efb
+# release/202511 (Secure)
+#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | b2b837cadad1c2282a7562585679f21b | 2026-03-23T19-04-35 | 1617810253e428d5455fe5fdb304789416564fa3
+
+# release/202502 (Non Secure)
+#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | cdec6e3cae1fb9ea6b40885aa3ac7317 | 2026-03-23T19-22-18 | 40548b12d821a8bce209f8b5559c3b230b226d50
+# release/202502 (Secure)
+#Track : 00000002 | UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf | cdec6e3cae1fb9ea6b40885aa3ac7317 | 2026-03-23T19-22-46 | 7d97213090cae9b9fa2d8d40e26eedf6949b9178
+
+# release/202511 (Non Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 0a403969919049fff1ee3f261a660f68 | 2026-03-23T19-05-01 | 18e13b478f0dc2279ad2956ff4c95c41e56c6efb
+# release/202511 (Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 0a403969919049fff1ee3f261a660f68 | 2026-03-23T19-05-20 | 1617810253e428d5455fe5fdb304789416564fa3
+
+# release/202502 (Non Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 74f77f7353733f32e136e79be24e75c9 | 2026-03-23T19-24-41 | 40548b12d821a8bce209f8b5559c3b230b226d50
+# release/202502 (Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 74f77f7353733f32e136e79be24e75c9 | 2026-03-23T19-24-57 | 7d97213090cae9b9fa2d8d40e26eedf6949b9178
 
 [Defines]
   INF_VERSION                    = 0x0001001A

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.inf
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmIplPei.inf
@@ -17,10 +17,26 @@
   PI_SPECIFICATION_VERSION       = 0x0001000A
   ENTRY_POINT                    = MmIplPeiEntry
 
-# release/202511
-#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | d40c6972c8fdedf15330e1ca758447b5 | 2026-01-09T02-58-15 | 90bd8f57b29398fda07843b9b99857b7bd08a82b
+# release/202511 (Non Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | a165f79660ba4b14254d8807a6e91591 | 2026-03-23T19-01-13 | 18e13b478f0dc2279ad2956ff4c95c41e56c6efb
+# release/202511 (Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | a165f79660ba4b14254d8807a6e91591 | 2026-03-23T19-01-30 | 1617810253e428d5455fe5fdb304789416564fa3
 
-#Override : 00000002 | MdeModulePkg/Universal/CapsulePei/CapsulePei.inf | ed9df131b59a49c5b6f12313952462ac | 2026-01-09T02-58-57 | 90bd8f57b29398fda07843b9b99857b7bd08a82b
+# release/202502 (Non Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | 25e768becf05bb0ea1cc33c990770e83 | 2026-03-23T19-20-18 | 40548b12d821a8bce209f8b5559c3b230b226d50
+# release/202502 (Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf | 25e768becf05bb0ea1cc33c990770e83 | 2026-03-23T19-20-37 | 7d97213090cae9b9fa2d8d40e26eedf6949b9178
+
+# release/202511 (Non Secure)
+#Track : 00000002 | MdeModulePkg/Universal/CapsulePei/CapsulePei.inf | ed9df131b59a49c5b6f12313952462ac | 2026-03-23T19-01-55 | 18e13b478f0dc2279ad2956ff4c95c41e56c6efb
+# release/202511 (Secure)
+#Track : 00000002 | MdeModulePkg/Universal/CapsulePei/CapsulePei.inf | ed9df131b59a49c5b6f12313952462ac | 2026-03-23T19-02-20 | 1617810253e428d5455fe5fdb304789416564fa3
+
+# release/202502 (Non Secure)
+#Track : 00000002 | MdeModulePkg/Universal/CapsulePei/CapsulePei.inf | 52d8f2a8158f91ca0d671c00dbcb3f5b | 2026-03-23T19-20-56 | 40548b12d821a8bce209f8b5559c3b230b226d50
+# release/202502 (Secure)
+#Track : 00000002 | MdeModulePkg/Universal/CapsulePei/CapsulePei.inf | 52d8f2a8158f91ca0d671c00dbcb3f5b | 2026-03-23T19-21-13 | 7d97213090cae9b9fa2d8d40e26eedf6949b9178
+
 #
 # The following information is for reference only and not required by the build tools.
 #

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
@@ -10,14 +10,25 @@
 
 # This module contains an instance of protocol/handle from StandaloneMmCore and pool memory + guard management from PiSmmCore.
 
-# release/202511
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 2d0cfa04356a3778273ce8aaf123fbdd | 2026-01-23T16-28-14 | 60efc6d51c056bb9dcd9fbdc3f26fbdf0ca14355
-# release/202502
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 887d09c7b82217d50d0b0cf311290739 | 2025-05-23T09-22-55 | a0369d2113577ca80280fb1eeafe3dc7c536d5d8
-# Secure
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 8fe771a8b6f0e46bb563d2491c9eb10e | 2025-07-25T21-04-21 | 4240524cbb169bee0b3c7480787d402e48d2b6f5
+# release/202511 (Non Secure)
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 2d0cfa04356a3778273ce8aaf123fbdd | 2026-03-23T19-03-02 | 18e13b478f0dc2279ad2956ff4c95c41e56c6efb
+# release/202511 (Secure)
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 2d0cfa04356a3778273ce8aaf123fbdd | 2026-03-23T19-03-36 | 1617810253e428d5455fe5fdb304789416564fa3
 
-#Override : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 0a403969919049fff1ee3f261a660f68 | 2026-01-09T03-01-12 | 90bd8f57b29398fda07843b9b99857b7bd08a82b
+# release/202502 (Non Secure)
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | c80945fbcea5c11226d4f179c83292f2 | 2026-03-23T19-21-41 | 40548b12d821a8bce209f8b5559c3b230b226d50
+# release/202502 (Secure)
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | c80945fbcea5c11226d4f179c83292f2 | 2026-03-23T19-22-00 | 7d97213090cae9b9fa2d8d40e26eedf6949b9178
+
+# release/202511 (Non Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 0a403969919049fff1ee3f261a660f68 | 2026-03-23T19-05-01 | 18e13b478f0dc2279ad2956ff4c95c41e56c6efb
+# release/202511 (Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 0a403969919049fff1ee3f261a660f68 | 2026-03-23T19-05-20 | 1617810253e428d5455fe5fdb304789416564fa3
+
+# release/202502 (Non Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 74f77f7353733f32e136e79be24e75c9 | 2026-03-23T19-24-41 | 40548b12d821a8bce209f8b5559c3b230b226d50
+# release/202502 (Secure)
+#Track : 00000002 | MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf | 74f77f7353733f32e136e79be24e75c9 | 2026-03-23T19-24-57 | 7d97213090cae9b9fa2d8d40e26eedf6949b9178
 
 [Defines]
   INF_VERSION                    = 0x0001001A

--- a/MmSupervisorPkg/Library/BaseCpuLibSysCall/BaseCpuLib.inf
+++ b/MmSupervisorPkg/Library/BaseCpuLibSysCall/BaseCpuLib.inf
@@ -15,7 +15,15 @@
 #
 ##
 
-#Override : 00000002 | MdePkg/Library/BaseCpuLib/BaseCpuLib.inf | 574c6b8ff5d4192af95ba062539da64e | 2026-01-09T03-02-52 | 90bd8f57b29398fda07843b9b99857b7bd08a82b
+# release/202511 (Non Secure)
+#Track : 00000002 | MdePkg/Library/BaseCpuLib/BaseCpuLib.inf | 574c6b8ff5d4192af95ba062539da64e | 2026-03-23T18-58-48 | 18e13b478f0dc2279ad2956ff4c95c41e56c6efb
+# release/202511 (Secure)
+#Track : 00000002 | MdePkg/Library/BaseCpuLib/BaseCpuLib.inf | 574c6b8ff5d4192af95ba062539da64e | 2026-03-23T18-59-13 | 1617810253e428d5455fe5fdb304789416564fa3
+
+# release/202502 (Non Secure)
+#Track : 00000002 | MdePkg/Library/BaseCpuLib/BaseCpuLib.inf | 3a01cac1d68c77e9e4f807ac56107bff | 2026-03-23T19-18-55 | 40548b12d821a8bce209f8b5559c3b230b226d50
+# release/202502 (Secure)
+#Track : 00000002 | MdePkg/Library/BaseCpuLib/BaseCpuLib.inf | 3a01cac1d68c77e9e4f807ac56107bff | 2026-03-23T19-19-19 | 7d97213090cae9b9fa2d8d40e26eedf6949b9178
 
 [Defines]
   INF_VERSION                    = 0x00010005

--- a/MmSupervisorPkg/Library/BaseIoLibIntrinsicSysCall/BaseIoLibIntrinsic.inf
+++ b/MmSupervisorPkg/Library/BaseIoLibIntrinsicSysCall/BaseIoLibIntrinsic.inf
@@ -17,7 +17,15 @@
 #
 ##
 
-#Override : 00000002 | MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf | 7b021fae81ffd495a45b1e3b50d81c93 | 2026-01-09T02-56-26 | 90bd8f57b29398fda07843b9b99857b7bd08a82b 
+# release/202511 (Non Secure)
+#Track : 00000002 | MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf | 7b021fae81ffd495a45b1e3b50d81c93 | 2026-03-23T18-59-43 | 18e13b478f0dc2279ad2956ff4c95c41e56c6efb
+# release/202511 (Secure)
+#Track : 00000002 | MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf | 7b021fae81ffd495a45b1e3b50d81c93 | 2026-03-23T19-00-33 | 1617810253e428d5455fe5fdb304789416564fa3
+
+# release/202502 (Non Secure)
+#Track : 00000002 | MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf | 14d63074792184beb6b5e68f5c69bf31 | 2026-03-23T19-19-38 | 40548b12d821a8bce209f8b5559c3b230b226d50
+# release/202502 (Secure)
+#Track : 00000002 | MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf | 14d63074792184beb6b5e68f5c69bf31 | 2026-03-23T19-19-52 | 7d97213090cae9b9fa2d8d40e26eedf6949b9178
 
 [Defines]
   INF_VERSION                    = 0x00010005


### PR DESCRIPTION
## Description

2502 override hashes are out-of-date. Also, updates the overrides to all use track tags with each hash explicitly provided to simplify updating and reviewing override tags.

Consolidating and expanding hashes overtime results in diffs that are not 1:1 and guesses as to whether a difference was a mistake missed previously or an expected change.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- OverrideValidation plugin against current 2502 and 2511 branches

## Integration Instructions

- Like usual, this repo has override hashes that match the current tips of release/202502 and release/202511 branches. See the commit hashes in the track tags for the underlying commit in the release branch used to generate the hash.