### PR TITLE
MmSupervisorPkg: Additional IDT creation update

### DIFF
--- a/MmSupervisorPkg/Core/Relocate/Relocate.c
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.c
@@ -129,10 +129,10 @@ InitializeSmmIdt (
   IA32_DESCRIPTOR  DxeIdtr;
 
   //
-  // There are 32 (not 255) entries in it since only processor
-  // generated exceptions will be handled.
+  // Populate 256 entries to ensure that a known state occurs
+  // for all possible IDT vectors.
   //
-  gcSmiIdtr.Limit = (sizeof (IA32_IDT_GATE_DESCRIPTOR) * 32) - 1;
+  gcSmiIdtr.Limit = (sizeof (IA32_IDT_GATE_DESCRIPTOR) * X86_CPU_INTERRUPT_NUM) - 1;
   //
   // Allocate page aligned IDT, because it might be set as read only.
   //


### PR DESCRIPTION
## Description
Additional change for ensuring 256 IDT entries.

Previous change in #622 missed the IDT being created for mm supervisor, which was hardcoded to 32.

Updated to use the same X86_CPU_INTERRUPT_NUM from mu_basecore. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Tested SEA platform.

## Integration Instructions
No integration necessary.