### PR TITLE
Support reblock

### DIFF
--- a/MmSupervisorPkg/Core/Request/Request.h
+++ b/MmSupervisorPkg/Core/Request/Request.h
@@ -95,4 +95,25 @@ ProcessUpdateCommBufferRequest (
   IN MM_SUPERVISOR_COMM_UPDATE_BUFFER  *UpdateCommBuffer
   );
 
+/**
+  Helper routine used to block requested region. The routine will loop through unblocked
+  entries and try to locate the entry that matches the input based on base address and
+  length. For the match entry, if the page is not already blocked, supervisor will issue
+  command to block access. Once successful, the corresponding entry will be removed from
+  unblocked list.
+
+  @param[in]  BlockMemDesc        Input unblock parameters conveyed from non-MM environment
+
+  @retval EFI_SUCCESS             The requested region properly unblocked.
+  @retval EFI_ACCESS_DENIED       The request was made post lock down event.
+  @retval EFI_INVALID_PARAMETER   UnblockMemParams or its ID GUID is null pointer.
+  @retval EFI_ALREADY_STARTED     The requested region has illegal page attributes.
+  @retval Others                  Page attribute setting/clearing routine has failed.
+
+**/
+EFI_STATUS
+ProcessBlockPages (
+  IN MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS  *BlockMemDesc
+  );
+
 #endif // _MM_SUPV_REQUEST_H_

--- a/MmSupervisorPkg/Core/Request/RequestDispatcher.c
+++ b/MmSupervisorPkg/Core/Request/RequestDispatcher.c
@@ -148,6 +148,22 @@ MmSupvRequestHandler (
                                       );
       break;
 
+    case MM_SUPERVISOR_REQUEST_REBLOCK_MEM:
+      ExpectedSize += sizeof (MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS);
+      if (*CommBufferSize < ExpectedSize) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "%a - Reblock param block has bad comm buffer size! %d < %d\n",
+          __func__,
+          *CommBufferSize,
+          ExpectedSize
+          ));
+        return EFI_INVALID_PARAMETER;
+      }
+
+      MmSupvRequestHeader->Result = ProcessBlockPages ((MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS *)(MmSupvRequestHeader + 1));
+      break;
+
     default:
       // Mark unknown requested command as EFI_UNSUPPORTED.
       DEBUG ((DEBUG_ERROR, "%a - Invalid command requested! %d\n", __func__, MmSupvRequestHeader->Request));

--- a/MmSupervisorPkg/Core/Request/UnblockMemory.c
+++ b/MmSupervisorPkg/Core/Request/UnblockMemory.c
@@ -278,21 +278,41 @@ ProcessBlockPages (
   )
 {
   UNBLOCKED_MEM_LIST                   *UnblockedListEntry;
-  MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS  UnblockedMemEntry;
+  MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS  *UnblockedMemEntry;
   LIST_ENTRY                           *Node;
   EFI_STATUS                           Status;
+
+  if (mMmReadyToLockDone) {
+    // Note that this flag will be set once the policy is requested
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a - Block requested after ready to lock, will not proceed!\n",
+      __func__
+      ));
+    return EFI_ACCESS_DENIED;
+  }
 
   if (BlockMemDesc == NULL) {
     return EFI_INVALID_PARAMETER;
   }
 
+  DEBUG ((
+    DEBUG_INFO,
+    "%a - %g requested blocking Address: 0x%p Length: 0x%x (Pages)\n",
+    __func__,
+    &BlockMemDesc->IdentifierGuid,
+    BlockMemDesc->MemoryDescriptor.PhysicalStart,
+    BlockMemDesc->MemoryDescriptor.NumberOfPages
+    ));
+
   Status = EFI_NOT_FOUND;
   BASE_LIST_FOR_EACH (Node, &mUnblockedMemoryList) {
     UnblockedListEntry = BASE_CR (Node, UNBLOCKED_MEM_LIST, Link);
-    UnblockedMemEntry  = UnblockedListEntry->UnblockMemData;
-    if ((UnblockedMemEntry.MemoryDescriptor.PhysicalStart == BlockMemDesc->MemoryDescriptor.PhysicalStart) &&
-        (UnblockedMemEntry.MemoryDescriptor.NumberOfPages == BlockMemDesc->MemoryDescriptor.NumberOfPages))
+    UnblockedMemEntry  = &UnblockedListEntry->UnblockMemData;
+    if ((UnblockedMemEntry->MemoryDescriptor.PhysicalStart == BlockMemDesc->MemoryDescriptor.PhysicalStart) &&
+        (UnblockedMemEntry->MemoryDescriptor.NumberOfPages == BlockMemDesc->MemoryDescriptor.NumberOfPages))
     {
+      DEBUG ((DEBUG_INFO, "%a - Found the unblock record for the requested block region from %g\n", __func__, &UnblockedMemEntry->IdentifierGuid));
       Status = EFI_SUCCESS;
       break;
     }
@@ -300,13 +320,14 @@ ProcessBlockPages (
 
   // If not found, then bail...
   if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - Cannot find the unblock record for the requested block region!\n", __func__));
     return Status;
   }
 
   // Mark this region to be inaccessible
   Status = SmmSetMemoryAttributes (
-             UnblockedMemEntry.MemoryDescriptor.PhysicalStart,
-             EFI_PAGES_TO_SIZE (UnblockedMemEntry.MemoryDescriptor.NumberOfPages),
+             UnblockedMemEntry->MemoryDescriptor.PhysicalStart,
+             EFI_PAGES_TO_SIZE (UnblockedMemEntry->MemoryDescriptor.NumberOfPages),
              EFI_MEMORY_RP
              );
   if (EFI_ERROR (Status)) {

--- a/MmSupervisorPkg/Drivers/StandaloneMmUnblockMem/StandaloneMmUnblockMem.c
+++ b/MmSupervisorPkg/Drivers/StandaloneMmUnblockMem/StandaloneMmUnblockMem.c
@@ -26,6 +26,7 @@
 
 BOOLEAN                               mReadyToLockOccurred    = FALSE;
 MM_SUPERVISOR_COMMUNICATION_PROTOCOL  *mMmCommunicateProtocol = NULL;
+BOOLEAN                               mReblockSupported       = FALSE;
 
 EFI_STATUS
 EFIAPI
@@ -35,9 +36,18 @@ MmIplRequestUnblockPages (
   IN CONST EFI_GUID        *IdentifierGuid
   );
 
+EFI_STATUS
+EFIAPI
+MmIplRequestReblockPages (
+  IN EFI_PHYSICAL_ADDRESS  ReblockAddress,
+  IN UINT64                NumberOfPages,
+  IN CONST EFI_GUID        *IdentifierGuid
+  );
+
 MM_SUPERVISOR_UNBLOCK_MEMORY_PROTOCOL  mMmUnblockMemProtocol = {
   .Version             = MM_UNBLOCK_REQUEST_PROTOCOL_VERSION,
-  .RequestUnblockPages = MmIplRequestUnblockPages
+  .RequestUnblockPages = MmIplRequestUnblockPages,
+  .RequestReblockPages = MmIplRequestReblockPages
 };
 
 /**
@@ -280,6 +290,7 @@ MmIplRequestUnblockPages (
   Status = mMmCommunicateProtocol->Communicate (mMmCommunicateProtocol, CommHeader, &CommBufferSize);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a - Failed from MmCommunication protocol - %r\n", __func__, Status));
+    FreePool (CommHeader);
     return Status;
   }
 
@@ -288,6 +299,140 @@ MmIplRequestUnblockPages (
     DEBUG ((DEBUG_ERROR, "%a - Failed from MmCommunication protocol - %r\n", __func__, RequestBuffer->Result));
   }
 
+  FreePool (CommHeader);
+  return RequestBuffer->Result;
+}
+
+/**
+  This API provides a way to reblock certain data pages to be inaccessible inside MM environment.
+  The reblock operation is the reverse of unblock operation, which means the input address and page
+  number should be already unblocked before, otherwise the reblock request will be rejected.
+
+  @param  ReblockAddress              The address of buffer caller requests to reblock, the address
+                                      has to be page aligned.
+  @param  NumberOfPages               The number of pages requested to be reblocked from MM
+                                      environment.
+
+  @return EFI_SUCCESS             The request goes through successfully.
+  @return EFI_NOT_AVAILABLE_YET   The requested functionality is not produced yet.
+  @return EFI_UNSUPPORTED         The requested functionality is not supported on current platform.
+  @return EFI_SECURITY_VIOLATION  The requested address failed to pass security check for
+                                      reblocking.
+  @return EFI_INVALID_PARAMETER   Input address either NULL pointer or not page aligned.
+  @return EFI_ACCESS_DENIED       The request is rejected due to system has passed certain boot
+                                      phase.
+
+**/
+EFI_STATUS
+EFIAPI
+MmIplRequestReblockPages (
+  IN EFI_PHYSICAL_ADDRESS  ReblockAddress,
+  IN UINT64                NumberOfPages,
+  IN CONST EFI_GUID        *IdentifierGuid
+  )
+{
+  EFI_STATUS                           Status;
+  EFI_MM_COMMUNICATE_HEADER            *CommHeader;
+  MM_SUPERVISOR_REQUEST_HEADER         *RequestBuffer;
+  MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS  *UnblockBuffer;
+  UINTN                                CommBufferSize;
+
+  // Step 0: Check if reblock functionality is supported on supervisor side, if not, just return unsupported.
+  if (!mReblockSupported) {
+    DEBUG ((DEBUG_WARN, "%a Reblock memory request is not supported by supervisor, return unsupported!\n", __func__));
+    return EFI_UNSUPPORTED;
+  }
+
+  // Step 1: Basic sanity check
+  if ((IdentifierGuid == NULL) ||
+      (ReblockAddress == 0) ||
+      ReblockAddress & (EFI_PAGE_SIZE - 1))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a Input argument of address %p or identifier GUID %p is invalid!\n",
+      __func__,
+      ReblockAddress,
+      IdentifierGuid
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (NumberOfPages == 0) {
+    // This is dumb...
+    DEBUG ((DEBUG_WARN, "%a Requesting to reblock 0 pages, return here!\n", __func__));
+    return EFI_SUCCESS;
+  }
+
+  if (mReadyToLockOccurred) {
+    // Someone must have done something terrible...
+    DEBUG ((DEBUG_ERROR, "%a Request is blocked after exit boot services, how did you get here?\n", __func__));
+    return EFI_ACCESS_DENIED;
+  }
+
+  if (mMmCommunicateProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a Communicate protocol is not in place, cannot process the request\n", __func__));
+    return EFI_NOT_READY;
+  }
+
+  // Reblock request should be evaluated in a more strict way by supervisor,
+  // here we do not check against the current usage of this memory region, because this
+  // interface could be potentially used for blocking anything now (MMIO, etc.).
+
+  // Status = EvaluateRequestedRegion (ReblockAddress, NumberOfPages);
+  // if (EFI_ERROR (Status)) {
+  //   // Someone must have done something terrible...
+  //   DEBUG ((DEBUG_ERROR, "%a Requested address did not pass evaluation %r\n", __func__, Status));
+  //   return EFI_ACCESS_DENIED;
+  // }
+
+  // Step 2: Start to populate contents
+
+  // Step 2.1: MM Communication common header
+  CommBufferSize = sizeof (MM_SUPERVISOR_REQUEST_HEADER) +
+                   sizeof (MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS) +
+                   OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data);
+  CommHeader = (EFI_MM_COMMUNICATE_HEADER *)AllocatePool (CommBufferSize);
+  ASSERT (CommHeader != NULL);
+  if (CommHeader == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (CommHeader, CommBufferSize);
+  CopyGuid (&CommHeader->HeaderGuid, &gMmSupervisorRequestHandlerGuid);
+  CommHeader->MessageLength = sizeof (MM_SUPERVISOR_REQUEST_HEADER) +
+                              sizeof (MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS);
+
+  // Step 2.2: MM_SUPERVISOR_REQUEST_HEADER content per our needs
+  RequestBuffer            = (MM_SUPERVISOR_REQUEST_HEADER *)(CommHeader->Data);
+  RequestBuffer->Signature = MM_SUPERVISOR_REQUEST_SIG;
+  RequestBuffer->Revision  = MM_SUPERVISOR_REQUEST_REVISION;
+  RequestBuffer->Request   = MM_SUPERVISOR_REQUEST_REBLOCK_MEM;
+  RequestBuffer->Result    = EFI_SUCCESS;
+
+  // Step 2.3: MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS content per our needs
+  UnblockBuffer = (MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS *)(RequestBuffer + 1);
+  CopyGuid (&UnblockBuffer->IdentifierGuid, IdentifierGuid);
+  UnblockBuffer->MemoryDescriptor.Type          = 0; // Type is not needed for reblock operation
+  UnblockBuffer->MemoryDescriptor.PhysicalStart = ReblockAddress;
+  UnblockBuffer->MemoryDescriptor.VirtualStart  = 0;
+  UnblockBuffer->MemoryDescriptor.NumberOfPages = NumberOfPages;
+  UnblockBuffer->MemoryDescriptor.Attribute     = 0;
+
+  // Step 3: Ready to signal Mmi.
+  Status = mMmCommunicateProtocol->Communicate (mMmCommunicateProtocol, CommHeader, &CommBufferSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - Failed from MmCommunication protocol - %r\n", __func__, Status));
+    FreePool (CommHeader);
+    return Status;
+  }
+
+  // Step 4: Just print the error here
+  if (EFI_ERROR (RequestBuffer->Result)) {
+    DEBUG ((DEBUG_ERROR, "%a - Failed from MmCommunication protocol - %r\n", __func__, RequestBuffer->Result));
+  }
+
+  FreePool (CommHeader);
   return RequestBuffer->Result;
 }
 
@@ -312,6 +457,95 @@ MmUnblockMemReadyToLockNotify (
 }
 
 /**
+  Communicate to MmSupervisor to query version information, as defined in
+  MM_SUPERVISOR_VERSION_INFO_BUFFER.
+
+  @param[out] VersionInfo        Pointer to hold returned version information structure.
+
+  @retval EFI_SUCCESS            The version information was successfully queried.
+  @retval EFI_INVALID_PARAMETER  The VersionInfo was NULL.
+  @retval EFI_SECURITY_VIOLATION The Version returned by supervisor is invalid.
+  @retval Others                 Other error status returned during communication to supervisor.
+
+**/
+EFI_STATUS
+QuerySupervisorVersion (
+  OUT MM_SUPERVISOR_VERSION_INFO_BUFFER  *VersionInfo
+  )
+{
+  EFI_STATUS                    Status;
+  MM_SUPERVISOR_REQUEST_HEADER  *RequestHeader;
+  EFI_MM_COMMUNICATE_HEADER     *CommHeader;
+  UINTN                         CommBufferSize;
+
+  if (VersionInfo == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Prepare MM Communication common header
+  CommBufferSize = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) +
+              sizeof (MM_SUPERVISOR_REQUEST_HEADER) +
+              sizeof (MM_SUPERVISOR_VERSION_INFO_BUFFER);
+  CommHeader = (EFI_MM_COMMUNICATE_HEADER *)AllocatePool (CommBufferSize);
+  ASSERT (CommHeader != NULL);
+  if (CommHeader == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (CommHeader, CommBufferSize);
+  CopyGuid (&(CommHeader->HeaderGuid), &gMmSupervisorRequestHandlerGuid);
+  CommHeader->MessageLength = sizeof (MM_SUPERVISOR_REQUEST_HEADER) + sizeof (MM_SUPERVISOR_VERSION_INFO_BUFFER);
+
+  RequestHeader            = (MM_SUPERVISOR_REQUEST_HEADER *)CommHeader->Data;
+  RequestHeader->Signature = MM_SUPERVISOR_REQUEST_SIG;
+  RequestHeader->Revision  = MM_SUPERVISOR_REQUEST_REVISION;
+  RequestHeader->Request   = MM_SUPERVISOR_REQUEST_VERSION_INFO;
+
+  //
+  // Generate the Software SMI and return the result
+  //
+  Status = mMmCommunicateProtocol->Communicate (mMmCommunicateProtocol, CommHeader, &CommBufferSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Failed to communicate to MM through supervisor channel - %r!!\n", __func__, Status));
+    FreePool (CommHeader);
+    return Status;
+  }
+
+  Status = EFI_SUCCESS;
+  if ((UINTN)RequestHeader->Result != 0) {
+    Status = ENCODE_ERROR ((UINTN)RequestHeader->Result);
+  }
+
+  CopyMem (
+    VersionInfo,
+    (MM_SUPERVISOR_VERSION_INFO_BUFFER *)(RequestHeader + 1),
+    sizeof (MM_SUPERVISOR_VERSION_INFO_BUFFER)
+    );
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a Supervisor version is 0x%x, patch level is 0x%x, maximal request level is 0x%x!!\n",
+    __func__,
+    VersionInfo->Version,
+    VersionInfo->PatchLevel,
+    VersionInfo->MaxSupervisorRequestLevel
+    ));
+
+  if (VersionInfo->Version == 0) {
+ #ifdef __GNUC__
+    DEBUG ((DEBUG_WARN, "%a Unable to get supervisor version under GCC compiler!!\n", __func__));
+ #else
+    // This means the supervisor version is 0, something must be wrong...
+    FreePool (CommHeader);
+    return EFI_SECURITY_VIOLATION;
+ #endif
+  }
+
+  FreePool (CommHeader);
+  return EFI_SUCCESS;
+}
+
+/**
 Register Exit Boot callback and process previous errors when variable service is ready
 
 @param[in]  Event                 Event whose notification function is being invoked.
@@ -329,6 +563,7 @@ SetupUnblockMemProtocol (
   EFI_STATUS  Status;
   EFI_HANDLE  UnusedHandle = NULL;
   EFI_EVENT   TempEvent;
+  MM_SUPERVISOR_VERSION_INFO_BUFFER VersionInfo;
 
   if (mMmCommunicateProtocol == NULL) {
     Status = gBS->LocateProtocol (&gMmSupervisorCommunicationProtocolGuid, NULL, (VOID **)&mMmCommunicateProtocol);
@@ -337,6 +572,18 @@ SetupUnblockMemProtocol (
       DEBUG ((DEBUG_ERROR, "%a Failed to locate Mm communicate protocol - %r!\n", __func__, Status));
       goto Done;
     }
+  }
+
+  Status = QuerySupervisorVersion (&VersionInfo);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    goto Done;
+  }
+
+  if (VersionInfo.MaxSupervisorRequestLevel < MM_SUPERVISOR_REQUEST_REBLOCK_MEM) {
+    DEBUG ((DEBUG_WARN, "%a Supervisor does not support reblock memory request, version: 0x%x!\n", __func__, VersionInfo.Version));
+  } else {
+    mReblockSupported = TRUE;
   }
 
   Status = gBS->InstallProtocolInterface (

--- a/MmSupervisorPkg/Include/Guid/MmSupervisorRequestData.h
+++ b/MmSupervisorPkg/Include/Guid/MmSupervisorRequestData.h
@@ -97,11 +97,18 @@ typedef struct _COMM_UPDATE_BUFFER {
 #define   MM_SUPERVISOR_REQUEST_COMM_UPDATE  0x0004
 
 /**
+  @retval EFI_SECURITY_VIOLATION     If requested page is not page aligned
+  @retval EFI_ACCESS_DENIED          If request occurs after ready to lock or policy fetching
+  @retval EFI_INVALID_PARAMETER      If incoming memory ID is invalid
+ **/
+#define   MM_SUPERVISOR_REQUEST_REBLOCK_MEM  0x0005
+
+/**
   Maximal request index supported by supervisor. When supported, the value of this definition
   will be populated in the MaxSupervisorRequestLevel of VERSION_INFO_BUFFER upon a successful query
   to supervisor.
 
  **/
-#define   MM_SUPERVISOR_REQUEST_MAX_SUPPORTED  MM_SUPERVISOR_REQUEST_COMM_UPDATE
+#define   MM_SUPERVISOR_REQUEST_MAX_SUPPORTED  MM_SUPERVISOR_REQUEST_REBLOCK_MEM
 
 #endif // _MM_SUPV_REQUEST_DATA_H_

--- a/MmSupervisorPkg/Include/Protocol/MmSupervisorUnblockMemoryProtocol.h
+++ b/MmSupervisorPkg/Include/Protocol/MmSupervisorUnblockMemoryProtocol.h
@@ -17,7 +17,7 @@
     0x10b5eea9, 0xbe0d, 0x4f11, { 0x86, 0x36, 0x1c, 0xb7, 0xa, 0xa3, 0xba, 0x6d } \
   }
 
-#define MM_UNBLOCK_REQUEST_PROTOCOL_VERSION  1
+#define MM_UNBLOCK_REQUEST_PROTOCOL_VERSION  2
 
 typedef struct _MM_SUPERVISOR_UNBLOCK_MEMORY_PROTOCOL MM_SUPERVISOR_UNBLOCK_MEMORY_PROTOCOL;
 
@@ -53,10 +53,40 @@ EFI_STATUS
   IN CONST EFI_GUID         *IdentifierGuid
   );
 
-#pragma pack (1)
+/**
+  This API provides a way to reblock certain data pages to be inaccessible inside MM environment.
+
+  The requested buffer needs to be page size aligned and mapped as data pages. The reblocked
+  buffer will be labeled as CPL3 data pages inaccessible by user mode drivers. MM supervisor will
+  reject the reblock request after Ready-To-Lock event is signaled or whenever supervisor deems
+  a necessity to lock down memory management.
+
+  @param  ReblockAddress          The address of buffer caller requests to reblock, the address
+                                  has to be page aligned.
+  @param  NumberOfPages           The number of pages requested to be reblocked from MM
+                                  environment.
+  @param  IdentifierGuid          The unique caller ID from requester.
+
+  @return EFI_SUCCESS             The request goes through successfully.
+  @return EFI_SECURITY_VIOLATION  The requested address failed to pass security check for
+                                  reblocking.
+  @return EFI_INVALID_PARAMETER   Input address or caller ID is either NULL pointer or not aligned.
+  @return EFI_ACCESS_DENIED       The request is rejected by MM supervisor due to memory map is
+                                  locked down.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *REQUEST_REBLOCK_PAGE)(
+  IN EFI_PHYSICAL_ADDRESS   ReblockAddress,
+  IN UINT64                 NumberOfPages,
+  IN CONST EFI_GUID         *IdentifierGuid
+  );
+
 struct _MM_SUPERVISOR_UNBLOCK_MEMORY_PROTOCOL {
   UINTN                   Version;
   REQUEST_UNBLOCK_PAGE    RequestUnblockPages;
+  REQUEST_REBLOCK_PAGE    RequestReblockPages;
 };
 
 #pragma pack ()

--- a/MmSupervisorPkg/Library/MmSupervisorUnblockMemoryLib/MmSupervisorUnblockMemoryLibDxe.c
+++ b/MmSupervisorPkg/Library/MmSupervisorUnblockMemoryLib/MmSupervisorUnblockMemoryLibDxe.c
@@ -65,3 +65,56 @@ MmUnblockMemoryRequest (
 Done:
   return Status;
 }
+
+/**
+  This API provides a way to reblock certain data pages to be inaccessible inside MM environment.
+  The reblock operation is the reverse of unblock operation, which means the input address and page
+  number should be already unblocked before, otherwise the reblock request will be rejected.
+
+  @param  ReblockAddress              The address of buffer caller requests to reblock, the address
+                                      has to be page aligned.
+  @param  NumberOfPages               The number of pages requested to be reblocked from MM
+                                      environment.
+
+  @return EFI_SUCCESS             The request goes through successfully.
+  @return EFI_NOT_AVAILABLE_YET   The requested functionality is not produced yet.
+  @return EFI_UNSUPPORTED         The requested functionality is not supported on current platform.
+  @return EFI_SECURITY_VIOLATION  The requested address failed to pass security check for
+                                      reblocking.
+  @return EFI_INVALID_PARAMETER   Input address either NULL pointer or not page aligned.
+  @return EFI_ACCESS_DENIED       The request is rejected due to system has passed certain boot
+                                      phase.
+
+**/
+EFI_STATUS
+EFIAPI
+MmReblockMemoryRequest (
+  IN EFI_PHYSICAL_ADDRESS  ReblockAddress,
+  IN UINT64                NumberOfPages
+  )
+{
+  EFI_STATUS                             Status;
+  MM_SUPERVISOR_UNBLOCK_MEMORY_PROTOCOL  *MmSupvUnblockMemoryProtocol = NULL;
+
+  if (gBS == NULL) {
+    Status = EFI_NOT_AVAILABLE_YET;
+    goto Done;
+  }
+
+  Status = gBS->LocateProtocol (&gMmSupervisorUnblockMemoryProtocolGuid, NULL, (VOID **)&MmSupvUnblockMemoryProtocol);
+  if (EFI_ERROR (Status)) {
+    // Should not happen due to depex requirement
+    DEBUG ((DEBUG_ERROR, "%a The reblock protocol has failed to locate - %r\n", __func__, Status));
+    Status = EFI_NOT_AVAILABLE_YET;
+    goto Done;
+  }
+
+  Status = MmSupvUnblockMemoryProtocol->RequestReblockPages (ReblockAddress, NumberOfPages, &gEfiCallerIdGuid);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a The reblock request has failed - %r\n", __func__, Status));
+    ASSERT_EFI_ERROR (Status);
+  }
+
+Done:
+  return Status;
+}

--- a/MmSupervisorPkg/Library/MmSupervisorUnblockMemoryLib/MmSupervisorUnblockMemoryLibPei.c
+++ b/MmSupervisorPkg/Library/MmSupervisorUnblockMemoryLib/MmSupervisorUnblockMemoryLibPei.c
@@ -83,3 +83,36 @@ MmUnblockMemoryRequest (
 Done:
   return Status;
 }
+
+/**
+  This API provides a way to reblock certain data pages to be inaccessible inside MM environment.
+  The reblock operation is the reverse of unblock operation, which means the input address and page
+  number should be already unblocked before, otherwise the reblock request will be rejected.
+
+  @param  ReblockAddress              The address of buffer caller requests to reblock, the address
+                                      has to be page aligned.
+  @param  NumberOfPages               The number of pages requested to be reblocked from MM
+                                      environment.
+
+  @retval RETURN_SUCCESS              The request goes through successfully.
+  @retval RETURN_NOT_AVAILABLE_YET    The requested functionality is not produced yet.
+  @retval RETURN_UNSUPPORTED          The requested functionality is not supported on current platform.
+  @retval RETURN_SECURITY_VIOLATION   The requested address failed to pass security check for
+                                      reblocking.
+  @retval RETURN_INVALID_PARAMETER    Input address either NULL pointer or not page aligned.
+  @retval RETURN_ACCESS_DENIED        The request is rejected due to system has passed certain boot
+                                      phase.
+
+**/
+RETURN_STATUS
+EFIAPI
+MmReblockMemoryRequest (
+  IN PHYSICAL_ADDRESS  ReblockAddress,
+  IN UINT64            NumberOfPages
+  )
+{
+  // For simplicty, we will not support this API in PEI phase, as the main use case of this API is for normal environment
+  // to revoke the access right of certain pages after they are done with MM service, which does not have common usage
+  // in PEI phase.
+  return EFI_UNSUPPORTED;
+}


### PR DESCRIPTION
## Description

Current method of migrating MM accessible buffers is leaving the previously unblocked buffers unblocked, which will pose the risk of failing DRTM validation.

This change adds the implementation of `MmReblockMemoryRequest` newly introduced in basecore:
- The supervisor will support a new opcode that supports reblocking a previously unblocked region
- The unblock memory driver will support a new protocol interface to accept reblocking requests
- The newly added protocol interface will serve as the back end of `MmReblockMemoryRequest`
- The supervisor will stop accepting the reblocking request after ready to lock event

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested using QEMU Q35 and booted to UEFI shell.

## Integration Instructions

N/A
