### PR TITLE
MmSupervisorPkg: Core: Return status value from SaveStateRead2

### DIFF
--- a/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
+++ b/MmSupervisorPkg/Core/PrivilegeMgmt/SyscallDispatcher.c
@@ -418,7 +418,7 @@ SyscallDispatcher (
 
       break;
     case SMM_SC_SVST_READ_2:
-      DEBUG ((DEBUG_VERBOSE, "%a Save state read\n", __func__));
+      DEBUG ((DEBUG_VERBOSE, "%a Save state read 2\n", __func__));
       Ret = 0;
       if (Arg1 == 0) {
         Status = EFI_INVALID_PARAMETER;
@@ -431,7 +431,10 @@ SyscallDispatcher (
       }
 
       Status = ProcessUserSaveStateAccess (CallIndex, (EFI_MM_CPU_PROTOCOL *)Arg1, Arg2, Arg3);
-      if (!EFI_ERROR (Status)) {
+      if (EFI_ERROR (Status)) {
+        Ret    = Status;
+        Status = EFI_SUCCESS;
+      } else {
         Ret = EFI_SUCCESS;
       }
 

--- a/MmSupervisorPkg/Core/Relocate/SmramSaveState.c
+++ b/MmSupervisorPkg/Core/Relocate/SmramSaveState.c
@@ -339,7 +339,6 @@ ProcessUserSaveStateAccess (
                  NULL
                  );
       if (Status == EFI_NOT_FOUND) {
-        Status = EFI_SUCCESS;
         goto Exit;
       } else if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "%a SavestateRead Blocked by Policy - %r\n", __func__, Status));
@@ -353,10 +352,6 @@ ProcessUserSaveStateAccess (
                  UserSaveStateAccessHolder.CpuIndex,
                  UserSaveStateAccessHolder.Buffer
                  );
-      if (!EFI_ERROR (Status) || (Status == EFI_NOT_FOUND)) {
-        // Only convert EFI_NOT_FOUND to unblocking return code on this attempt.
-        Status = EFI_SUCCESS;
-      }
 
       break;
     default:


### PR DESCRIPTION
## Description

When consumers of `gEfiSmmCpuProtocolGuid` are given a `ReadSaveState` function that calls `SysCallMmReadSaveState` in MmSupervisorRing3Broker, they cannot rely on the returned Status value and may proceed to use invalid data present in the `Buffer` argument, since the Buffer is not manipulated in non-Success paths.
This change ensures that the function interface for this protocol works as expected by protocol consumers.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Exposing failure case was this function returning Success on all CPUs, not just the CPU where a Software MMI was triggered.
Verified after the change that only the intended CPU returned Success.

## Integration Instructions

Likely N/A; consumers of `gEfiSmmCpuProtocolGuid` should review handling of the return Status in case they were expecting Success in non-success cases.
