### PR TITLE
MmSupervisorPkg: Update MmiHandlerProfileInfo hash

### DIFF
--- a/MmSupervisorPkg/Test/MmiHandlerProfileInfo/MmiHandlerProfileInfo.inf
+++ b/MmSupervisorPkg/Test/MmiHandlerProfileInfo/MmiHandlerProfileInfo.inf
@@ -10,7 +10,11 @@
 #
 ##
 
-#Override : 00000002 | MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf | 200a51f252b868a8a770351037002853 | 2026-01-09T02-59-38 | 90bd8f57b29398fda07843b9b99857b7bd08a82b
+# 202511
+#Track : 00000002 | MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf | 200a51f252b868a8a770351037002853 | 2026-04-30T16-57-32 | 2a8e32f2f098dd120cf91b0cc6013b02c0501a0d
+
+# 202502
+#Track : 00000002 | MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf | 9064d4320f2bd1591d42a64fcb48270a | 2026-04-30T16-53-50 | 2f423645f34fafd5fde43ec813305361f0807dad
 
 [Defines]
   INF_VERSION                    = 0x00010005


### PR DESCRIPTION
## Description

The hash for the latest 2502 and 2511 branches is different. Move to track tags with updated hash values.

---

2511 does not currently have the CodeQL change as it is waiting for the changes to be merged into edk2 (PR is active).

<img width="2405" height="594" alt="image" src="https://github.com/user-attachments/assets/b8b2fe9d-f6ec-490a-9d45-e484da6c28d1" />

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run OverrideValidation plugin against the 2502 and 2511 `SmiHandlerProfileAuditTestApp` modules.

## Integration Instructions

- Update release/202502 and release/202511 to latest commits. Currently:
  - release/202511: 2a8e32f2f098dd120cf91b0cc6013b02c0501a0d
  - release/202502: 2f423645f34fafd5fde43ec813305361f0807dad