### PR TITLE
Bump `MessageLength` to buffer size for supervisor communications

### DIFF
--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/Common/MmIplCommon.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/Common/MmIplCommon.c
@@ -144,6 +144,10 @@ SmmCommunicationCommunicateWorker (
     CopyMem (CommunicateHeader, CommBuffer, TempCommSize);
   }
 
+  // When communicating to supervisor, we always bump up the message length to the size of the buffer, so that supervisor can access the entire buffer
+  if (TalkToSupervisor) {
+    CommunicateHeader->MessageLength = TempCommSize - OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data);
+  }
   // MU_CHANGE Ends: MM_SUPV
 
   //

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/Common/MmIplCommon.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/Common/MmIplCommon.c
@@ -148,6 +148,7 @@ SmmCommunicationCommunicateWorker (
   if (TalkToSupervisor) {
     CommunicateHeader->MessageLength = TempCommSize - OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data);
   }
+
   // MU_CHANGE Ends: MM_SUPV
 
   //

--- a/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
+++ b/MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.c
@@ -185,7 +185,6 @@ VerifyMemPolicy (
   This helper function preps the shared CommBuffer for use by the test step.
 
   @param[out] CommBuffer      Returns a pointer to the CommBuffer for the test step to use.
-  @param[in]  AdditionalSize  Additional size needed in the CommBuffer for test-specific data.
 
   @retval     EFI_SUCCESS         CommBuffer initialized and ready to use.
   @retval     EFI_ABORTED         Some error occurred.
@@ -194,8 +193,7 @@ VerifyMemPolicy (
 STATIC
 EFI_STATUS
 MmSupvRequestGetCommBuffer (
-  OUT  MM_SUPERVISOR_REQUEST_HEADER  **CommBuffer,
-  IN   UINT64                        AdditionalSize
+  OUT  MM_SUPERVISOR_REQUEST_HEADER  **CommBuffer
   )
 {
   EFI_MM_COMMUNICATE_HEADER  *CommHeader;
@@ -208,7 +206,7 @@ MmSupvRequestGetCommBuffer (
 
   // First, let's zero the comm buffer. Couldn't hurt.
   CommHeader     = (EFI_MM_COMMUNICATE_HEADER *)mMmSupvCommonCommBufferAddress;
-  CommBufferSize = AdditionalSize + sizeof (MM_SUPERVISOR_REQUEST_HEADER) + OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data);
+  CommBufferSize = sizeof (MM_SUPERVISOR_REQUEST_HEADER) + OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data);
   if (CommBufferSize > mMmSupvCommonCommBufferSize) {
     DEBUG ((DEBUG_ERROR, "[%a] - Communication buffer is too small!\n", __func__));
     return EFI_ABORTED;
@@ -218,7 +216,7 @@ MmSupvRequestGetCommBuffer (
 
   // MM Communication Parameters
   CopyGuid (&CommHeader->HeaderGuid, &gMmSupervisorRequestHandlerGuid);
-  CommHeader->MessageLength = sizeof (MM_SUPERVISOR_REQUEST_HEADER) + AdditionalSize;
+  CommHeader->MessageLength = sizeof (MM_SUPERVISOR_REQUEST_HEADER);
 
   // Return a pointer to the CommBuffer for the test to modify.
   *CommBuffer = (MM_SUPERVISOR_REQUEST_HEADER *)CommHeader->Data;
@@ -283,7 +281,7 @@ FetchSecurityPolicyFromSupv (
   SecurityPolicy = NULL;
 
   // Grab the CommBuffer and fill it in for this test
-  Status = MmSupvRequestGetCommBuffer (&CommBuffer, mMmSupvCommonCommBufferSize - sizeof (MM_SUPERVISOR_REQUEST_HEADER) - OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data));
+  Status = MmSupvRequestGetCommBuffer (&CommBuffer);
   if (EFI_ERROR (Status)) {
     return NULL;
   }
@@ -646,7 +644,7 @@ RequestVersionInfo (
   MM_SUPERVISOR_VERSION_INFO_BUFFER  *VersionInfo;
 
   // Grab the CommBuffer and fill it in for this test
-  Status = MmSupvRequestGetCommBuffer (&CommBuffer, sizeof (MM_SUPERVISOR_VERSION_INFO_BUFFER));
+  Status = MmSupvRequestGetCommBuffer (&CommBuffer);
   UT_ASSERT_NOT_EFI_ERROR (Status);
 
   CommBuffer->Signature = MM_SUPERVISOR_REQUEST_SIG;
@@ -698,7 +696,7 @@ RequestUnblockRegion (
   }
 
   // Grab the CommBuffer and fill it in for this test
-  Status = MmSupvRequestGetCommBuffer (&CommBuffer, sizeof (MM_SUPERVISOR_UNBLOCK_MEMORY_PARAMS));
+  Status = MmSupvRequestGetCommBuffer (&CommBuffer);
   UT_ASSERT_NOT_EFI_ERROR (Status);
 
   CommBuffer->Signature = MM_SUPERVISOR_REQUEST_SIG;
@@ -886,7 +884,7 @@ RequestUpdateCommBuffer (
   MM_SUPERVISOR_COMM_UPDATE_BUFFER  *UpdateCommBuffer;
 
   // Grab the CommBuffer and fill it in for this test
-  Status = MmSupvRequestGetCommBuffer (&CommBuffer, sizeof (MM_SUPERVISOR_COMM_UPDATE_BUFFER));
+  Status = MmSupvRequestGetCommBuffer (&CommBuffer);
   UT_ASSERT_NOT_EFI_ERROR (Status);
 
   CommBuffer->Signature = MM_SUPERVISOR_REQUEST_SIG;


### PR DESCRIPTION
## Description

The `MessageLength` has been tied to input buffer size in the recent movement of removing core private data.

This makes the caller having to change to compensate this because the buffer size was meant to indicate the total buffer size the MM core can use for the return.

Given this supervised MM environment has fixed buffer size, already pre-unblocked, it could be treated that the message length will always be covering the entire prepared buffer region.

The test is also reverted to verify the corresponding change.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU Q35 and passed the updated test app.

## Integration Instructions

N/A