### PR TITLE
Close supervisor communication channel at Exit Boot Services

### DIFF
--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -447,11 +447,11 @@ MmReadyToLockHandler (
   This function will set a flag to indicate MM is at runtime, and the flag will be used to prevent
   any further MM communication through supervisor buffer.
 
-  @param  DispatchHandle  The unique handle assigned to this handler by MmiHandlerRegister().
-  @param  Context         Points to an optional handler context which was specified when the handler was registered.
-  @param  CommBuffer      A pointer to a collection of data in memory that will
-                          be conveyed from a non-MM environment into an MM environment.
-  @param  CommBufferSize  The size of the CommBuffer.
+  @param[in]      DispatchHandle  The unique handle assigned to this handler by MmiHandlerRegister().
+  @param[in]      Context         Points to an optional handler context which was specified when the handler was registered.
+  @param[in,out]  CommBuffer      A pointer to a collection of data in memory that will
+                                  be conveyed from a non-MM environment into an MM environment.
+  @param[in,out]  CommBufferSize  The size of the CommBuffer.
 
   @return Status Code
 

--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -108,10 +108,11 @@ EFI_MEMORY_DESCRIPTOR  mMmSupervisorAccessBuffer[MM_OPEN_BUFFER_CNT];
 // Table of MMI Handlers that are registered by the MM Core when it is initialized
 //
 MM_CORE_MMI_HANDLERS  mMmCoreMmiHandlers[] = {
-  { MmDriverDispatchHandler, &gMmSupervisorDriverDispatchGuid,  NULL, TRUE  },
-  { MmReadyToLockHandler,    &gEfiDxeMmReadyToLockProtocolGuid, NULL, TRUE  },
-  { MmSupvRequestHandler,    &gMmSupervisorRequestHandlerGuid,  NULL, FALSE },
-  { NULL,                    NULL,                              NULL, FALSE },
+  { MmDriverDispatchHandler,    &gMmSupervisorDriverDispatchGuid,  NULL, TRUE  },
+  { MmReadyToLockHandler,       &gEfiDxeMmReadyToLockProtocolGuid, NULL, TRUE  },
+  { MmSupvRequestHandler,       &gMmSupervisorRequestHandlerGuid,  NULL, FALSE },
+  { MmExitBootServicesHandler,  &gEfiEventExitBootServicesGuid,    NULL, FALSE },
+  { NULL,                    NULL,                                 NULL, FALSE },
 };
 
 EFI_SYSTEM_TABLE                  *mEfiSystemTable;
@@ -121,6 +122,7 @@ EFI_MM_DRIVER_ENTRY               *mMmCoreDriverEntry;
 MM_SUPV_USER_COMMON_BUFFER        *SupervisorToUserDataBuffer = NULL;
 BOOLEAN                           mMmReadyToLockDone          = FALSE;
 BOOLEAN                           mCoreInitializationComplete = FALSE;
+BOOLEAN                           mAtRuntime                  = FALSE;
 VOID                              *mInternalCommBufferCopy[MM_OPEN_BUFFER_CNT];
 SMM_SUPV_SECURE_POLICY_DATA_V1_0  *FirmwarePolicy = NULL;
 
@@ -441,6 +443,45 @@ MmReadyToLockHandler (
 }
 
 /**
+  Software MMI handler that should be triggered from non-MM environment upon DxeMmReadyToLock
+  event. This function unregisters the SUPERVISOR MMIs that are not required after Ready To Lock
+  event. Certain features, such as unblock memory regions, will not be available after this point.
+
+  Note: User ready to lock event will be notified prior to this supervisor ready to lock event.
+  This order is controlled in the corresponding DXE agent (IPL and/or DxeSupport driver).
+
+  @param  DispatchHandle  The unique handle assigned to this handler by MmiHandlerRegister().
+  @param  Context         Points to an optional handler context which was specified when the handler was registered.
+  @param  CommBuffer      A pointer to a collection of data in memory that will
+                          be conveyed from a non-MM environment into an MM environment.
+  @param  CommBufferSize  The size of the CommBuffer.
+
+  @return Status Code
+
+**/
+EFI_STATUS
+EFIAPI
+MmExitBootServicesHandler (
+  IN     EFI_HANDLE  DispatchHandle,
+  IN     CONST VOID  *Context         OPTIONAL,
+  IN OUT VOID        *CommBuffer      OPTIONAL,
+  IN OUT UINTN       *CommBufferSize  OPTIONAL
+  )
+{
+  DEBUG ((DEBUG_INFO, "%a\n", __func__));
+
+  if (mAtRuntime) {
+    DEBUG ((DEBUG_ERROR, "ExitBootServices event is signaled more than once??\n"));
+    ASSERT (FALSE);
+    return EFI_ALREADY_STARTED;
+  }
+
+  mAtRuntime = TRUE;
+
+  return EFI_SUCCESS;
+}
+
+/**
   Determine if two buffers overlap in memory.
 
   @param[in] Buff1  Pointer to first buffer
@@ -532,7 +573,63 @@ MmEntryPoint (
     CopyMem (&MmCommunicationUserBufferStatus, mMmCommUserMailboxBufferStatus, sizeof (*mMmCommUserMailboxBufferStatus));
   }
 
-  if (MmCommunicationSupvBufferStatus.IsCommBufferValid) {
+  if (MmCommunicationUserBufferStatus.IsCommBufferValid) {
+    //
+    // This should be user communicate channel, follow normal user channel iterations, but use ring 3 buffer to hold BufferSize changes
+    //
+    CommunicationBuffer = mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].PhysicalStart;
+    ZeroMem (mInternalCommBufferCopy[MM_USER_BUFFER_T], EFI_PAGES_TO_SIZE (mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].NumberOfPages));
+    CopyMem (mInternalCommBufferCopy[MM_USER_BUFFER_T], (VOID *)(UINTN)CommunicationBuffer, EFI_PAGES_TO_SIZE (mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].NumberOfPages));
+    CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER *)(UINTN)mInternalCommBufferCopy[MM_USER_BUFFER_T];
+
+    // Check if MM Communicate V3 is being used
+    if (CompareGuid (&(CommunicateHeader->HeaderGuid), &gEfiMmCommunicateHeaderV3Guid)) {
+      CommunicateHeaderV3 = (EFI_MM_COMMUNICATE_HEADER_V3 *)CommunicateHeader;
+      CommGuidOffset      = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER_V3, MessageGuid);
+      CommHeaderSize      = sizeof (EFI_MM_COMMUNICATE_HEADER_V3);
+      BufferSize          = CommunicateHeaderV3->BufferSize;
+    } else {
+      CommGuidOffset = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, HeaderGuid);
+      CommHeaderSize = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data);
+      BufferSize     = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + CommunicateHeader->MessageLength;
+    }
+
+    if (BufferSize > EFI_PAGES_TO_SIZE (mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].NumberOfPages)) {
+      // The input buffer size is larger than the maximal allowed size, need to panic here.
+      DEBUG ((DEBUG_ERROR, "%a Input buffer size is larger than maximal allowed user buffer size, something is off...\n", __func__));
+      ASSERT (FALSE);
+      MmCommunicationUserBufferStatus.IsCommBufferValid = FALSE;
+      MmCommunicationUserBufferStatus.ReturnBufferSize  = 0;
+      MmCommunicationUserBufferStatus.ReturnStatus      = EFI_BAD_BUFFER_SIZE;
+      goto Cleanup;
+    }
+
+    BufferSize                                -= CommHeaderSize;
+    SupervisorToUserDataBuffer->UserBufferSize = BufferSize;
+
+    Status = MmiManage (
+               (EFI_GUID *)((UINT8 *)CommunicateHeader + CommGuidOffset),
+               NULL,
+               (UINT8 *)CommunicateHeader + CommHeaderSize,
+               (UINTN *)&(SupervisorToUserDataBuffer->UserBufferSize)
+               );
+    //
+    // Update CommunicationBuffer, BufferSize and ReturnStatus
+    // Communicate service finished, reset the pointer to CommBuffer to NULL
+    //
+    BufferSize = SupervisorToUserDataBuffer->UserBufferSize + CommHeaderSize;
+    if (BufferSize <= EFI_PAGES_TO_SIZE (mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].NumberOfPages)) {
+      CopyMem ((VOID *)(UINTN)CommunicationBuffer, CommunicateHeader, BufferSize);
+    } else {
+      // The returned buffer size indicating the return buffer is larger than input buffer, need to panic here.
+      DEBUG ((DEBUG_ERROR, "%a Returned buffer size is larger than maximal allowed size indicated in input, something is off...\n", __func__));
+      ASSERT (FALSE);
+    }
+
+    MmCommunicationUserBufferStatus.IsCommBufferValid = FALSE;
+    MmCommunicationUserBufferStatus.ReturnBufferSize  = BufferSize;
+    MmCommunicationUserBufferStatus.ReturnStatus      = (Status == EFI_SUCCESS) ? EFI_SUCCESS : EFI_NOT_FOUND;
+  } else if (!mAtRuntime && MmCommunicationSupvBufferStatus.IsCommBufferValid) {
     //
     // This should be supervisor communicate channel, everything can be ring 0 buffer fine
     //
@@ -594,62 +691,6 @@ MmEntryPoint (
     // Do not handle asynchronous MMI sources. This cannot be it...
     //
     goto Cleanup;
-  } else if (MmCommunicationUserBufferStatus.IsCommBufferValid) {
-    //
-    // This should be user communicate channel, follow normal user channel iterations, but use ring 3 buffer to hold BufferSize changes
-    //
-    CommunicationBuffer = mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].PhysicalStart;
-    ZeroMem (mInternalCommBufferCopy[MM_USER_BUFFER_T], EFI_PAGES_TO_SIZE (mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].NumberOfPages));
-    CopyMem (mInternalCommBufferCopy[MM_USER_BUFFER_T], (VOID *)(UINTN)CommunicationBuffer, EFI_PAGES_TO_SIZE (mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].NumberOfPages));
-    CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER *)(UINTN)mInternalCommBufferCopy[MM_USER_BUFFER_T];
-
-    // Check if MM Communicate V3 is being used
-    if (CompareGuid (&(CommunicateHeader->HeaderGuid), &gEfiMmCommunicateHeaderV3Guid)) {
-      CommunicateHeaderV3 = (EFI_MM_COMMUNICATE_HEADER_V3 *)CommunicateHeader;
-      CommGuidOffset      = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER_V3, MessageGuid);
-      CommHeaderSize      = sizeof (EFI_MM_COMMUNICATE_HEADER_V3);
-      BufferSize          = CommunicateHeaderV3->BufferSize;
-    } else {
-      CommGuidOffset = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, HeaderGuid);
-      CommHeaderSize = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data);
-      BufferSize     = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + CommunicateHeader->MessageLength;
-    }
-
-    if (BufferSize > EFI_PAGES_TO_SIZE (mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].NumberOfPages)) {
-      // The input buffer size is larger than the maximal allowed size, need to panic here.
-      DEBUG ((DEBUG_ERROR, "%a Input buffer size is larger than maximal allowed user buffer size, something is off...\n", __func__));
-      ASSERT (FALSE);
-      MmCommunicationUserBufferStatus.IsCommBufferValid = FALSE;
-      MmCommunicationUserBufferStatus.ReturnBufferSize  = 0;
-      MmCommunicationUserBufferStatus.ReturnStatus      = EFI_BAD_BUFFER_SIZE;
-      goto Cleanup;
-    }
-
-    BufferSize                                -= CommHeaderSize;
-    SupervisorToUserDataBuffer->UserBufferSize = BufferSize;
-
-    Status = MmiManage (
-               (EFI_GUID *)((UINT8 *)CommunicateHeader + CommGuidOffset),
-               NULL,
-               (UINT8 *)CommunicateHeader + CommHeaderSize,
-               (UINTN *)&(SupervisorToUserDataBuffer->UserBufferSize)
-               );
-    //
-    // Update CommunicationBuffer, BufferSize and ReturnStatus
-    // Communicate service finished, reset the pointer to CommBuffer to NULL
-    //
-    BufferSize = SupervisorToUserDataBuffer->UserBufferSize + CommHeaderSize;
-    if (BufferSize <= EFI_PAGES_TO_SIZE (mMmSupervisorAccessBuffer[MM_USER_BUFFER_T].NumberOfPages)) {
-      CopyMem ((VOID *)(UINTN)CommunicationBuffer, CommunicateHeader, BufferSize);
-    } else {
-      // The returned buffer size indicating the return buffer is larger than input buffer, need to panic here.
-      DEBUG ((DEBUG_ERROR, "%a Returned buffer size is larger than maximal allowed size indicated in input, something is off...\n", __func__));
-      ASSERT (FALSE);
-    }
-
-    MmCommunicationUserBufferStatus.IsCommBufferValid = FALSE;
-    MmCommunicationUserBufferStatus.ReturnBufferSize  = BufferSize;
-    MmCommunicationUserBufferStatus.ReturnStatus      = (Status == EFI_SUCCESS) ? EFI_SUCCESS : EFI_NOT_FOUND;
   } else {
     DEBUG ((DEBUG_INFO, "No valid communication buffer, no Synchronous MMI will be processed\n"));
   }

--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -468,9 +468,9 @@ MmExitBootServicesHandler (
   DEBUG ((DEBUG_INFO, "%a\n", __func__));
 
   if (mAtRuntime) {
-    DEBUG ((DEBUG_ERROR, "ExitBootServices event is signaled more than once??\n"));
-    ASSERT (FALSE);
-    return EFI_ALREADY_STARTED;
+    DEBUG ((DEBUG_WARN, "ExitBootServices event is signaled more than once??\n"));
+    // This is to prevent further dispatching of other handlers.
+    return EFI_SUCCESS;
   }
 
   mAtRuntime = TRUE;

--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -108,11 +108,11 @@ EFI_MEMORY_DESCRIPTOR  mMmSupervisorAccessBuffer[MM_OPEN_BUFFER_CNT];
 // Table of MMI Handlers that are registered by the MM Core when it is initialized
 //
 MM_CORE_MMI_HANDLERS  mMmCoreMmiHandlers[] = {
-  { MmDriverDispatchHandler,    &gMmSupervisorDriverDispatchGuid,  NULL, TRUE  },
-  { MmReadyToLockHandler,       &gEfiDxeMmReadyToLockProtocolGuid, NULL, TRUE  },
-  { MmSupvRequestHandler,       &gMmSupervisorRequestHandlerGuid,  NULL, FALSE },
-  { MmExitBootServicesHandler,  &gEfiEventExitBootServicesGuid,    NULL, FALSE },
-  { NULL,                    NULL,                                 NULL, FALSE },
+  { MmDriverDispatchHandler,   &gMmSupervisorDriverDispatchGuid,  NULL, TRUE  },
+  { MmReadyToLockHandler,      &gEfiDxeMmReadyToLockProtocolGuid, NULL, TRUE  },
+  { MmSupvRequestHandler,      &gMmSupervisorRequestHandlerGuid,  NULL, FALSE },
+  { MmExitBootServicesHandler, &gEfiEventExitBootServicesGuid,    NULL, FALSE },
+  { NULL,                      NULL,                              NULL, FALSE },
 };
 
 EFI_SYSTEM_TABLE                  *mEfiSystemTable;

--- a/MmSupervisorPkg/Core/MmSupervisorCore.c
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.c
@@ -443,12 +443,9 @@ MmReadyToLockHandler (
 }
 
 /**
-  Software MMI handler that should be triggered from non-MM environment upon DxeMmReadyToLock
-  event. This function unregisters the SUPERVISOR MMIs that are not required after Ready To Lock
-  event. Certain features, such as unblock memory regions, will not be available after this point.
-
-  Note: User ready to lock event will be notified prior to this supervisor ready to lock event.
-  This order is controlled in the corresponding DXE agent (IPL and/or DxeSupport driver).
+  Software MMI handler that is called when ExitBootServices is triggered in non-MM environment.
+  This function will set a flag to indicate MM is at runtime, and the flag will be used to prevent
+  any further MM communication through supervisor buffer.
 
   @param  DispatchHandle  The unique handle assigned to this handler by MmiHandlerRegister().
   @param  Context         Points to an optional handler context which was specified when the handler was registered.
@@ -629,7 +626,16 @@ MmEntryPoint (
     MmCommunicationUserBufferStatus.IsCommBufferValid = FALSE;
     MmCommunicationUserBufferStatus.ReturnBufferSize  = BufferSize;
     MmCommunicationUserBufferStatus.ReturnStatus      = (Status == EFI_SUCCESS) ? EFI_SUCCESS : EFI_NOT_FOUND;
-  } else if (!mAtRuntime && MmCommunicationSupvBufferStatus.IsCommBufferValid) {
+  } else if (MmCommunicationSupvBufferStatus.IsCommBufferValid) {
+    if (mAtRuntime) {
+      DEBUG ((DEBUG_ERROR, "Supervisor buffer cannot be used for communication after ExitBootServices is signaled!!\n"));
+      ASSERT (FALSE);
+      MmCommunicationSupvBufferStatus.IsCommBufferValid = FALSE;
+      MmCommunicationSupvBufferStatus.ReturnBufferSize  = 0;
+      MmCommunicationSupvBufferStatus.ReturnStatus      = EFI_ACCESS_DENIED;
+      goto Cleanup;
+    }
+
     //
     // This should be supervisor communicate channel, everything can be ring 0 buffer fine
     //

--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -803,12 +803,9 @@ MmReadyToLockHandler (
   );
 
 /**
-  Software MMI handler that should be triggered from non-MM environment upon DxeMmReadyToLock
-  event. This function unregisters the SUPERVISOR MMIs that are not required after Ready To Lock
-  event. Certain features, such as unblock memory regions, will not be available after this point.
-
-  Note: User ready to lock event will be notified prior to this supervisor ready to lock event.
-  This order is controlled in the corresponding DXE agent (IPL and/or DxeSupport driver).
+  Software MMI handler that is called when ExitBootServices is triggered in non-MM environment.
+  This function will set a flag to indicate MM is at runtime, and the flag will be used to prevent
+  any further MM communication through supervisor buffer.
 
   @param  DispatchHandle  The unique handle assigned to this handler by MmiHandlerRegister().
   @param  Context         Points to an optional handler context which was specified when the handler was registered.

--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -803,6 +803,32 @@ MmReadyToLockHandler (
   );
 
 /**
+  Software MMI handler that should be triggered from non-MM environment upon DxeMmReadyToLock
+  event. This function unregisters the SUPERVISOR MMIs that are not required after Ready To Lock
+  event. Certain features, such as unblock memory regions, will not be available after this point.
+
+  Note: User ready to lock event will be notified prior to this supervisor ready to lock event.
+  This order is controlled in the corresponding DXE agent (IPL and/or DxeSupport driver).
+
+  @param  DispatchHandle  The unique handle assigned to this handler by MmiHandlerRegister().
+  @param  Context         Points to an optional handler context which was specified when the handler was registered.
+  @param  CommBuffer      A pointer to a collection of data in memory that will
+                          be conveyed from a non-MM environment into an MM environment.
+  @param  CommBufferSize  The size of the CommBuffer.
+
+  @return Status Code
+
+**/
+EFI_STATUS
+EFIAPI
+MmExitBootServicesHandler (
+  IN     EFI_HANDLE  DispatchHandle,
+  IN     CONST VOID  *Context         OPTIONAL,
+  IN OUT VOID        *CommBuffer      OPTIONAL,
+  IN OUT UINTN       *CommBufferSize  OPTIONAL
+  );
+
+/**
   Place holder function until all the MM System Table Service are available.
 
   @param  Arg1                   Undefined

--- a/MmSupervisorPkg/Core/MmSupervisorCore.h
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.h
@@ -807,11 +807,11 @@ MmReadyToLockHandler (
   This function will set a flag to indicate MM is at runtime, and the flag will be used to prevent
   any further MM communication through supervisor buffer.
 
-  @param  DispatchHandle  The unique handle assigned to this handler by MmiHandlerRegister().
-  @param  Context         Points to an optional handler context which was specified when the handler was registered.
-  @param  CommBuffer      A pointer to a collection of data in memory that will
-                          be conveyed from a non-MM environment into an MM environment.
-  @param  CommBufferSize  The size of the CommBuffer.
+  @param[in]      DispatchHandle  The unique handle assigned to this handler by MmiHandlerRegister().
+  @param[in]      Context         Points to an optional handler context which was specified when the handler was registered.
+  @param[in,out]  CommBuffer      A pointer to a collection of data in memory that will
+                                  be conveyed from a non-MM environment into an MM environment.
+  @param[in,out]  CommBufferSize  The size of the CommBuffer.
 
   @return Status Code
 

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -242,6 +242,7 @@
   gEfiHobListGuid
   gMmFvDispatchGuid
   gEfiEventLegacyBootGuid
+  gEfiEventExitBootServicesGuid
 
   gMmCoreMmProfileGuid
   gMmCommonRegionHobGuid                        ## CONSUMES

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
@@ -106,8 +106,8 @@ SmmIplEndOfDxeEventNotify (
 /**
   Event notification that is fired when the ExitBootServices event is signaled.
 
-  @param  Event                 The Event that is being processed, not used.
-  @param  Context               Event Context, not used.
+  @param[in]  Event                 The Event that is being processed, not used.
+  @param[in]  Context               Event Context, not used.
 
 **/
 VOID

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
@@ -103,6 +103,20 @@ SmmIplEndOfDxeEventNotify (
   IN VOID       *Context
   );
 
+/**
+  Event notification that is fired when the ExitBootServices event is signaled.
+
+  @param  Event                 The Event that is being processed, not used.
+  @param  Context               Event Context, not used.
+
+**/
+VOID
+EFIAPI
+SmmIplExitBootServicesEventNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  );
+
 //
 // Data structure used to declare a table of protocol notifications and event
 // notifications required by the SMM IPL
@@ -162,6 +176,10 @@ SMM_IPL_EVENT_NOTIFICATION  mSmmIplEvents[] = {
   // used to make sure SMRAM is locked before any boot options are processed.
   //
   { FALSE, TRUE,  &gEfiEventReadyToBootGuid,          SmmIplReadyToLockEventNotify, &gEfiEventReadyToBootGuid,          TPL_CALLBACK,     NULL },
+  //
+  // Declare event notification on Exit Boot Services Event Group.  This is used to signal the supervisor to
+  // stop accepting any supervisor requests after handing off to OS.
+  { FALSE, FALSE, &gEfiEventExitBootServicesGuid,      SmmIplExitBootServicesEventNotify, &gEfiEventExitBootServicesGuid,     TPL_CALLBACK,     NULL },
   //
   // Terminate the table of event notifications
   //
@@ -345,6 +363,56 @@ SmmIplReadyToLockEventNotify (
 }
 
 // MM_SUPV: Update communicate buffer when entering DXE.
+
+/**
+  Event notification that is fired when the ExitBootServices event is signaled.
+
+  @param  Event                 The Event that is being processed, not used.
+  @param  Context               Event Context, not used.
+
+**/
+VOID
+EFIAPI
+SmmIplExitBootServicesEventNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Size;
+
+  //
+  // We inform SMM Core that the DxeSmmReadyToLock protocol was installed
+  //
+  mCommunicateHeader = (EFI_SMM_COMMUNICATE_HEADER *)mMmSupvCommonBuffer;
+
+  //
+  // Use Guid to initialize EFI_SMM_COMMUNICATE_HEADER structure
+  //
+  CopyGuid (&mCommunicateHeader->HeaderGuid, (EFI_GUID *)Context);
+
+  //
+  // Check to make sure the header GUID is the correct one for ExitBootServices.
+  //
+  if (!CompareGuid ((EFI_GUID *)Context, &gEfiEventExitBootServicesGuid)) {
+    DEBUG ((DEBUG_ERROR, "Unexpected event notification for %g\n", (EFI_GUID *)Context));
+    ASSERT (FALSE);
+    return;
+  }
+
+  mCommunicateHeader->MessageLength = 1;
+  mCommunicateHeader->Data[0]       = 0;
+
+  //
+  // Generate the Software SMI and return the result
+  //
+  Size = sizeof (EFI_SMM_COMMUNICATE_HEADER);
+  Status = SupvCommunicationCommunicate (&mMmSupvCommunication, mCommunicateHeader, &Size);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed to communicate with supervisor at ExitBootServices event - %r\n", Status));
+    ASSERT_EFI_ERROR (Status);
+  }
+}
 
 /**
   Communicate to MmSupervisor to update the buffer to runtime pages allocated in DXE.

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
@@ -166,24 +166,24 @@ SMM_IPL_EVENT_NOTIFICATION  mSmmIplEvents[] = {
   // the associated event is immediately signalled, so the notification function will be executed and the
   // DXE SMM Ready To Lock Protocol will be found if it is already in the handle database.
   //
-  { TRUE,  TRUE,  &gEfiDxeSmmReadyToLockProtocolGuid, SmmIplReadyToLockEventNotify, &gEfiDxeSmmReadyToLockProtocolGuid, TPL_CALLBACK - 1, NULL },
+  { TRUE,  TRUE,  &gEfiDxeSmmReadyToLockProtocolGuid, SmmIplReadyToLockEventNotify,      &gEfiDxeSmmReadyToLockProtocolGuid, TPL_CALLBACK - 1, NULL },
   //
   // Declare event notification on EndOfDxe event.  This is used to set EndOfDxe event signaled flag.
   //
-  { FALSE, TRUE,  &gEfiEndOfDxeEventGroupGuid,        SmmIplEndOfDxeEventNotify,    &gEfiEndOfDxeEventGroupGuid,        TPL_CALLBACK,     NULL },
+  { FALSE, TRUE,  &gEfiEndOfDxeEventGroupGuid,        SmmIplEndOfDxeEventNotify,         &gEfiEndOfDxeEventGroupGuid,        TPL_CALLBACK,     NULL },
   //
   // Declare event notification on Ready To Boot Event Group.  This is an extra event notification that is
   // used to make sure SMRAM is locked before any boot options are processed.
   //
-  { FALSE, TRUE,  &gEfiEventReadyToBootGuid,          SmmIplReadyToLockEventNotify, &gEfiEventReadyToBootGuid,          TPL_CALLBACK,     NULL },
+  { FALSE, TRUE,  &gEfiEventReadyToBootGuid,          SmmIplReadyToLockEventNotify,      &gEfiEventReadyToBootGuid,          TPL_CALLBACK,     NULL },
   //
   // Declare event notification on Exit Boot Services Event Group.  This is used to signal the supervisor to
   // stop accepting any supervisor requests after handing off to OS.
-  { FALSE, FALSE, &gEfiEventExitBootServicesGuid,      SmmIplExitBootServicesEventNotify, &gEfiEventExitBootServicesGuid,     TPL_CALLBACK,     NULL },
+  { FALSE, FALSE, &gEfiEventExitBootServicesGuid,     SmmIplExitBootServicesEventNotify, &gEfiEventExitBootServicesGuid,     TPL_CALLBACK,     NULL },
   //
   // Terminate the table of event notifications
   //
-  { FALSE, FALSE, NULL,                               NULL,                         NULL,                               TPL_CALLBACK,     NULL }
+  { FALSE, FALSE, NULL,                               NULL,                              NULL,                               TPL_CALLBACK,     NULL }
 };
 
 // MU_CHANGE: Abstracted function implementation of MmControl->Trigger for PEI
@@ -406,7 +406,7 @@ SmmIplExitBootServicesEventNotify (
   //
   // Generate the Software SMI and return the result
   //
-  Size = sizeof (EFI_SMM_COMMUNICATE_HEADER);
+  Size   = sizeof (EFI_SMM_COMMUNICATE_HEADER);
   Status = SupvCommunicationCommunicate (&mMmSupvCommunication, mCommunicateHeader, &Size);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Failed to communicate with supervisor at ExitBootServices event - %r\n", Status));

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
@@ -367,8 +367,8 @@ SmmIplReadyToLockEventNotify (
 /**
   Event notification that is fired when the ExitBootServices event is signaled.
 
-  @param  Event                 The Event that is being processed, not used.
-  @param  Context               Event Context, not used.
+  @param[in]  Event                 The Event that is being processed, not used.
+  @param[in]  Context               Event Context, not used.
 
 **/
 VOID

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
@@ -400,6 +400,7 @@ SmmIplExitBootServicesEventNotify (
     return;
   }
 
+  // Set the message length to 1 and data to 0 to keep the MmiManage input check happy.
   mCommunicateHeader->MessageLength = 1;
   mCommunicateHeader->Data[0]       = 0;
 

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
@@ -387,11 +387,6 @@ SmmIplExitBootServicesEventNotify (
   mCommunicateHeader = (EFI_SMM_COMMUNICATE_HEADER *)mMmSupvCommonBuffer;
 
   //
-  // Use Guid to initialize EFI_SMM_COMMUNICATE_HEADER structure
-  //
-  CopyGuid (&mCommunicateHeader->HeaderGuid, (EFI_GUID *)Context);
-
-  //
   // Check to make sure the header GUID is the correct one for ExitBootServices.
   //
   if (!CompareGuid ((EFI_GUID *)Context, &gEfiEventExitBootServicesGuid)) {
@@ -399,6 +394,11 @@ SmmIplExitBootServicesEventNotify (
     ASSERT (FALSE);
     return;
   }
+
+  //
+  // Use Guid to initialize EFI_SMM_COMMUNICATE_HEADER structure
+  //
+  CopyGuid (&mCommunicateHeader->HeaderGuid, (EFI_GUID *)Context);
 
   // Set the message length to 1 and data to 0 to keep the MmiManage input check happy.
   mCommunicateHeader->MessageLength = 1;

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.inf
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.inf
@@ -60,6 +60,7 @@
   ## SOMETIMES_PRODUCES ## UNDEFINED # Used to do smm communication
   gEfiEventReadyToBootGuid
   gEfiEndOfDxeEventGroupGuid                    ## CONSUMES             ## Event
+  gEfiEventExitBootServicesGuid                 ## CONSUMES             ## Event
   gMmCommonRegionHobGuid                        ## CONSUMES
   gMmSupervisorRequestHandlerGuid               ## CONSUMES
   gMmCommBufferHobGuid                          ## CONSUMES


### PR DESCRIPTION
## Description

This change updates the Supervisor communication DXE agent to signal the exit boot services to supervisor in order to shut down the supervisor communication channel after the control is handed off to the OS.

The change also flips the communication buffer consumption order, which prioritize the user buffer serving first, then the supervisor buffer.

Resolves #654.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU Q35 and booted to Windows desktop with `MmExitBootServicesHandler` printed in the log.

## Integration Instructions

N/A