### PR TITLE
Fixing the initial supervisor buffer status

### DIFF
--- a/MmSupervisorPkg/Drivers/MmCommunicationBuffer/MmCommunicationBufferPei.c
+++ b/MmSupervisorPkg/Drivers/MmCommunicationBuffer/MmCommunicationBufferPei.c
@@ -98,6 +98,8 @@ ReserveSupvCommBuffer (
     goto Done;
   }
 
+  ZeroMem ((VOID *)(UINTN)CommRegionHob->MmStatusRegionAddr, sizeof (MM_COMM_BUFFER_STATUS));
+
   DEBUG ((DEBUG_INFO, "Reserved MM common buffer type 0x%x\n", CommRegionHob->MmCommonRegionType));
   DEBUG ((DEBUG_INFO, "  PhysicalStart   - 0x%lx\n", CommRegionHob->MmCommonRegionAddr));
   DEBUG ((DEBUG_INFO, "  NumberOfPages   - 0x%lx\n", CommRegionHob->MmCommonRegionPages));


### PR DESCRIPTION
## Description

The current implementation of parallel status buffer does not out the allocated buffer, which could cause the attempt to communicate to supervisor to assert. This change is intended to fix this issue for when the buffer is non-zero.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested on physical hardware platform and would no longer cause the same assert when trying to use supervisor status buffer to communicate.

## Integration Instructions

N/A