### PR TITLE
[gen_aux] Allow the non-forward-reference symbols of zero length

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -856,6 +856,11 @@ impl TypeInfo {
             if d.size != 0 {
                 return Ok(data);
             }
+            // A size-0 class that is a complete definition (not a forward
+            // reference) is a genuine zero-sized type. Return it as-is.
+            if !d.properties.forward_reference() {
+                return Ok(data);
+            }
             class_name = d.name.to_string().to_string();
         } else {
             return Ok(data);

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -800,11 +800,10 @@ impl TypeInfo {
                 // type, which is ultimately divided by the total size of the symbol.
                 let total_size = arr.dimensions[0] as usize;
                 let element = TypeInfo::from_type_index(info, arr.element_type)?;
-                TypeInfo::many(
-                    element.element_size(),
-                    total_size / element.element_size() as usize,
-                    element.type_id(),
-                )
+                let element_size = element.element_size();
+                // Guard against a zero-sized element type.
+                let count = if element_size == 0 { 1 } else { total_size / element_size as usize };
+                TypeInfo::many(element_size, count, element.type_id())
             }
             pdb::TypeData::Union(union) => TypeInfo::one(union.size as u32, Some(index)),
             // We don't have a good way to deal with bit-fields in this code, so we just return the size of the
@@ -867,8 +866,8 @@ impl TypeInfo {
             return Ok(data);
         }
 
-        // The type was a class and size 0, so it should have a shadow class
-        // with the real information.
+        // The type was a size-0 forward-reference class, so it should have a
+        // shadow class with the real information.
         let mut iter = info.iter();
         let item = iter.find(|item| {
             let item = item.parse()?;

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -848,9 +848,8 @@ impl TypeInfo {
         let data = finder.find(index)?;
         let item = data.parse()?;
 
-        // Return the item if it is anything other than class, and only
-// Return the item as-is if it is anything other than a class, or if it
-// is a class that is not a zero-size forward reference.
+        // Return the item as-is if it is anything other than a class, or if it
+        // is a class that is not a zero-size forward reference.
         let class_name;
         if let TypeData::Class(d) = item {
             if d.size != 0 {

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -850,7 +850,8 @@ impl TypeInfo {
         let item = data.parse()?;
 
         // Return the item if it is anything other than class, and only
-        // if the class size is not zero.
+// Return the item as-is if it is anything other than a class, or if it
+// is a class that is not a zero-size forward reference.
         let class_name;
         if let TypeData::Class(d) = item {
             if d.size != 0 {


### PR DESCRIPTION
## Description

This issue was found when running this tool against the rust supervisor. The **NopLogger** pulled in as part of the logging crate has this field of 0 length.

This type of symbol are genuine Zero-Sized Type (ZST) and we should allow it. For other zero-sized symbol, we will keep the errors as before.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested against the rust supervisor and fixed the tool exception.

## Integration Instructions

N/A
