### PR TITLE
[CHERRY-PICK] Integrate PEI memory bin into MM IPL and DXE support

### DIFF
--- a/MmSupervisorPkg/Drivers/MmCommunicationBuffer/MmCommunicationBufferPei.c
+++ b/MmSupervisorPkg/Drivers/MmCommunicationBuffer/MmCommunicationBufferPei.c
@@ -80,7 +80,12 @@ ReserveSupvCommBuffer (
   //
   // Allocate and fill CommRegionHob
   //
-  CommRegionHob->MmCommonRegionAddr = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocatePages ((UINTN)PageSize);
+  if (FeaturePcdGet (PcdPeiMemoryBinsEnable)) {
+    CommRegionHob->MmCommonRegionAddr = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateRuntimePages ((UINTN)PageSize);
+  } else {
+    CommRegionHob->MmCommonRegionAddr = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocatePages ((UINTN)PageSize);
+  }
+
   if (NULL == (VOID *)(UINTN)CommRegionHob->MmCommonRegionAddr) {
     DEBUG ((DEBUG_ERROR, "%a Request of allocating common buffer of 0x%x pages failed!\n", __func__, PageSize));
     ASSERT (FALSE);
@@ -90,7 +95,12 @@ ReserveSupvCommBuffer (
 
   CommRegionHob->MmCommonRegionPages = PageSize;
 
-  CommRegionHob->MmStatusRegionAddr = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocatePages (EFI_SIZE_TO_PAGES (sizeof (MM_COMM_BUFFER_STATUS)));
+  if (FeaturePcdGet (PcdPeiMemoryBinsEnable)) {
+    CommRegionHob->MmStatusRegionAddr = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateRuntimePages (EFI_SIZE_TO_PAGES (sizeof (MM_COMM_BUFFER_STATUS)));
+  } else {
+    CommRegionHob->MmStatusRegionAddr = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocatePages (EFI_SIZE_TO_PAGES (sizeof (MM_COMM_BUFFER_STATUS)));
+  }
+
   if (NULL == (VOID *)(UINTN)CommRegionHob->MmStatusRegionAddr) {
     DEBUG ((DEBUG_ERROR, "%a Request of allocating common buffer status failed!\n", __func__));
     ASSERT (FALSE);
@@ -162,7 +172,12 @@ ReserveUserCommBuffer (
   //
   // Allocate and fill CommRegionHob
   //
-  CommRegionHob->PhysicalStart = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocatePages ((UINTN)PageSize);
+  if (FeaturePcdGet (PcdPeiMemoryBinsEnable)) {
+    CommRegionHob->PhysicalStart = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateRuntimePages ((UINTN)PageSize);
+  } else {
+    CommRegionHob->PhysicalStart = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocatePages ((UINTN)PageSize);
+  }
+
   if (NULL == (VOID *)(UINTN)CommRegionHob->PhysicalStart) {
     DEBUG ((DEBUG_ERROR, "%a Request of allocating common buffer of 0x%x pages failed!\n", __func__, PageSize));
     ASSERT (FALSE);
@@ -172,7 +187,12 @@ ReserveUserCommBuffer (
 
   CommRegionHob->NumberOfPages = PageSize;
 
-  CommRegionStatus = (MM_COMM_BUFFER_STATUS *)(UINTN)AllocatePages (EFI_SIZE_TO_PAGES (sizeof (MM_COMM_BUFFER_STATUS)));
+  if (FeaturePcdGet (PcdPeiMemoryBinsEnable)) {
+    CommRegionStatus = (MM_COMM_BUFFER_STATUS *)(UINTN)AllocateRuntimePages (EFI_SIZE_TO_PAGES (sizeof (MM_COMM_BUFFER_STATUS)));
+  } else {
+    CommRegionStatus = (MM_COMM_BUFFER_STATUS *)(UINTN)AllocatePages (EFI_SIZE_TO_PAGES (sizeof (MM_COMM_BUFFER_STATUS)));
+  }
+
   if (NULL == (VOID *)CommRegionStatus) {
     DEBUG ((DEBUG_ERROR, "%a Request of allocating common buffer status failed!\n", __func__));
     ASSERT (FALSE);

--- a/MmSupervisorPkg/Drivers/MmCommunicationBuffer/MmCommunicationBufferPei.inf
+++ b/MmSupervisorPkg/Drivers/MmCommunicationBuffer/MmCommunicationBufferPei.inf
@@ -49,6 +49,7 @@
 [Pcd]
   gMmSupervisorPkgTokenSpaceGuid.PcdSupervisorCommBufferPages           ## CONSUMES
   gMmSupervisorPkgTokenSpaceGuid.PcdUserCommBufferPages                 ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPeiMemoryBinsEnable                 ## CONSUMES
 
 [Depex]
   gEfiPeiMemoryDiscoveredPpiGuid

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
@@ -624,9 +624,8 @@ MmDxeSupportEntry (
   VOID        *Registration;
   // MU_CHANGE: MM_SUPV: Test supervisor communication before publishing protocol
   MM_SUPERVISOR_VERSION_INFO_BUFFER  VersionInfo;
-
-  // MM_SUPERVISOR_COMM_UPDATE_BUFFER   NewCommBuffer;
-  // MM_COMM_BUFFER_UPDATE_PROTOCOL     *MmCommBufferUpdate;
+  MM_SUPERVISOR_COMM_UPDATE_BUFFER   NewCommBuffer;
+  MM_COMM_BUFFER_UPDATE_PROTOCOL     *MmCommBufferUpdate;
 
   // MU_CHANGE: MM_SUPV: Initialize Comm buffer from HOBs first
   Status = InitializeCommunicationBufferFromHob (
@@ -661,42 +660,44 @@ MmDxeSupportEntry (
     return Status;
   }
 
-  // // MU_CHANGE: MM_SUPV: We are just making sure this communication to supervisor does not fail.
-  // Status = UpdateDxeCommunicateBuffer (&VersionInfo, &NewCommBuffer);
-  // if (EFI_ERROR (Status)) {
-  //   DEBUG ((DEBUG_ERROR, "%a Failed to switch communication channel - %r\n", __func__, Status));
-  //   ASSERT_EFI_ERROR (Status);
-  //   return Status;
-  // }
+  // MU_CHANGE: MM_SUPV: We are just making sure this communication to supervisor does not fail.
+  if (!FeaturePcdGet (PcdPeiMemoryBinsEnable)) {
+    Status = UpdateDxeCommunicateBuffer (&VersionInfo, &NewCommBuffer);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a Failed to switch communication channel - %r\n", __func__, Status));
+      ASSERT_EFI_ERROR (Status);
+      return Status;
+    }
 
-  // // Query it another time to make sure the change took effect
-  // Status = QuerySupervisorVersion (&VersionInfo);
-  // if (EFI_ERROR (Status)) {
-  //   ASSERT_EFI_ERROR (Status);
-  //   return Status;
-  // }
+    // Query it another time to make sure the change took effect
+    Status = QuerySupervisorVersion (&VersionInfo);
+    if (EFI_ERROR (Status)) {
+      ASSERT_EFI_ERROR (Status);
+      return Status;
+    }
 
-  // MmCommBufferUpdate = AllocateZeroPool (sizeof (*MmCommBufferUpdate));
-  // if (MmCommBufferUpdate == NULL) {
-  //   return EFI_OUT_OF_RESOURCES;
-  // }
+    MmCommBufferUpdate = AllocateZeroPool (sizeof (*MmCommBufferUpdate));
+    if (MmCommBufferUpdate == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
 
-  // MmCommBufferUpdate->Version                         = MM_COMMUNICATE_BUFFER_UPDATE_PROTOCOL_VERSION;
-  // MmCommBufferUpdate->UpdatedCommBuffer.PhysicalStart = NewCommBuffer.NewCommBuffers[MM_USER_BUFFER_T].MemoryDescriptor.PhysicalStart;
-  // MmCommBufferUpdate->UpdatedCommBuffer.NumberOfPages = NewCommBuffer.NewCommBuffers[MM_USER_BUFFER_T].MemoryDescriptor.NumberOfPages;
-  // MmCommBufferUpdate->UpdatedCommBuffer.Status        = NewCommBuffer.NewMmStatusBuff[MM_USER_BUFFER_T].MemoryDescriptor.PhysicalStart;
+    MmCommBufferUpdate->Version                         = MM_COMMUNICATE_BUFFER_UPDATE_PROTOCOL_VERSION;
+    MmCommBufferUpdate->UpdatedCommBuffer.PhysicalStart = NewCommBuffer.NewCommBuffers[MM_USER_BUFFER_T].MemoryDescriptor.PhysicalStart;
+    MmCommBufferUpdate->UpdatedCommBuffer.NumberOfPages = NewCommBuffer.NewCommBuffers[MM_USER_BUFFER_T].MemoryDescriptor.NumberOfPages;
+    MmCommBufferUpdate->UpdatedCommBuffer.Status        = NewCommBuffer.NewMmStatusBuff[MM_USER_BUFFER_T].MemoryDescriptor.PhysicalStart;
 
-  // Status = gBS->InstallMultipleProtocolInterfaces (
-  //                 &ImageHandle,
-  //                 &gMmCommBufferUpdateProtocolGuid,
-  //                 MmCommBufferUpdate,
-  //                 NULL
-  //                 );
-  // if (EFI_ERROR (Status)) {
-  //   DEBUG ((DEBUG_ERROR, "%a Failed to install MM_COMM_BUFFER_UPDATE_PROTOCOL - %r\n", __func__, Status));
-  //   FreePool (MmCommBufferUpdate);
-  //   return Status;
-  // }
+    Status = gBS->InstallMultipleProtocolInterfaces (
+                    &ImageHandle,
+                    &gMmCommBufferUpdateProtocolGuid,
+                    MmCommBufferUpdate,
+                    NULL
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a Failed to install MM_COMM_BUFFER_UPDATE_PROTOCOL - %r\n", __func__, Status));
+      FreePool (MmCommBufferUpdate);
+      return Status;
+    }
+  }
 
   // MU_CHANGE: Since we already set up everything, directly move to protocol installation.
   //

--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.inf
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.inf
@@ -65,5 +65,8 @@
   gMmSupervisorRequestHandlerGuid               ## CONSUMES
   gMmCommBufferHobGuid                          ## CONSUMES
 
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPeiMemoryBinsEnable  ## CONSUMES
+
 [Depex]
   gEfiSmmControl2ProtocolGuid


### PR DESCRIPTION
## Description

Since the integration of PEI memory bin feature, the MM IPL and DXE support should also be updated to support this optional feature.

This change does not involve the supervisor core to support the communication buffer migration for older platforms.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change was tested on QEMU Q35 and booted to Windows desktop.

## Integration Instructions

The `gEfiMdeModulePkgTokenSpaceGuid.PcdPeiMemoryBinsEnable` is wired up to these 2 modules to skip the migration if PEI memory bin is supported.
