### PR TITLE
[REBASE & FF] GenSeaArtifacts: Update script to allow different file name and padding bytes

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
+++ b/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
@@ -26,6 +26,7 @@ from edk2toollib.utility_functions import RunCmd, RunPythonScript
 
 HASH_ALGORITHM = "sha256"
 AUX_CONFIG_NAME = "AuxConfig.toml"
+MM_SUPERVISOR_CORE_NAME = "MmSupervisorCore"
 
 
 class GenSeaArtifacts(IUefiHelperPlugin):
@@ -44,7 +45,8 @@ class GenSeaArtifacts(IUefiHelperPlugin):
         mm_supervisor_build_dir: Path,
         mmi_file_path: Path,
         out_path: Path,
-        workspace=None
+        workspace=None,
+        supervisor_name=MM_SUPERVISOR_CORE_NAME,
     ):
         """Generates SEA artifacts.
 
@@ -63,13 +65,14 @@ class GenSeaArtifacts(IUefiHelperPlugin):
             mmi_file_path: Path to MmiEntrySea.bin file.
             out_path: Path to place all generated artifacts.
             workspace: Path to the workspace. If not provided, the current directory is used.
+            supervisor_name: Name of the supervisor. If not provided, a default name is used.
         """
         try:
             inc_file_path = out_path / "MmArtifacts.dsc.inc"
             temp_hash_dir = out_path / "temp_hash.bin"
             temp_out_dir = out_path / "temp_out.inc"
 
-            aux_path = generate_aux_file(aux_config_path, mm_supervisor_build_dir, scopes, out_path, workspace=workspace)
+            aux_path = generate_aux_file(aux_config_path, mm_supervisor_build_dir, scopes, out_path, workspace=workspace, supervisor_name=supervisor_name)
 
             # Copy the aux configuration file to the same directory as the aux file.
             shutil.copy2(aux_config_path, out_path / AUX_CONFIG_NAME)
@@ -108,7 +111,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
                 o.write("gEfiSeaPkgTokenSpaceGuid.PcdMmiEntryBinSize|0x%08X" % os.path.getsize(mmi_file_path))
 
             # MM supervisor core hash patching
-            mm_supv_file = mm_supervisor_build_dir / "MmSupervisorCore.efi"
+            mm_supv_file = mm_supervisor_build_dir / f"{supervisor_name}.efi"
             mm_supv_core_hash = calculate_loadable_image_hash(mm_supv_file)
             hex_bytes = bytes.fromhex(mm_supv_core_hash)
             with open(temp_hash_dir, 'wb') as f:
@@ -244,21 +247,22 @@ class GenSeaArtifacts(IUefiHelperPlugin):
         return 0
 
     @staticmethod
-    def generate_test_aux_binary(output_path: Path, mm_supervisor_build_dir: Path, pecoff_validation_lib_build_dir: Path, workspace = None):
+    def generate_test_aux_binary(output_path: Path, mm_supervisor_build_dir: Path, pecoff_validation_lib_build_dir: Path, workspace = None, supervisor_name=MM_SUPERVISOR_CORE_NAME):
         """Generates the test-aux binary.
 
         Args:
             output_path (Path): Path to place the test-aux binary
             mm_supervisor_build_dir (Path): Path to the MM Supervisor build output.
-            sea_build_dir (Path): Path to the Sea Package build output.
+            pecoff_validation_lib_build_dir (Path): Path to the PECOFF validation library build output.
             workspace (Path): Path to the workspace. If not provided, the current directory is used.
+            supervisor_name: Name of the supervisor. If not provided, a default name is used.
         """
 
         manifest_path = Path(workspace if workspace else Path(__file__).parent) / "Cargo.toml"
 
         os.environ['TEST_AUX_PECOFF_VALIDATION_LIB_DIR'] = str(pecoff_validation_lib_build_dir)
-        os.environ['TEST_AUX_MM_SUPERVISOR_CORE_PDB_PATH'] = str(mm_supervisor_build_dir / "MmSupervisorCore.pdb")
-        os.environ['TEST_AUX_MM_SUPERVISOR_CORE_EFI_PATH'] = str(mm_supervisor_build_dir / "MmSupervisorCore.efi")
+        os.environ['TEST_AUX_MM_SUPERVISOR_CORE_PDB_PATH'] = str(mm_supervisor_build_dir / f"{supervisor_name}.pdb")
+        os.environ['TEST_AUX_MM_SUPERVISOR_CORE_EFI_PATH'] = str(mm_supervisor_build_dir / f"{supervisor_name}.efi")
         os.environ['RUSTC_BOOTSTRAP'] = str("1")
 
         args = 'build --release'
@@ -276,7 +280,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
         return 0
 
 
-def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, scopes: list[str], output_dir: Path, workspace = None):
+def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, scopes: list[str], output_dir: Path, workspace = None, supervisor_name=MM_SUPERVISOR_CORE_NAME):
     """Generates the auxiliary file for the MmsupervisorCore.
 
     Args:
@@ -284,18 +288,19 @@ def generate_aux_file(aux_config_path: Path, mm_supervisor_build_dir: Path, scop
         mm_supervisor_build_dir: Path to the MM Supervisor build output.
         scopes: A list of scopes to activate for rule filtering. See create-aux --help for more information.
         output_dir: Path to place the artifacts.
+        supervisor_name: Name of the supervisor. If not provided, a default name is used.
 
     Raises:
         RuntimeError: if create-aux fails
     """
 
-    output_path = output_dir / 'MmSupervisorCore.aux'
+    output_path = output_dir / f'{supervisor_name}.aux'
     manifest_path = Path(workspace if workspace else Path(__file__).parent) / "Cargo.toml"
 
     args = f"run --manifest-path {str(manifest_path)}"
     args += " --bin create-aux --"
-    args += f" --pdb {str(mm_supervisor_build_dir / 'MmSupervisorCore.pdb')}"
-    args += f" --efi {str(mm_supervisor_build_dir / 'MmSupervisorCore.efi')}"
+    args += f" --pdb {str(mm_supervisor_build_dir / f'{supervisor_name}.pdb')}"
+    args += f" --efi {str(mm_supervisor_build_dir / f'{supervisor_name}.efi')}"
     args += f" --output {str(output_path)}"
     args += f" --config {str(aux_config_path)}"
     for scope in scopes: 

--- a/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
+++ b/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts.py
@@ -18,6 +18,8 @@ import json
 from pathlib import Path
 import shutil
 
+import pefile
+
 from edk2toolext.environment.plugintypes.uefi_helper_plugin import IUefiHelperPlugin
 from edk2toollib.utility_functions import RunCmd, RunPythonScript
 
@@ -107,7 +109,7 @@ class GenSeaArtifacts(IUefiHelperPlugin):
 
             # MM supervisor core hash patching
             mm_supv_file = mm_supervisor_build_dir / "MmSupervisorCore.efi"
-            mm_supv_core_hash = calculate_file_hash(mm_supv_file)
+            mm_supv_core_hash = calculate_loadable_image_hash(mm_supv_file)
             hex_bytes = bytes.fromhex(mm_supv_core_hash)
             with open(temp_hash_dir, 'wb') as f:
                 f.write(hex_bytes)
@@ -333,3 +335,47 @@ def calculate_file_hash(file: Path, offset: int = 0, length: int = -1):
                 length -= len(data)
             hasher.update(data)
     return hasher.hexdigest()
+
+
+def calculate_loadable_image_hash(file: Path):
+    """Calculates the hash of a PE/COFF image over only the bytes a loader can reproduce.
+
+    Each section's raw data is padded out to FileAlignment, but a loader only copies
+    min(VirtualSize, SizeOfRawData) bytes, so that padding never reaches memory. Linkers do
+    not agree on what to leave there: MSVC link.exe writes zeros, while lld-link fills the
+    gaps and the file-alignment tail of executable sections with 0xCC. Code that reconstructs the file
+    image from memory, such as the SEA load reversion, can only produce zeros there, so the
+    padding is zeroed before hashing to keep the reference limited to what is attestable.
+
+    Args:
+        file: Path to the PE/COFF image.
+
+    Returns:
+        The hash of the canonicalized image.
+
+    Raises:
+        FileNotFoundError: The file does not exist
+        ValueError: The file is not a PE/COFF image, or a section extends past its end
+    """
+    if not file.exists():
+        raise FileNotFoundError(file)
+
+    data = bytearray(file.read_bytes())
+    try:
+        image = pefile.PE(data=data, fast_load=True)
+    except pefile.PEFormatError as error:
+        raise ValueError(f"{file} is not a valid PE/COFF image: {error}") from error
+
+    for index, section in enumerate(image.sections):
+        virtual_size = section.Misc_VirtualSize
+        raw_size = section.SizeOfRawData
+        raw_offset = section.PointerToRawData
+        if virtual_size == 0 or raw_size <= virtual_size:
+            continue
+        start = raw_offset + virtual_size
+        end = raw_offset + raw_size
+        if end > len(data):
+            raise ValueError(f"{file} section {index} extends past the end of the file.")
+        data[start:end] = bytes(end - start)
+
+    return hashlib.new(HASH_ALGORITHM, data).hexdigest()

--- a/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts_test.py
+++ b/SeaPkg/Tools/GenSeaArtifacts/GenSeaArtifacts_test.py
@@ -1,0 +1,160 @@
+
+# @file
+# unit tests for GenSeaArtifacts
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import hashlib
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+from GenSeaArtifacts import HASH_ALGORITHM, calculate_loadable_image_hash
+
+# The byte lld-link leaves in the file-alignment tail of an executable section.
+INT3 = 0xCC
+
+
+def build_pe(sections, pe_offset=0x80, optional_header_size=0xF0):
+    """Builds a minimal PE/COFF image.
+
+    Only the fields calculate_loadable_image_hash reads are populated; the rest is left zero.
+
+    Args:
+        sections: a list of (virtual_size, raw_bytes) pairs, laid out in order.
+
+    Returns:
+        The image bytes.
+    """
+    section_table = pe_offset + 24 + optional_header_size
+    raw_start = section_table + 40 * len(sections)
+
+    image = bytearray(raw_start)
+    image[0:2] = b"MZ"
+    struct.pack_into("<I", image, 0x3C, pe_offset)
+    image[pe_offset:pe_offset + 4] = b"PE\0\0"
+    struct.pack_into("<H", image, pe_offset + 6, len(sections))
+    struct.pack_into("<H", image, pe_offset + 20, optional_header_size)
+
+    offset = raw_start
+    for index, (virtual_size, raw) in enumerate(sections):
+        header = section_table + index * 40
+        image[header:header + 8] = f".s{index}".ljust(8, "\0").encode()
+        struct.pack_into("<IIII", image, header + 8, virtual_size, 0x1000 * (index + 1), len(raw), offset)
+        image.extend(raw)
+        offset += len(raw)
+
+    return bytes(image)
+
+
+class TestCalculateLoadableImageHash(unittest.TestCase):
+
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+
+    def write(self, name, data):
+        path = Path(self.directory.name) / name
+        path.write_bytes(data)
+        return path
+
+    def digest(self, data):
+        return hashlib.new(HASH_ALGORITHM, data).hexdigest()
+
+    def test_fill_byte_in_section_padding_does_not_change_the_hash(self):
+        """Two linkers disagreeing on the fill byte must still produce the same reference."""
+        payload = b"\x01" * 0x10
+        zeroed = build_pe([(len(payload), payload + b"\x00" * 0x30)])
+        filled = build_pe([(len(payload), payload + bytes([INT3]) * 0x30)])
+
+        self.assertNotEqual(zeroed, filled)
+        self.assertEqual(
+            calculate_loadable_image_hash(self.write("zeroed.efi", zeroed)),
+            calculate_loadable_image_hash(self.write("filled.efi", filled)),
+        )
+
+    def test_hash_is_taken_over_the_zeroed_image(self):
+        """The reference is the image a loader can reproduce, which has zeros in the padding."""
+        payload = b"\x02" * 0x20
+        zeroed = build_pe([(len(payload), payload + b"\x00" * 0x20)])
+        filled = build_pe([(len(payload), payload + bytes([INT3]) * 0x20)])
+
+        self.assertEqual(
+            calculate_loadable_image_hash(self.write("filled.efi", filled)),
+            self.digest(zeroed),
+        )
+
+    def test_bytes_within_virtual_size_are_never_zeroed(self):
+        """Only the tail past VirtualSize is padding; the loader copies everything before it."""
+        payload = bytes([INT3]) * 0x40
+        image = build_pe([(len(payload), payload)])
+
+        self.assertEqual(
+            calculate_loadable_image_hash(self.write("exact.efi", image)),
+            self.digest(image),
+        )
+
+    def test_section_larger_in_memory_than_on_disk_is_untouched(self):
+        """A .bss style section has no raw bytes to canonicalize."""
+        image = build_pe([(0x1000, bytes([INT3]) * 0x10)])
+
+        self.assertEqual(
+            calculate_loadable_image_hash(self.write("bss.efi", image)),
+            self.digest(image),
+        )
+
+    def test_section_without_virtual_size_is_untouched(self):
+        """A zero VirtualSize says nothing about how much of the section is real."""
+        image = build_pe([(0, bytes([INT3]) * 0x10)])
+
+        self.assertEqual(
+            calculate_loadable_image_hash(self.write("novsize.efi", image)),
+            self.digest(image),
+        )
+
+    def test_every_section_is_canonicalized(self):
+        """Padding is per section, so a later section must not be skipped."""
+        first = b"\x03" * 0x10
+        second = b"\x04" * 0x10
+        zeroed = build_pe([(len(first), first + b"\x00" * 0x10), (len(second), second + b"\x00" * 0x10)])
+        filled = build_pe(
+            [(len(first), first + bytes([INT3]) * 0x10), (len(second), second + bytes([INT3]) * 0x10)]
+        )
+
+        self.assertEqual(
+            calculate_loadable_image_hash(self.write("multi.efi", filled)),
+            self.digest(zeroed),
+        )
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            calculate_loadable_image_hash(Path(self.directory.name) / "absent.efi")
+
+    def test_missing_dos_header_raises(self):
+        path = self.write("nodos.efi", b"XX" + build_pe([(0x10, b"\x00" * 0x10)])[2:])
+
+        with self.assertRaises(ValueError):
+            calculate_loadable_image_hash(path)
+
+    def test_missing_pe_signature_raises(self):
+        image = bytearray(build_pe([(0x10, b"\x00" * 0x10)]))
+        pe_offset = struct.unpack_from("<I", image, 0x3C)[0]
+        image[pe_offset:pe_offset + 4] = b"NOPE"
+
+        with self.assertRaises(ValueError):
+            calculate_loadable_image_hash(self.write("nosig.efi", bytes(image)))
+
+    def test_section_past_end_of_file_raises(self):
+        """A truncated image must be rejected rather than silently hashed short."""
+        image = build_pe([(0x10, b"\x05" * 0x40)])
+
+        with self.assertRaises(ValueError):
+            calculate_loadable_image_hash(self.write("short.efi", image[:-0x20]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

With the upcoming support of MM supervisor in rust, there are 2 issues with the current gen_aux script:

1. The current script hardcoded the supervisor file name to be `MmSupervisorCore`, which may not be true for binaries produced under rust projects.
2. With LLVM linker in place, the padding bytes beyond valid section size in the file is set to 0xCC, and not carried to memory during image loading. We will artificially inject 0s to the padding region only calculate the hash for SEA validation.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change includes unit test and also ran against the rust supervisor, the validation routine now passes.

## Integration Instructions

N/A