### PR TITLE
[feat] gen_aux: allow key symbols to reference fields

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -41,11 +41,13 @@ symbol and add them to the the header (`IMAGE_VALIDATION_DATA_HEADER`).
 [[key]]
 signature = 'Required[[char; 4]]'
 symbol = 'Optional[String]'
+field = 'Optional[String]'
 offset = 'Optional[u32]'
 ```
 
 - `signature`: The 4 byte signature used by the firmware to determine how to use the offset (i.e. ['F', 'P', 'O', 'L'])
 - `symbol`: Used to calculate the offset value. Mutually exclusive to `offset`
+- `field`: Updates the offset to point at this field within `symbol`, rather than the symbol itself.
 - `offset`: The offset used by the firmware. Mutually exclusive to `symbol`
 
 ### rule

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
@@ -77,6 +77,8 @@ pub struct Key {
     pub signature: [char; 4],
     /// The offset
     pub symbol: String,
+    /// The field inside the symbol that the key should point at. Optional.
+    pub field: Option<String>,
 }
 
 /// A struct representing a rule that should be applied to a symbol in the auxiliary file.

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -184,7 +184,27 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
     /// Creates a new KeySymbol from the given key.
     pub fn build_key_symbol(&mut self, key: &config::Key) -> Result<file::KeySymbol> {
         let symbol = self.find_symbol(&key.symbol).clone();
-        Ok(file::KeySymbol::new(key.signature, symbol.address))
+        let mut address = symbol.address;
+
+        if let Some(field) = &key.field {
+            let type_information = &mut self.pdb.type_information()?;
+            let type_id = symbol.type_info.type_id().ok_or_else(|| {
+                anyhow!(
+                    "Symbol [{}] has no type information. Cannot resolve field [{}].",
+                    symbol.name(),
+                    field
+                )
+            })?;
+            let (field_offset, _) = Symbol::find_field_offset_and_size(
+                type_information,
+                &type_id,
+                field,
+                symbol.name(),
+            )?;
+            address += field_offset;
+        }
+
+        Ok(file::KeySymbol::new(key.signature, address))
     }
 
     /// Creates new zero content rules for padding that should always be all zeros.
@@ -1129,24 +1149,64 @@ mod test {
         let key = Key {
             symbol: "ABCDEFG".to_string(),
             signature: ['L', 'O', 'O', 'L'],
+            field: None,
         };
 
         // This will panic
         let _ = metadata.build_key_symbol(&key);
     }
     #[test]
-    fn test_build_key_symbol() {
+    fn test_build_key_symbol_without_field_uses_symbol_address() {
         let mut metadata = build_metadata();
+        let expected_address = metadata.find_symbol("mMmSupvPoolLists").address;
 
         let key = Key {
             symbol: "mMmSupvPoolLists".to_string(),
             signature: ['P', 'O', 'O', 'L'],
+            field: None,
         };
 
         let key_symbol = metadata
             .build_key_symbol(&key)
             .unwrap_or_else(|e| panic!("Failed to build key symbol: [{}]", e));
         assert_eq!(key_symbol.signature, 0x4c_4f_4f_50); // 'POOL'
+        assert_eq!(key_symbol.offset, expected_address);
+    }
+
+    #[test]
+    fn test_build_key_symbol_with_field_adds_field_offset() {
+        let mut metadata = build_metadata();
+        let symbol_address = metadata.find_symbol("mRootMmiEntry").address;
+        let key = Key {
+            symbol: "mRootMmiEntry".to_string(),
+            signature: ['L', 'I', 'S', 'T'],
+            field: Some("AllEntries".to_string()),
+        };
+
+        let key_symbol = metadata
+            .build_key_symbol(&key)
+            .unwrap_or_else(|e| panic!("Failed to build key symbol: [{}]", e));
+
+        assert_eq!(key_symbol.signature, 0x54_53_49_4c); // 'LIST'
+        assert_eq!(key_symbol.offset, symbol_address + 0x8);
+    }
+
+    #[test]
+    fn test_build_key_symbol_with_invalid_field_fails() {
+        let mut metadata = build_metadata();
+        let key = Key {
+            symbol: "mRootMmiEntry".to_string(),
+            signature: ['L', 'I', 'S', 'T'],
+            field: Some("NonExistentField".to_string()),
+        };
+
+        let error = metadata
+            .build_key_symbol(&key)
+            .expect_err("an invalid key field should fail");
+
+        assert!(error
+            .to_string()
+            .contains("Field [NonExistentField] not found in symbol [mRootMmiEntry]"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Allowing the field of a symbol to support the field inside bigger structured global variables, or static variables in the rust components.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

This was tested by adding a field in the key entry of the rule set and the 

## Integration Instructions

Follow doc updates in the PR.