### PR TITLE
[REBASE & FF] [gen_aux] Fixing field resolution for unions and added optional automatic descension logic

### DIFF
--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -20,6 +20,32 @@ use crate::{config, file, report};
 
 const POINTER_LENGTH: u64 = 8;
 
+/// A class or union record reduced to the parts this module needs, so one code path handles both.
+struct Aggregate<'t> {
+    name: pdb::RawString<'t>,
+    size: u64,
+    /// A class may have no field list; a union always has one.
+    fields: Option<TypeIndex>,
+    forward_reference: bool,
+}
+
+impl<'t> Aggregate<'t> {
+    fn new(data: &TypeData<'t>) -> Option<Self> {
+        let (name, size, fields, properties) = match data {
+            TypeData::Class(c) => (c.name, c.size, c.fields, c.properties),
+            TypeData::Union(u) => (u.name, u.size, Some(u.fields), u.properties),
+            _ => return None,
+        };
+
+        Some(Self {
+            name,
+            size,
+            fields,
+            forward_reference: properties.forward_reference(),
+        })
+    }
+}
+
 /// Additional context associated with a rule
 pub struct Context {
     pub name: String,
@@ -657,7 +683,7 @@ impl Symbol {
         }
     }
 
-    /// Returns the offset and size of a field in a class.
+    /// Returns the offset and size of a field in a class or union.
     fn find_field_offset_and_size(
         info: &TypeInformation,
         id: &TypeIndex,
@@ -667,54 +693,52 @@ impl Symbol {
         let mut parts = attribute.splitn(2, '.');
         let attribute = parts.next().unwrap_or("");
         let remaining = parts.next().unwrap_or("");
-        match TypeInfo::find_type(info, *id)?.parse()? {
-            TypeData::Class(class) => {
-                if let Some(fields) = class.fields {
-                    if let pdb::TypeData::FieldList(fields) =
-                        TypeInfo::find_type(info, fields)?.parse()?
-                    {
-                        for field in fields.fields {
-                            if let TypeData::Member(member) = field {
-                                if member.name.to_string() == attribute {
-                                    let size = TypeInfo::from_type_index(info, member.field_type)?
-                                        .total_size();
-                                    if !remaining.is_empty() {
-                                        let (offset, size) = Self::find_field_offset_and_size(
-                                            info,
-                                            &member.field_type,
-                                            remaining,
-                                            symbol,
-                                        )?;
-                                        return Ok((member.offset as u32 + offset, size));
-                                    }
-                                    return Ok((member.offset as u32, size));
-                                }
-                            }
-                        }
-                        return Err(anyhow::anyhow!(
-                            "Field [{}] not found in symbol [{}]",
-                            attribute,
-                            symbol
-                        ));
-                    }
-                    // Theoretically unreachable, unless the pdb file is malformed or there is a bug in the pdb crate
-                    // code.
-                    return Err(anyhow::anyhow!(
-                        "UNEXPECTED: Symbol [{}] fields are not a field list.",
-                        symbol
-                    ));
-                }
-                // Theoretically unreachable as you cannot have a struct defined without fields in C.
-                Err(anyhow::anyhow!(
-                    "Symbol [{}] is a class, but has no fields.",
+
+        let aggregate =
+            Aggregate::new(&TypeInfo::find_type(info, *id)?.parse()?).ok_or_else(|| {
+                anyhow!(
+                    "Symbol [{}] is not a class or union. Cannot get fields.",
                     symbol
-                ))
-            }
-            _ => Err(anyhow::anyhow!(
-                "Symbol [{}] is not a class. Cannot get class fields.",
+                )
+            })?;
+
+        // Theoretically unreachable as you cannot have a struct defined without fields in C.
+        let field_list = aggregate
+            .fields
+            .ok_or_else(|| anyhow!("Symbol [{}] is a class, but has no fields.", symbol))?;
+
+        let TypeData::FieldList(fields) = TypeInfo::find_type(info, field_list)?.parse()? else {
+            // Theoretically unreachable, unless the pdb file is malformed or there is a bug in the
+            // pdb crate code.
+            return Err(anyhow::anyhow!(
+                "UNEXPECTED: Symbol [{}] fields are not a field list.",
                 symbol
-            )),
+            ));
+        };
+
+        for field in fields.fields {
+            if let TypeData::Member(member) = field {
+                if member.name.to_string() == attribute {
+                    if !remaining.is_empty() {
+                        let (offset, size) = Self::find_field_offset_and_size(
+                            info,
+                            &member.field_type,
+                            remaining,
+                            symbol,
+                        )?;
+                        return Ok((member.offset as u32 + offset, size));
+                    }
+                    let size = TypeInfo::from_type_index(info, member.field_type)?.total_size();
+                    return Ok((member.offset as u32, size));
+                }
+            }
         }
+
+        Err(anyhow::anyhow!(
+            "Field [{}] not found in symbol [{}]",
+            attribute,
+            symbol
+        ))
     }
 }
 
@@ -794,6 +818,11 @@ impl TypeInfo {
         data: TypeData,
         index: TypeIndex,
     ) -> Result<Self> {
+        // A class and a union are both sized aggregates; only their member layout differs.
+        if let Some(aggregate) = Aggregate::new(&data) {
+            return Ok(TypeInfo::one(aggregate.size as u32, Some(index)));
+        }
+
         Ok(match data {
             TypeData::Primitive(prim) => {
                 if prim.indirection.is_some() {
@@ -802,7 +831,6 @@ impl TypeInfo {
                     TypeInfo::one(Self::get_size_from_primitive(prim.kind), Some(index))
                 }
             }
-            TypeData::Class(class) => TypeInfo::one(class.size as u32, Some(index)),
             TypeData::VirtualFunctionTablePointer(_) => {
                 TypeInfo::one(POINTER_LENGTH as u32, Some(index))
             }
@@ -822,10 +850,13 @@ impl TypeInfo {
                 let element = TypeInfo::from_type_index(info, arr.element_type)?;
                 let element_size = element.element_size();
                 // Guard against a zero-sized element type.
-                let count = if element_size == 0 { 1 } else { total_size / element_size as usize };
+                let count = if element_size == 0 {
+                    1
+                } else {
+                    total_size / element_size as usize
+                };
                 TypeInfo::many(element_size, count, element.type_id())
             }
-            pdb::TypeData::Union(union) => TypeInfo::one(union.size as u32, Some(index)),
             // We don't have a good way to deal with bit-fields in this code, so we just return the size of the
             // underlying type. This is a limitation of the current implementation because the size we set is in bytes,
             // but the size of a particular bit-field is in bits. If we ever wish to make a rule for individual
@@ -855,8 +886,8 @@ impl TypeInfo {
         })
     }
 
-    /// Returns a type using the type index. If the type is a class with size 0, it will
-    /// check for a shadow class with the real information, returning that instead.
+    /// Returns a type using the type index. If the type is a class or union with size 0, it will
+    /// check for a shadow definition with the real information, returning that instead.
     fn find_type<'a>(info: &'a TypeInformation, index: TypeIndex) -> Result<Item<'a, TypeIndex>> {
         let mut iter = info.iter();
         let mut finder = info.finder();
@@ -868,43 +899,39 @@ impl TypeInfo {
         let data = finder.find(index)?;
         let item = data.parse()?;
 
-        // Return the item as-is if it is anything other than a class, or if it
-        // is a class that is not a zero-size forward reference.
-        let class_name;
-        if let TypeData::Class(d) = item {
-            if d.size != 0 {
-                return Ok(data);
+        // Anything that is not a zero-size forward reference is returned as-is. That includes a
+        // size-0 complete definition, which is a genuine zero-sized type rather than a stand-in.
+        // Unions are forward referenced the same way classes are; without following them the
+        // `fields` index of the forward reference is used, which does not point at a field list.
+        let type_name = match Aggregate::new(&item) {
+            Some(aggregate) if aggregate.size == 0 && aggregate.forward_reference => {
+                aggregate.name.to_string().to_string()
             }
-            // A size-0 class that is a complete definition (not a forward
-            // reference) is a genuine zero-sized type. Return it as-is.
-            if !d.properties.forward_reference() {
-                return Ok(data);
-            }
-            class_name = d.name.to_string().to_string();
-        } else {
-            return Ok(data);
-        }
+            _ => return Ok(data),
+        };
 
-        // The type was a size-0 forward-reference class, so it should have a
-        // shadow class with the real information.
-        let mut iter = info.iter();
-        let item = iter.find(|item| {
-            let item = item.parse()?;
-            if let Some(name) = item.name() {
-                if name.to_string() == class_name {
-                    if let TypeData::Class(data) = item {
-                        if data.size != 0 {
-                            return Ok(true);
-                        }
-                    }
-                }
-            }
-            Ok(false)
-        });
-        if let Ok(Some(item)) = item {
+        // The record was a size-0 forward reference, so it should have a shadow definition
+        // carrying the real information.
+        if let Some(item) = Self::find_aggregate(info, &type_name, |a| a.size != 0) {
             return Ok(item);
         }
-        Err(anyhow!("Symbol {} was found, but size was 0", class_name))
+
+        Err(anyhow!("Symbol {} was found, but size was 0", type_name))
+    }
+
+    /// Scans the type stream for a class or union named `name` that satisfies `accept`.
+    fn find_aggregate<'a>(
+        info: &'a TypeInformation,
+        name: &str,
+        accept: impl Fn(&Aggregate) -> bool,
+    ) -> Option<Item<'a, TypeIndex>> {
+        let mut iter = info.iter();
+        iter.find(|item| {
+            let data = item.parse()?;
+            Ok(Aggregate::new(&data).is_some_and(|a| a.name.to_string() == name && accept(&a)))
+        })
+        .ok()
+        .flatten()
     }
 
     /// Returns the size of a primitive type in bytes.
@@ -1828,6 +1855,73 @@ mod test {
             .contains("Field [NonExistentField] not found in symbol [mRootMmiEntry]")));
     }
 
+    /// `gMmMps.HeapGuardPolicy` is a C union of a raw byte and a bitfield struct, both at offset
+    /// 0 within the union, which itself sits at offset 0x2 of the symbol.
+    #[test]
+    fn test_symbol_find_field_offset_and_size_through_union() {
+        let mut metadata = build_metadata();
+        let type_info = &metadata.pdb.type_information().unwrap();
+        let type_index = metadata.find_symbol("gMmMps").type_info.type_id().unwrap();
+
+        let (offset, size) = Symbol::find_field_offset_and_size(
+            type_info,
+            &type_index,
+            "HeapGuardPolicy.Data",
+            "gMmMps",
+        )
+        .expect("a field behind a union should resolve");
+
+        assert_eq!(offset, 0x2);
+        assert_eq!(size, 0x1);
+    }
+
+    /// Union members overlap, so two members of the same union report the same offset while
+    /// keeping their own sizes.
+    #[test]
+    fn test_symbol_find_field_offset_and_size_union_members_overlap() {
+        let mut metadata = build_metadata();
+        let type_info = &metadata.pdb.type_information().unwrap();
+        let type_index = metadata.find_symbol("gMmMps").type_info.type_id().unwrap();
+
+        let data = Symbol::find_field_offset_and_size(
+            type_info,
+            &type_index,
+            "HeapGuardPoolType.Data",
+            "gMmMps",
+        )
+        .expect("union member should resolve");
+        let fields = Symbol::find_field_offset_and_size(
+            type_info,
+            &type_index,
+            "HeapGuardPoolType.Fields",
+            "gMmMps",
+        )
+        .expect("union member should resolve");
+
+        assert_eq!(data.0, 0x4);
+        assert_eq!(fields.0, data.0);
+        assert_ne!(fields.1, data.1);
+    }
+
+    /// A path may continue into a struct that lives behind a union.
+    #[test]
+    fn test_symbol_find_field_offset_and_size_through_union_into_struct() {
+        let mut metadata = build_metadata();
+        let type_info = &metadata.pdb.type_information().unwrap();
+        let type_index = metadata.find_symbol("gMmMps").type_info.type_id().unwrap();
+
+        let (offset, _) = Symbol::find_field_offset_and_size(
+            type_info,
+            &type_index,
+            "HeapGuardPolicy.Fields.MmPageGuard",
+            "gMmMps",
+        )
+        .expect("a field of a struct behind a union should resolve");
+
+        // The union sits at 0x2, and both the struct and its first bitfield start at 0.
+        assert_eq!(offset, 0x2);
+    }
+
     #[test]
     fn test_symbol_find_field_offset_and_size_not_class() {
         let mut metadata = build_metadata();
@@ -1844,6 +1938,6 @@ mod test {
         let result = Symbol::find_field_offset_and_size(type_info, &type_index, field, symbol);
         assert!(result.is_err_and(|err| err
             .to_string()
-            .contains("Symbol [mMapDepth] is not a class. Cannot get class fields.")));
+            .contains("Symbol [mMapDepth] is not a class or union. Cannot get fields.")));
     }
 }

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -690,8 +690,24 @@ impl Symbol {
         attribute: &str,
         symbol: &str,
     ) -> Result<(u32, u32)> {
+        Self::find_field_offset_and_size_at(info, id, attribute, symbol, 0)
+    }
+
+    /// Walks a dotted field path, transparently descending through wrapper types.
+    ///
+    /// `depth` counts only the wrapper layers that were skipped implicitly, and exists solely to
+    /// stop a malformed PDB from producing an unbounded descent.
+    fn find_field_offset_and_size_at(
+        info: &TypeInformation,
+        id: &TypeIndex,
+        attribute: &str,
+        symbol: &str,
+        depth: u32,
+    ) -> Result<(u32, u32)> {
+        const MAX_WRAPPER_DEPTH: u32 = 32;
+
         let mut parts = attribute.splitn(2, '.');
-        let attribute = parts.next().unwrap_or("");
+        let name = parts.next().unwrap_or("");
         let remaining = parts.next().unwrap_or("");
 
         let aggregate =
@@ -706,6 +722,7 @@ impl Symbol {
         let field_list = aggregate
             .fields
             .ok_or_else(|| anyhow!("Symbol [{}] is a class, but has no fields.", symbol))?;
+        let parent_size = aggregate.size;
 
         let TypeData::FieldList(fields) = TypeInfo::find_type(info, field_list)?.parse()? else {
             // Theoretically unreachable, unless the pdb file is malformed or there is a bug in the
@@ -716,29 +733,124 @@ impl Symbol {
             ));
         };
 
+        let mut members = Vec::new();
         for field in fields.fields {
             if let TypeData::Member(member) = field {
-                if member.name.to_string() == attribute {
+                if member.name.to_string() == name {
                     if !remaining.is_empty() {
-                        let (offset, size) = Self::find_field_offset_and_size(
+                        let (offset, size) = Self::find_field_offset_and_size_at(
                             info,
                             &member.field_type,
                             remaining,
                             symbol,
+                            depth,
                         )?;
                         return Ok((member.offset as u32 + offset, size));
                     }
                     let size = TypeInfo::from_type_index(info, member.field_type)?.total_size();
                     return Ok((member.offset as u32, size));
                 }
+                members.push((
+                    member.name.to_string().to_string(),
+                    member.offset,
+                    member.field_type,
+                ));
+            }
+        }
+
+        // Nothing matched at this level. A record whose single populated member starts at offset
+        // 0 and spans the whole parent contributes a name and no storage, so descend through it
+        // and retry; config paths then only name the fields a reader would recognize. Rust
+        // produces this shape constantly via `UnsafeCell`, `ManuallyDrop`, `MaybeUninit` and
+        // newtypes. Explicit paths still work, because this runs only after an exact match fails.
+        if depth < MAX_WRAPPER_DEPTH {
+            if let Some(inner) = Self::transparent_wrapper_member(info, &members, parent_size) {
+                return Self::find_field_offset_and_size_at(
+                    info,
+                    &inner,
+                    attribute,
+                    symbol,
+                    depth + 1,
+                );
             }
         }
 
         Err(anyhow::anyhow!(
-            "Field [{}] not found in symbol [{}]",
-            attribute,
-            symbol
+            "Field [{}] not found in symbol [{}]. Available fields at this level: [{}]",
+            name,
+            symbol,
+            members
+                .iter()
+                .map(|(name, ..)| name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
         ))
+    }
+
+    /// Returns the type of the sole data-carrying member if `members` describes a transparent
+    /// wrapper, meaning exactly one member that begins at offset 0 and covers the full
+    /// `parent_size`. Members are only disregarded when they are provably zero sized, so a
+    /// member that occupies storage can never be stepped over.
+    ///
+    /// Returns `None` whenever the shape is ambiguous or a member size cannot be resolved, so an
+    /// unrecognized layout reports the original "field not found" error rather than guessing.
+    fn transparent_wrapper_member(
+        info: &TypeInformation,
+        members: &[(String, u64, TypeIndex)],
+        parent_size: u64,
+    ) -> Option<TypeIndex> {
+        if parent_size == 0 {
+            return None;
+        }
+
+        let mut payload = None;
+        for (_, offset, field_type) in members {
+            if Self::is_provably_zero_sized(info, *field_type) {
+                continue;
+            }
+            if payload.is_some() {
+                return None;
+            }
+            // Any member that is not provably empty must account for the whole parent, otherwise
+            // this is a real aggregate and stepping through it would skip storage.
+            let size = TypeInfo::from_type_index(info, *field_type)
+                .ok()?
+                .total_size();
+            if *offset != 0 || size as u64 != parent_size {
+                return None;
+            }
+            payload = Some(*field_type);
+        }
+        payload
+    }
+
+    /// Returns whether `index` refers to a type that provably occupies no storage.
+    ///
+    /// Only a complete aggregate definition that records a size of zero qualifies. A computed
+    /// size of zero is deliberately not accepted, because several type encodings yield zero when
+    /// the size is merely unknown: `PrimitiveKind::NoType`, and arrays whose declared byte length
+    /// is smaller than one element. Forward references are rejected as well, since their size is
+    /// a placeholder rather than a statement about the real definition.
+    fn is_provably_zero_sized(info: &TypeInformation, index: TypeIndex) -> bool {
+        // Bound the walk so a malformed PDB cannot produce an unbounded modifier chain.
+        const MAX_MODIFIER_DEPTH: u32 = 32;
+
+        let mut index = index;
+        for _ in 0..MAX_MODIFIER_DEPTH {
+            let Ok(data) = TypeInfo::find_type(info, index).and_then(|item| Ok(item.parse()?))
+            else {
+                return false;
+            };
+            match data {
+                // Qualifiers do not change the size of the underlying type.
+                TypeData::Modifier(modifier) => index = modifier.underlying_type,
+                data => {
+                    return Aggregate::new(&data)
+                        .is_some_and(|a| a.size == 0 && !a.forward_reference)
+                }
+            }
+        }
+        false
     }
 }
 
@@ -901,8 +1013,6 @@ impl TypeInfo {
 
         // Anything that is not a zero-size forward reference is returned as-is. That includes a
         // size-0 complete definition, which is a genuine zero-sized type rather than a stand-in.
-        // Unions are forward referenced the same way classes are; without following them the
-        // `fields` index of the forward reference is used, which does not point at a field list.
         let type_name = match Aggregate::new(&item) {
             Some(aggregate) if aggregate.size == 0 && aggregate.forward_reference => {
                 aggregate.name.to_string().to_string()
@@ -913,6 +1023,15 @@ impl TypeInfo {
         // The record was a size-0 forward reference, so it should have a shadow definition
         // carrying the real information.
         if let Some(item) = Self::find_aggregate(info, &type_name, |a| a.size != 0) {
+            return Ok(item);
+        }
+
+        // The forward reference may describe a type whose real definition is genuinely zero
+        // sized, such as an empty aggregate or Rust's `PhantomData`. No non-zero-sized definition
+        // can exist for those, so accept a complete (non-forward-reference) definition instead. A
+        // forward reference with no definition at all matches neither and falls through to the
+        // error below, so a genuinely missing type is not masked.
+        if let Some(item) = Self::find_aggregate(info, &type_name, |a| !a.forward_reference) {
             return Ok(item);
         }
 
@@ -1939,5 +2058,123 @@ mod test {
         assert!(result.is_err_and(|err| err
             .to_string()
             .contains("Symbol [mMapDepth] is not a class or union. Cannot get fields.")));
+    }
+
+    /// The descent only fires for a record that is unambiguously a pass-through: one payload, at
+    /// offset 0, covering the whole parent.
+    #[test]
+    fn test_transparent_wrapper_member_accepts_a_sole_full_width_payload() {
+        let mut metadata = build_metadata();
+        let type_info = &metadata.pdb.type_information().unwrap();
+
+        let payload = metadata
+            .find_symbol("mMapDepth")
+            .type_info
+            .type_id()
+            .unwrap();
+        let width = TypeInfo::from_type_index(type_info, payload)
+            .unwrap()
+            .total_size() as u64;
+
+        let members = vec![("value".to_string(), 0u64, payload)];
+        assert_eq!(
+            Symbol::transparent_wrapper_member(type_info, &members, width),
+            Some(payload)
+        );
+    }
+
+    /// Anything that is not provably a pass-through is refused, so a descent can never move a
+    /// path onto storage the author did not name.
+    #[test]
+    fn test_transparent_wrapper_member_refuses_anything_ambiguous() {
+        let mut metadata = build_metadata();
+        let type_info = &metadata.pdb.type_information().unwrap();
+
+        let payload = metadata
+            .find_symbol("mMapDepth")
+            .type_info
+            .type_id()
+            .unwrap();
+        let width = TypeInfo::from_type_index(type_info, payload)
+            .unwrap()
+            .total_size() as u64;
+
+        // Two members that both carry data: which one to follow is a guess, so neither is taken.
+        let two = vec![
+            ("a".to_string(), 0u64, payload),
+            ("b".to_string(), 0u64, payload),
+        ];
+        assert_eq!(
+            Symbol::transparent_wrapper_member(type_info, &two, width),
+            None
+        );
+
+        // Sole member, but it does not start the parent, so bytes precede it.
+        let offset = vec![("value".to_string(), 1u64, payload)];
+        assert_eq!(
+            Symbol::transparent_wrapper_member(type_info, &offset, width),
+            None
+        );
+
+        // Sole member at offset 0, but it does not span the parent, so bytes follow it.
+        let short = vec![("value".to_string(), 0u64, payload)];
+        assert_eq!(
+            Symbol::transparent_wrapper_member(type_info, &short, width + 1),
+            None
+        );
+
+        // A parent of unknown size proves nothing about its members.
+        assert_eq!(
+            Symbol::transparent_wrapper_member(type_info, &short, 0),
+            None
+        );
+    }
+
+    /// A C bitfield union has two full width members, so the descent cannot choose between them.
+    /// The failure names what was available rather than silently landing on one of them.
+    #[test]
+    fn test_symbol_find_field_refuses_to_guess_through_an_ambiguous_union() {
+        let mut metadata = build_metadata();
+        let type_info = &metadata.pdb.type_information().unwrap();
+        let type_index = metadata.find_symbol("gMmMps").type_info.type_id().unwrap();
+
+        // `MmPageGuard` lives under `HeapGuardPolicy.Fields`, and skipping `Fields` is a guess.
+        let error = Symbol::find_field_offset_and_size(
+            type_info,
+            &type_index,
+            "HeapGuardPolicy.MmPageGuard",
+            "gMmMps",
+        )
+        .expect_err("an ambiguous union must not be descended through");
+
+        let error = error.to_string();
+        assert!(error.contains("Field [MmPageGuard] not found"));
+        assert!(error.contains("Data"), "{}", error);
+        assert!(error.contains("Fields"), "{}", error);
+    }
+
+    #[test]
+    fn test_symbol_is_provably_zero_sized_rejects_types_that_occupy_storage() {
+        let mut metadata = build_metadata();
+        let type_info = &metadata.pdb.type_information().unwrap();
+
+        // An aggregate that holds data is never treated as empty, so the transparent wrapper
+        // descent can never step over it.
+        let class_index = metadata
+            .find_symbol("mRootMmiEntry")
+            .type_info
+            .type_id()
+            .unwrap();
+        assert!(!Symbol::is_provably_zero_sized(type_info, class_index));
+
+        // Non-aggregates are rejected as well. Several encodings report a computed size of zero
+        // when the size is merely unknown, so only an explicit zero-sized aggregate definition
+        // counts as proof.
+        let scalar_index = metadata
+            .find_symbol("mMapDepth")
+            .type_info
+            .type_id()
+            .unwrap();
+        assert!(!Symbol::is_provably_zero_sized(type_info, scalar_index));
     }
 }


### PR DESCRIPTION
## Description

This PR introduces 2 modifications on the field name resolution logic:

1. Added the support for union field.
2. Added a fallback logic to automatically descend to child fields if no exact match is found and a full blanket data layer is observed.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested with inline unit tests and verified on the rust-based supervisor binary.

## Integration Instructions

Before change:
```
[[rule]]
symbol = "mm_supervisor::LOGGER"
field = 'cell.data.value.value.inner.serial_port.blocking'
```

After change:
```
[[rule]]
symbol = "mm_supervisor::LOGGER"
field = 'cell.data.inner.serial_port.blocking'
```