### PR TITLE
[feat] gen_aux: support indexed nested array members

### DIFF
--- a/SeaPkg/Docs/PlatformIntegration/SoftwareComponentOverview.md
+++ b/SeaPkg/Docs/PlatformIntegration/SoftwareComponentOverview.md
@@ -17,31 +17,31 @@ For more general background about the steps necessary to integrate the MM Superv
 ## SEA PEI Modules
 
 | PEI Module | Location |
-| ---| ---|
+| --- | --- |
 | MsegSmramPei | SeaPkg/Drivers/MsegSmramPei/MsegSmramPei.inf |
 
 ## SEA Standalone MM Core Libraries
 
 | Library | Location |
-| --- | ---|
+| --- | --- |
 | SmmCpuFeaturesLib | SeaPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLibStm.inf |
 
 ## SEA Standalone MM Entry Point
 
 | MM Component | Location |
-| ---| ---|
+| --- | --- |
 | MmiEntrySea | SeaPkg/MmiEntrySea/MmiEntrySea.inf |
 
 ## SEA Core
 
 | MM Component | Location |
-| ---| ---|
+| --- | --- |
 | SeaCore | SeaPkg/Core/Stm.inf |
 
 ## SEA Libraries
 
 | Library | Location |
-| --- | ---|
+| --- | --- |
 | BaseCryptLib | SeaPkg/Library/BaseCryptLibMbedTls/BaseCryptLib.inf |
 | BasePeCoffLibNegative | SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf |
 | BasePeCoffValidationLib | SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.inf |
@@ -56,5 +56,5 @@ For more general background about the steps necessary to integrate the MM Superv
 ## SEA Validation Test Application
 
 | Application | Location |
-| --- | ---|
+| --- | --- |
 | ResponderValidationTestApp | SeaPkg/Tests/ResponderValidationTest/ResponderValidationTestApp.inf |

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -72,13 +72,8 @@ remarks = 'Optional[String]'
 
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
 - `symbol`: Determines the address and size for the rule
-- `field`: Updates the address and size to be that of the field, rather than the symbol itself. A symbol recovered
-from a linker map has no field names, because a map records only names and addresses, so its `field` is instead the
-index of one of the pieces the optimizer split it into, such as `'0'`. A `&dyn Trait` static, for example, is split
-into piece `0` for the data pointer and piece `1` for the vtable pointer.
-- `array.field`: Names an array member of the symbol, for when the array is nested inside the symbol rather than being
-the symbol itself. The rule then iterates that member, `array.index` refers to it, and `field` names a field of its
-element type. Without this the rule iterates the symbol's own elements, and `field` names a field of those.
+- `field`: Updates the address and size to be that of the field, rather than the symbol itself.
+- `array.field`: Names a member inside a structure that is an array. This could be used in conjunction with `field` to validate a "field" inside this array.
 - `array.index`: Only apply the rule to the specified index of the array, or inclusive range.
 - `array.sentinel`: Apply content rule to only the final rule such that its content must be all zeros.
 - `validation.type`: The type of validation to perform on this symbol. Different values may also require additional configuration

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -61,6 +61,7 @@ comes with the following standard options:
 scope = 'Optional[String]'
 symbol = 'Required[String]'
 field = 'Optional[String]'
+array.field = 'Optional[String]'
 array.index = 'Optional[Int]'|'Optional[Array[Int;2]]'
 array.sentinel = 'Optional[Boolean]'
 validation.type = 'Required[String]'
@@ -71,8 +72,14 @@ remarks = 'Optional[String]'
 
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
 - `symbol`: Determines the address and size for the rule
-- `field`: Updates the address and size to be that of the field, rather than the symbol itself.
-- `array.index`: Only apply the rule to the specified index of the array, or inclusive range
+- `field`: Updates the address and size to be that of the field, rather than the symbol itself. A symbol recovered
+from a linker map has no field names, because a map records only names and addresses, so its `field` is instead the
+index of one of the pieces the optimizer split it into, such as `'0'`. A `&dyn Trait` static, for example, is split
+into piece `0` for the data pointer and piece `1` for the vtable pointer.
+- `array.field`: Names an array member of the symbol, for when the array is nested inside the symbol rather than being
+the symbol itself. The rule then iterates that member, `array.index` refers to it, and `field` names a field of its
+element type. Without this the rule iterates the symbol's own elements, and `field` names a field of those.
+- `array.index`: Only apply the rule to the specified index of the array, or inclusive range.
 - `array.sentinel`: Apply content rule to only the final rule such that its content must be all zeros.
 - `validation.type`: The type of validation to perform on this symbol. Different values may also require additional configuration
 settings in the `[[rule]]`.

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -73,7 +73,8 @@ remarks = 'Optional[String]'
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
 - `symbol`: Determines the address and size for the rule
 - `field`: Updates the address and size to be that of the field, rather than the symbol itself.
-- `array.field`: Names a member inside a structure that is an array. This could be used in conjunction with `field` to validate a "field" inside this array.
+- `array.field`: Names a member inside a structure that is an array. This could be used in conjunction with `field` to validate
+a "field" inside this array.
 - `array.index`: Only apply the rule to the specified index of the array, or inclusive range.
 - `array.sentinel`: Apply content rule to only the final rule such that its content must be all zeros.
 - `validation.type`: The type of validation to perform on this symbol. Different values may also require additional configuration

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -72,9 +72,9 @@ remarks = 'Optional[String]'
 
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
 - `symbol`: Determines the address and size for the rule
-- `field`: Updates the address and size to be that of the field, rather than the symbol itself.
-- `array.field`: Names a member of the symbol's structure that is itself an array, for when the array is nested rather than
-  being the symbol itself.
+- `field`: Updates the address and size to be that of the field, rather than the symbol itself. When array configuration
+  is present, this names the array member to iterate. Leave unset when the symbol itself is the array.
+- `array.field`: Names a field inside each array element. Leave unset to apply the rule to each whole element.
 - `array.index`: Only apply the rule to the specified index of the array, or inclusive range.
 - `array.sentinel`: Apply content rule to only the final rule such that its content must be all zeros.
 - `validation.type`: The type of validation to perform on this symbol. Different values may also require additional configuration

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/readme.md
@@ -73,8 +73,8 @@ remarks = 'Optional[String]'
 - `scope`: If specified, the rule is only applied when this scope is active. Otherwise it is always applied.
 - `symbol`: Determines the address and size for the rule
 - `field`: Updates the address and size to be that of the field, rather than the symbol itself.
-- `array.field`: Names a member inside a structure that is an array. This could be used in conjunction with `field` to validate
-a "field" inside this array.
+- `array.field`: Names a member of the symbol's structure that is itself an array, for when the array is nested rather than
+  being the symbol itself.
 - `array.index`: Only apply the rule to the specified index of the array, or inclusive range.
 - `array.sentinel`: Apply content rule to only the final rule such that its content must be all zeros.
 - `validation.type`: The type of validation to perform on this symbol. Different values may also require additional configuration

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
@@ -167,6 +167,13 @@ where
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Array {
+    /// The path to an array member of the symbol, for when the array is nested inside the symbol
+    /// rather than being the symbol itself.
+    ///
+    /// [Rule::field] then names a field of the array's element type, so `index` always refers to
+    /// this array. Leave unset when the symbol is itself an array.
+    #[serde(default)]
+    pub field: Option<String>,
     /// The last index of the array is a sentinel value, thus creating a different validation rule for the last index.
     #[serde(default)]
     pub sentinel: bool,

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
@@ -90,6 +90,9 @@ pub struct Rule {
     /// The symbol that the rule is associated with.
     pub symbol: String,
     /// The field inside the symbol that the rule is associated with.
+    ///
+    /// When array configuration is present, this field names the array to iterate. Leave unset
+    /// when the symbol itself is the array.
     pub field: Option<String>,
     /// The scope that the rule is associated with. If the rule has no scope, it is always applied.
     pub scope: Option<String>,
@@ -163,15 +166,13 @@ where
     Ok(reviewers)
 }
 
-/// Configuration for a symbol that is an array of an underlying type.
+/// Configuration for selecting elements from an array.
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Array {
-    /// The path to an array member of the symbol, for when the array is nested inside the symbol
-    /// rather than being the symbol itself.
+    /// The field inside each array element that the rule is associated with.
     ///
-    /// [Rule::field] then names a field of the array's element type, so `index` always refers to
-    /// this array. Leave unset when the symbol is itself an array.
+    /// Leave unset when the rule applies to each whole array element.
     #[serde(default)]
     pub field: Option<String>,
     /// The last index of the array is a sentinel value, thus creating a different validation rule for the last index.

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/config.rs
@@ -164,7 +164,7 @@ where
 }
 
 /// Configuration for a symbol that is an array of an underlying type.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Array {
     /// The path to an array member of the symbol, for when the array is nested inside the symbol

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -131,12 +131,11 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
         let symbol = self.find_symbol(&rule.symbol).clone();
         self.validate_rule(&symbol, rule)?;
 
+        let extent = self.rule_extent(&symbol, rule)?;
+
         let mut ret = Vec::new();
 
-        let type_information = &mut self.pdb.type_information()?;
-        let element_count = symbol.type_info.element_count();
-
-        for i in 0..element_count {
+        for i in 0..extent.count {
             if !rule
                 .array
                 .as_ref()
@@ -147,24 +146,12 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
                 continue;
             }
 
-            let mut offset = 0;
-            let mut size = symbol.type_info.element_size();
-
-            if let Some(field) = &rule.field {
-                let (field_offset, total_size) = Symbol::find_field_offset_and_size(
-                    type_information,
-                    &symbol.type_info.type_id().unwrap(),
-                    field,
-                    symbol.name(),
-                )?;
-                offset += field_offset;
-                size = total_size;
-            }
+            let size = extent.size;
 
             let validation_type = if rule
                 .array
                 .as_ref()
-                .is_some_and(|a| a.sentinel && i == element_count - 1)
+                .is_some_and(|a| a.sentinel && i == extent.count - 1)
             {
                 file::ValidationType::Content {
                     content: vec![0; size as usize],
@@ -174,7 +161,7 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
             };
 
             let entry = file::ImageValidationEntryHeader {
-                offset: symbol.address(i) + offset,
+                offset: symbol.address + extent.field_offset + extent.stride * i as u32,
                 size,
                 validation_type,
                 ..Default::default()
@@ -184,9 +171,13 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
                 [entry.offset as usize..(entry.offset + entry.size) as usize]
                 .to_vec();
 
+            // The index belongs to whichever array the rule iterates: the array member named by
+            // `array.field`, or the symbol itself.
             let mut name = rule.symbol.clone();
-            if element_count > 1 {
-                name += format!("[{}]", i).as_str();
+            match rule.array.as_ref().and_then(|array| array.field.as_deref()) {
+                Some(array_field) => name += format!(".{}[{}]", array_field, i).as_str(),
+                None if extent.count > 1 => name += format!("[{}]", i).as_str(),
+                None => {}
             }
             if let Some(field) = &rule.field {
                 name += format!(".{}", field).as_str();
@@ -309,21 +300,119 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
         Some((offset / symbol.type_info.element_size()) as usize)
     }
 
+    /// Returns the offset of a rule's field within its symbol, along with the field's type.
+    fn resolve_field(&mut self, symbol: &Symbol, field: &str) -> Result<(u32, TypeInfo)> {
+        let type_id = symbol.type_info.type_id().ok_or_else(|| {
+            anyhow!(
+                "Symbol [{}] has no type information. Cannot resolve field [{}].",
+                symbol.name(),
+                field
+            )
+        })?;
+
+        let info = self.pdb.type_information()?;
+        Symbol::find_field(&info, &type_id, field, symbol.name())
+    }
+
+    /// Returns what a rule iterates over, and how large each entry it produces is.
+    ///
+    /// A rule produces one entry per element of the symbol, validating the same field within each.
+    /// A rule that names [config::Array::field] iterates that array member of the symbol instead,
+    /// so the elements of a nested array can be validated individually.
+    fn rule_extent(&mut self, symbol: &Symbol, rule: &config::Rule) -> Result<RuleExtent> {
+        if let Some(array_field) = rule.array.as_ref().and_then(|array| array.field.as_deref()) {
+            return self.array_field_extent(symbol, array_field, rule.field.as_deref());
+        }
+
+        let stride = symbol.type_info.element_size();
+        let count = symbol.type_info.element_count();
+
+        let Some(field) = &rule.field else {
+            return Ok(RuleExtent {
+                field_offset: 0,
+                stride,
+                size: stride,
+                count,
+            });
+        };
+
+        let (field_offset, field_type) = self.resolve_field(symbol, field)?;
+
+        Ok(RuleExtent {
+            field_offset,
+            stride,
+            size: field_type.total_size(),
+            count,
+        })
+    }
+
+    /// Returns the extent of a rule that iterates an array member of its symbol.
+    ///
+    /// `field`, when given, selects the same field within every element of that array. Without it
+    /// each entry covers a whole element.
+    fn array_field_extent(
+        &mut self,
+        symbol: &Symbol,
+        array_field: &str,
+        field: Option<&str>,
+    ) -> Result<RuleExtent> {
+        // A single `index` cannot address two levels of array, so the symbol has to be the one
+        // value that holds the array being iterated.
+        if symbol.type_info.element_count() > 1 {
+            return Err(anyhow!(
+                "Invalid Rule Configuration: Symbol {}: `array.field` cannot be used because the symbol is itself an array.",
+                symbol.name()
+            ));
+        }
+
+        let (array_offset, array_type) = self.resolve_field(symbol, array_field)?;
+
+        if array_type.element_count() <= 1 {
+            return Err(anyhow!(
+                "Invalid Rule Configuration: Symbol {}: `array.field` [{}] is not an array.",
+                symbol.name(),
+                array_field
+            ));
+        }
+
+        let extent = RuleExtent {
+            field_offset: array_offset,
+            stride: array_type.element_size(),
+            size: array_type.element_size(),
+            count: array_type.element_count(),
+        };
+
+        let Some(field) = field else {
+            return Ok(extent);
+        };
+
+        // `TypeInfo` records an array as a repeat of its element type, so this is the type a field
+        // named alongside `array.field` is resolved against.
+        let element_type = array_type.type_id().ok_or_else(|| {
+            anyhow!(
+                "Array field [{}] of symbol [{}] has no element type information. Cannot resolve field [{}].",
+                array_field,
+                symbol.name(),
+                field
+            )
+        })?;
+
+        let info = self.pdb.type_information()?;
+        let (offset, field_type) = Symbol::find_field(&info, &element_type, field, symbol.name())?;
+
+        Ok(RuleExtent {
+            field_offset: array_offset + offset,
+            size: field_type.total_size(),
+            ..extent
+        })
+    }
+
     fn validate_rule(&mut self, symbol: &Symbol, rule: &crate::config::Rule) -> Result<()> {
+        let extent = self.rule_extent(symbol, rule)?;
+
         // If the rule is a content rule, make sure that the content size matches the symbol size.
         if let config::Validation::Content { content } = &rule.validation {
-            let size = match &rule.field {
-                Some(field) => {
-                    let (_, size) = Symbol::find_field_offset_and_size(
-                        &self.pdb.type_information()?,
-                        &symbol.type_info.type_id().unwrap(),
-                        field,
-                        symbol.name(),
-                    )?;
-                    size
-                }
-                None => symbol.type_info.element_size(),
-            };
+            let size = extent.size;
 
             if content.len() != size as usize {
                 let name = if let Some(field) = &rule.field {
@@ -340,7 +429,7 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
             }
         }
 
-        let element_count = symbol.type_info.element_count();
+        let element_count = extent.count;
 
         if element_count == 1 && rule.array.is_some() {
             return Err(anyhow!(
@@ -591,6 +680,18 @@ pub struct Section {
     pub symbols: Vec<Symbol>,
 }
 
+/// What a rule iterates over, and how large each entry it produces is.
+struct RuleExtent {
+    /// Offset of the field within the symbol, or zero when the rule targets the symbol itself.
+    field_offset: u32,
+    /// Distance between consecutive entries.
+    stride: u32,
+    /// Size of each entry.
+    size: u32,
+    /// Number of entries the rule can produce.
+    count: usize,
+}
+
 #[derive(Debug, Clone)]
 pub struct Symbol {
     pub address: u32,
@@ -690,6 +791,20 @@ impl Symbol {
         attribute: &str,
         symbol: &str,
     ) -> Result<(u32, u32)> {
+        let (offset, type_info) = Self::find_field(info, id, attribute, symbol)?;
+        Ok((offset, type_info.total_size()))
+    }
+
+    /// Returns the offset of a field within its symbol, along with the type of the field.
+    ///
+    /// The type is returned rather than just a size so that a rule can tell an array field from a
+    /// single value and iterate its elements.
+    fn find_field(
+        info: &TypeInformation,
+        id: &TypeIndex,
+        attribute: &str,
+        symbol: &str,
+    ) -> Result<(u32, TypeInfo)> {
         Self::find_field_offset_and_size_at(info, id, attribute, symbol, 0)
     }
 
@@ -703,7 +818,7 @@ impl Symbol {
         attribute: &str,
         symbol: &str,
         depth: u32,
-    ) -> Result<(u32, u32)> {
+    ) -> Result<(u32, TypeInfo)> {
         const MAX_WRAPPER_DEPTH: u32 = 32;
 
         let mut parts = attribute.splitn(2, '.');
@@ -747,7 +862,7 @@ impl Symbol {
                         )?;
                         return Ok((member.offset as u32 + offset, size));
                     }
-                    let size = TypeInfo::from_type_index(info, member.field_type)?.total_size();
+                    let size = TypeInfo::from_type_index(info, member.field_type)?;
                     return Ok((member.offset as u32, size));
                 }
                 members.push((
@@ -1201,6 +1316,7 @@ mod test {
         let rule = Rule {
             symbol: "mMmSupvPoolLists".to_string(),
             array: Some(Array {
+                field: None,
                 sentinel: false,
                 index: Some(1usize..=2usize),
             }),
@@ -1257,6 +1373,7 @@ mod test {
             symbol: "mMmSupvPoolLists".to_string(),
             validation: config::Validation::None,
             array: Some(Array {
+                field: None,
                 sentinel: true,
                 index: None,
             }),
@@ -1511,12 +1628,13 @@ mod test {
     }
 
     #[test]
-    fn test_validate_rule_when_array_field_but_symbol_not_array() {
+    fn test_validate_rule_when_array_config_but_symbol_not_array() {
         let mut metadata = build_metadata();
 
         let rule = Rule {
             symbol: "mUnblockedMemoryList".to_string(),
             array: Some(Array {
+                field: None,
                 sentinel: false,
                 index: Some(1..=2),
             }),
@@ -1543,6 +1661,7 @@ mod test {
         let rule = Rule {
             symbol: "mReservedVectorsData".to_string(),
             array: Some(Array {
+                field: None,
                 sentinel: true,
                 index: Some(1..=2),
             }),
@@ -1569,6 +1688,7 @@ mod test {
         let rule = Rule {
             symbol: "mMmSupvPoolLists".to_string(),
             array: Some(Array {
+                field: None,
                 sentinel: false,
                 index: Some(99..=99),
             }),

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -651,7 +651,9 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
                         Some(idx) => format!("{}[{}].{}", uncovered.symbol(), idx, field),
                         None => format!("{}.{}", uncovered.symbol(), field),
                     };
-                    !report.segments(|s| s.symbol() == expected).is_empty()
+                    !report
+                        .segments(|s| field_name_matches(s.symbol(), &expected))
+                        .is_empty()
                 });
 
                 if covered {
@@ -672,6 +674,26 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
 
         Ok(ret)
     }
+}
+
+fn field_name_matches(actual: &str, expected: &str) -> bool {
+    if actual == expected {
+        return true;
+    }
+
+    let Some(indexed_field) = actual
+        .strip_prefix(expected)
+        .and_then(|suffix| suffix.strip_prefix('['))
+    else {
+        return false;
+    };
+    let Some((index, suffix)) = indexed_field.split_once(']') else {
+        return false;
+    };
+
+    !index.is_empty()
+        && index.bytes().all(|byte| byte.is_ascii_digit())
+        && (suffix.is_empty() || suffix.starts_with('.'))
 }
 
 pub struct Section {
@@ -1544,6 +1566,30 @@ mod test {
             metadata.create_padding_entries(&coverage).unwrap().len(),
             40
         );
+    }
+
+    #[test]
+    fn test_field_name_matches_indexed_array_field() {
+        let expected = "mStructure.ArrayField";
+
+        assert!(field_name_matches(expected, expected));
+        assert!(field_name_matches("mStructure.ArrayField[0]", expected));
+        assert!(field_name_matches(
+            "mStructure.ArrayField[12].Member",
+            expected
+        ));
+        assert!(!field_name_matches(
+            "mStructure.ArrayFieldOther[0].Member",
+            expected
+        ));
+        assert!(!field_name_matches(
+            "mStructure.ArrayField.Member",
+            expected
+        ));
+        assert!(!field_name_matches(
+            "mStructure.ArrayField[index].Member",
+            expected
+        ));
     }
 
     #[test]

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -171,16 +171,22 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
                 [entry.offset as usize..(entry.offset + entry.size) as usize]
                 .to_vec();
 
-            // The index belongs to whichever array the rule iterates: the array member named by
-            // `array.field`, or the symbol itself.
             let mut name = rule.symbol.clone();
-            match rule.array.as_ref().and_then(|array| array.field.as_deref()) {
-                Some(array_field) => name += format!(".{}[{}]", array_field, i).as_str(),
-                None if extent.count > 1 => name += format!("[{}]", i).as_str(),
-                None => {}
-            }
-            if let Some(field) = &rule.field {
-                name += format!(".{}", field).as_str();
+            if let Some(array) = &rule.array {
+                if let Some(field) = &rule.field {
+                    name += format!(".{}", field).as_str();
+                }
+                name += format!("[{}]", i).as_str();
+                if let Some(field) = &array.field {
+                    name += format!(".{}", field).as_str();
+                }
+            } else {
+                if extent.count > 1 {
+                    name += format!("[{}]", i).as_str();
+                }
+                if let Some(field) = &rule.field {
+                    name += format!(".{}", field).as_str();
+                }
             }
             self.context_map.insert(
                 entry.offset,
@@ -316,18 +322,27 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
 
     /// Returns what a rule iterates over, and how large each entry it produces is.
     ///
-    /// A rule produces one entry per element of the symbol, validating the same field within each.
-    /// A rule that names [config::Array::field] iterates that array member of the symbol instead,
-    /// so the elements of a nested array can be validated individually.
+    /// A rule with array configuration iterates either the array named by [config::Rule::field],
+    /// or the symbol itself when that field is unset. [config::Array::field] optionally selects a
+    /// field within each array element.
     fn rule_extent(&mut self, symbol: &Symbol, rule: &config::Rule) -> Result<RuleExtent> {
-        if let Some(array_field) = rule.array.as_ref().and_then(|array| array.field.as_deref()) {
-            return self.array_field_extent(symbol, array_field, rule.field.as_deref());
+        if let Some(array) = &rule.array {
+            return match rule.field.as_deref() {
+                Some(field) => self.field_array_extent(symbol, field, array.field.as_deref()),
+                None => self.symbol_extent(symbol, array.field.as_deref()),
+            };
         }
 
+        self.symbol_extent(symbol, rule.field.as_deref())
+    }
+
+    /// Returns the extent of a symbol, optionally selecting the same field in each element when
+    /// the symbol is an array.
+    fn symbol_extent(&mut self, symbol: &Symbol, field: Option<&str>) -> Result<RuleExtent> {
         let stride = symbol.type_info.element_size();
         let count = symbol.type_info.element_count();
 
-        let Some(field) = &rule.field else {
+        let Some(field) = field else {
             return Ok(RuleExtent {
                 field_offset: 0,
                 stride,
@@ -346,32 +361,30 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
         })
     }
 
-    /// Returns the extent of a rule that iterates an array member of its symbol.
+    /// Returns the extent of a rule that iterates the array named by `field` within its symbol.
     ///
-    /// `field`, when given, selects the same field within every element of that array. Without it
-    /// each entry covers a whole element.
-    fn array_field_extent(
+    /// `element_field`, when given, selects the same field within every element of that array.
+    /// Without it each entry covers a whole element.
+    fn field_array_extent(
         &mut self,
         symbol: &Symbol,
-        array_field: &str,
-        field: Option<&str>,
+        field: &str,
+        element_field: Option<&str>,
     ) -> Result<RuleExtent> {
-        // A single `index` cannot address two levels of array, so the symbol has to be the one
-        // value that holds the array being iterated.
         if symbol.type_info.element_count() > 1 {
             return Err(anyhow!(
-                "Invalid Rule Configuration: Symbol {}: `array.field` cannot be used because the symbol is itself an array.",
+                "Invalid Rule Configuration: Symbol {}: `field` cannot name an array because the symbol is itself an array.",
                 symbol.name()
             ));
         }
 
-        let (array_offset, array_type) = self.resolve_field(symbol, array_field)?;
+        let (array_offset, array_type) = self.resolve_field(symbol, field)?;
 
         if array_type.element_count() <= 1 {
             return Err(anyhow!(
-                "Invalid Rule Configuration: Symbol {}: `array.field` [{}] is not an array.",
+                "Invalid Rule Configuration: Symbol {}: `field` [{}] is not an array.",
                 symbol.name(),
-                array_field
+                field
             ));
         }
 
@@ -382,23 +395,22 @@ impl<'a, S: Source<'a> + 'a> PdbMetadata<'a, S> {
             count: array_type.element_count(),
         };
 
-        let Some(field) = field else {
+        let Some(element_field) = element_field else {
             return Ok(extent);
         };
 
-        // `TypeInfo` records an array as a repeat of its element type, so this is the type a field
-        // named alongside `array.field` is resolved against.
         let element_type = array_type.type_id().ok_or_else(|| {
             anyhow!(
                 "Array field [{}] of symbol [{}] has no element type information. Cannot resolve field [{}].",
-                array_field,
+                field,
                 symbol.name(),
-                field
+                element_field
             )
         })?;
 
         let info = self.pdb.type_information()?;
-        let (offset, field_type) = Symbol::find_field(&info, &element_type, field, symbol.name())?;
+        let (offset, field_type) =
+            Symbol::find_field(&info, &element_type, element_field, symbol.name())?;
 
         Ok(RuleExtent {
             field_offset: array_offset + offset,
@@ -1350,6 +1362,72 @@ mod test {
             .unwrap_or_else(|e| panic!("Failed to build entries: [{}]", e));
 
         assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn test_build_entries_with_array_element_field() {
+        let mut metadata = build_metadata();
+
+        let rule = Rule {
+            symbol: "mMmSupvPoolLists".to_string(),
+            array: Some(Array {
+                field: Some("ForwardLink".to_string()),
+                index: Some(1usize..=2usize),
+                ..Default::default()
+            }),
+            validation: config::Validation::None,
+            ..Default::default()
+        };
+
+        let entries = metadata
+            .build_entries(&rule)
+            .expect("array element field should produce entries");
+
+        assert_eq!(entries.len(), 2);
+        assert!(entries
+            .iter()
+            .all(|entry| entry.0.size == POINTER_LENGTH as u32));
+        assert_eq!(
+            metadata
+                .context_from_address(&entries[0].0.offset)
+                .unwrap()
+                .name,
+            "mMmSupvPoolLists[1].ForwardLink"
+        );
+    }
+
+    #[test]
+    fn test_build_entries_with_nested_array_element_field() {
+        let mut metadata = build_metadata();
+        let symbol_address = metadata.find_symbol("gSmiMtrrs").address;
+
+        let rule = Rule {
+            symbol: "gSmiMtrrs".to_string(),
+            field: Some("Variables.Mtrr".to_string()),
+            array: Some(Array {
+                field: Some("Mask".to_string()),
+                index: Some(1usize..=2usize),
+                ..Default::default()
+            }),
+            validation: config::Validation::None,
+            ..Default::default()
+        };
+
+        let entries = metadata
+            .build_entries(&rule)
+            .expect("nested array element field should produce entries");
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0.offset, symbol_address + 0x70);
+        assert_eq!(entries[1].0.offset, symbol_address + 0x80);
+        assert!(entries.iter().all(|entry| entry.0.size == 8));
+        assert_eq!(
+            metadata
+                .context_from_address(&entries[0].0.offset)
+                .unwrap()
+                .name,
+            "gSmiMtrrs.Variables.Mtrr[1].Mask"
+        );
     }
 
     #[test]

--- a/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
+++ b/SeaPkg/Tools/GenSeaArtifacts/gen_aux/src/metadata.rs
@@ -1316,9 +1316,8 @@ mod test {
         let rule = Rule {
             symbol: "mMmSupvPoolLists".to_string(),
             array: Some(Array {
-                field: None,
-                sentinel: false,
                 index: Some(1usize..=2usize),
+                ..Default::default()
             }),
             validation: config::Validation::None,
             ..Default::default()
@@ -1373,9 +1372,8 @@ mod test {
             symbol: "mMmSupvPoolLists".to_string(),
             validation: config::Validation::None,
             array: Some(Array {
-                field: None,
                 sentinel: true,
-                index: None,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -1634,9 +1632,8 @@ mod test {
         let rule = Rule {
             symbol: "mUnblockedMemoryList".to_string(),
             array: Some(Array {
-                field: None,
-                sentinel: false,
                 index: Some(1..=2),
+                ..Default::default()
             }),
             validation: config::Validation::Content {
                 content: vec![0x0; 16],
@@ -1661,9 +1658,9 @@ mod test {
         let rule = Rule {
             symbol: "mReservedVectorsData".to_string(),
             array: Some(Array {
-                field: None,
                 sentinel: true,
                 index: Some(1..=2),
+                ..Default::default()
             }),
             validation: config::Validation::Content {
                 content: vec![0x0; 96],
@@ -1688,9 +1685,8 @@ mod test {
         let rule = Rule {
             symbol: "mMmSupvPoolLists".to_string(),
             array: Some(Array {
-                field: None,
-                sentinel: false,
                 index: Some(99..=99),
+                ..Default::default()
             }),
             validation: config::Validation::Content {
                 content: vec![0x0; 16],


### PR DESCRIPTION
## Description

Added an `array.field` to indicate the element name inside an array field. The original `field` is now used as the path to descend to the intended field in the structure.

The new `array.field` can be used in combination with the `array.index` to apply rules to specific fields inside an array.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested against the rust based supervisor and resolved all symbols inside the static variable.

## Integration Instructions

One could specify the following to validate the `entries` array inside IDT symbol, and ensures all the `offset_low` fields in each array element is not zero:

```
[[rule]]
symbol = "patina_internal_cpu::interrupts::x64::idt::IDT"
array.field = 'entries'
array.index = [0, 31]
field = 'offset_low'
validation.type = "non zero"
```