### PR TITLE
[sea] Fix a logic flaw in the memory attribute validation

### DIFF
--- a/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
+++ b/SeaPkg/Library/BasePeCoffValidationLib/BasePeCoffValidationLib.c
@@ -516,7 +516,7 @@ PeCoffImageValidationMemAttr (
   }
 
   // Check if the memory attributes of the target image meet the requirements
-  if (((MemAttr & MemAttrHdr->TargetMemoryAttributeMustHave) != MemAttrHdr->TargetMemoryAttributeMustHave) &&
+  if (((MemAttr & MemAttrHdr->TargetMemoryAttributeMustHave) != MemAttrHdr->TargetMemoryAttributeMustHave) ||
       ((MemAttr & MemAttrHdr->TargetMemoryAttributeMustNotHave) != 0))
   {
     DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%p: 0x%x attribute 0x%x violated aux file specification must have 0x%x and must not have 0x%x\n", __func__, Hdr, Hdr->Size, MemAttr, MemAttrHdr->TargetMemoryAttributeMustHave, MemAttrHdr->TargetMemoryAttributeMustNotHave));


### PR DESCRIPTION
## Description

The current memory attributes validation has a logic error, where it requires both the must have and must not have conditions to fail before failing the entire check.

This change fixes the gap by failing the check when either "must have" or "must not have" condition fails.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested locally and passed SEA validation and reaches level 30.

## Integration Instructions

N/A
