### PR TITLE
[sea] Fix MSEG memory attribute validation

### DIFF
--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -854,7 +854,10 @@ PeCoffImageDiffValidation (
   MsegMemAttr.TargetMemoryAttributeMustHave    = SEA_MSEG_ATTRIBUTE;
   MsegMemAttr.TargetMemoryAttributeMustNotHave = 0;
   MsegMemAttr.TargetMemorySize                 = MsegSize;
-  Status                                       = PeCoffImageValidationMemAttr (&MsegBase, &(MsegMemAttr.Header), PageTableBase);
+
+  // Here we basically treats the MsegBase as the target image. Because the validation function reaches into
+  // the "target image buffer" to validate the _content_ at "the target address + offset".
+  Status  = PeCoffImageValidationMemAttr (&MsegBase, &(MsegMemAttr.Header), PageTableBase);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to validate MSEG memory attributes - %r\n", __func__, Status));
     return Status;

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -854,7 +854,7 @@ PeCoffImageDiffValidation (
   MsegMemAttr.TargetMemoryAttributeMustHave    = SEA_MSEG_ATTRIBUTE;
   MsegMemAttr.TargetMemoryAttributeMustNotHave = 0;
   MsegMemAttr.TargetMemorySize                 = MsegSize;
-  Status                                       = PeCoffImageValidationMemAttr ((VOID *)MsegBase, &(MsegMemAttr.Header), PageTableBase);
+  Status                                       = PeCoffImageValidationMemAttr (&MsegBase, &(MsegMemAttr.Header), PageTableBase);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to validate MSEG memory attributes - %r\n", __func__, Status));
     return Status;

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -857,7 +857,7 @@ PeCoffImageDiffValidation (
 
   // Here we basically treats the MsegBase as the target image. Because the validation function reaches into
   // the "target image buffer" to validate the _content_ at "the target address + offset".
-  Status  = PeCoffImageValidationMemAttr (&MsegBase, &(MsegMemAttr.Header), PageTableBase);
+  Status = PeCoffImageValidationMemAttr (&MsegBase, &(MsegMemAttr.Header), PageTableBase);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to validate MSEG memory attributes - %r\n", __func__, Status));
     return Status;


### PR DESCRIPTION
## Description

After the fix from #680, the SEA validation exposed an issue where the MSEG region memory attribute is not properly set up.

This change fixed up the call site and properly used the `PeCoffImageValidationMemAttr` function.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change is tested on QEMU Q35 and passed local SEA validation.

## Integration Instructions

N/A