### PR TITLE
MmSupervisorPkg: Harden relocation memory initialization

### DIFF
--- a/MmSupervisorPkg/Core/Relocate/Relocate.c
+++ b/MmSupervisorPkg/Core/Relocate/Relocate.c
@@ -388,7 +388,7 @@ GetSmBase (
     GuidHob                = GetNextGuidHob (&gSmmBaseHobGuid, GET_NEXT_HOB (GuidHob));
   }
 
-  SmBaseBuffer = (UINTN *)AllocatePool (sizeof (UINTN) * (MaxNumberOfCpus));
+  SmBaseBuffer = (UINTN *)AllocatePages (EFI_SIZE_TO_PAGES (sizeof (UINTN) * (MaxNumberOfCpus)));
   ASSERT (SmBaseBuffer != NULL);
   if (SmBaseBuffer == NULL) {
     FreePool (SmBaseHobs);

--- a/MmSupervisorPkg/Core/Relocate/Relocate_init.c
+++ b/MmSupervisorPkg/Core/Relocate/Relocate_init.c
@@ -452,6 +452,7 @@ SetupSmiEntryExit (
 
   Stacks = (UINT8 *)AllocatePages (gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus * (EFI_SIZE_TO_PAGES (mSmmStackSize + mSmmShadowStackSize)));
   ASSERT (Stacks != NULL);
+  ZeroMem (Stacks, gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus * (mSmmStackSize + mSmmShadowStackSize));
   mSmmStackArrayBase = (UINTN)Stacks;
   mSmmStackArrayEnd  = mSmmStackArrayBase + gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus * (mSmmStackSize + mSmmShadowStackSize) - 1;
 


### PR DESCRIPTION
## Description

MmSupervisorPkg: Harden relocation memory initialization

Allocate the SMBASE buffer from page backed memory(for SEA validations)
and zero the per CPU SMI stack allocation before use.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated on hardware platform.

## Integration Instructions

NA