### PR TITLE
[SEA] Add PCD to report all image validation violations before dumping the image

### DIFF
--- a/SeaPkg/Core/Init/StmInit.h
+++ b/SeaPkg/Core/Init/StmInit.h
@@ -41,7 +41,7 @@ extern SEA_HOST_CONTEXT_COMMON  mHostContextCommon;
       }                            \
     } while (FALSE)
 #else
-#define DEBUG(Expression)
+#define SAFE_DEBUG(Expression)
 #endif
 
 /**

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -816,6 +816,8 @@ PeCoffImageDiffValidation (
   IMAGE_VALIDATION_ENTRY_HEADER  *NextImageValidationEntryHdr;
   UINTN                          Index;
   EFI_STATUS                     Status;
+  EFI_STATUS                     FinalStatus;
+  UINTN                          ViolationCount;
   EFI_PHYSICAL_ADDRESS           MsegBase;
   UINTN                          MsegSize;
   IMAGE_VALIDATION_MEM_ATTR      MsegMemAttr;
@@ -863,18 +865,25 @@ PeCoffImageDiffValidation (
     return Status;
   }
 
+  FinalStatus              = EFI_SUCCESS;
+  ViolationCount           = 0;
   ImageValidationEntryHdr  = (IMAGE_VALIDATION_ENTRY_HEADER *)((UINTN)ImageValidationHdr + ImageValidationHdr->OffsetToFirstEntry);
   OriginalImageLoadAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)(UINT8 *)OriginalImageBaseAddress;
   for (Index = 0; Index < ImageValidationHdr->EntryCount; Index++) {
     // TODO: Safe integer arithmetic
     if ((UINT8 *)(ImageValidationEntryHdr) >= ((UINT8 *)ImageValidationHdr + ImageValidationHdr->Size)) {
       DEBUG ((DEBUG_ERROR, "%a: Current header 0x%p exceeds the reference data limit 0x%x\n", __func__, ImageValidationEntryHdr, (UINT8 *)ImageValidationHdr + ImageValidationHdr->Size));
-      return EFI_COMPROMISED_DATA;
+      ViolationCount++;
+      FinalStatus = EFI_COMPROMISED_DATA;
+      // The entry stream cannot be parsed any further.
+      break;
     }
 
     if (ImageValidationEntryHdr->Offset + ImageValidationEntryHdr->Size > TargetImageSize) {
       DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%x exceeds target image limit 0x%x\n", __func__, ImageValidationEntryHdr->Offset + ImageValidationEntryHdr->Size, TargetImageSize));
-      return EFI_INVALID_PARAMETER;
+      ViolationCount++;
+      FinalStatus = EFI_INVALID_PARAMETER;
+      break;
     }
 
     // Ensure this entry's default value does not overflow the Auxiliary file buffer.
@@ -887,16 +896,10 @@ PeCoffImageDiffValidation (
         ImageValidationEntryHdr->OffsetToDefault + ImageValidationEntryHdr->Size,
         ImageValidationHdr->Size
         ));
-      return EFI_COMPROMISED_DATA;
+      ViolationCount++;
+      FinalStatus = EFI_COMPROMISED_DATA;
+      break;
     }
-
-    DEBUG ((
-      DEBUG_INFO,
-      "%a: Evaluating symbol at offset: 0x%x in the target image with rule type: 0x%x\n",
-      __func__,
-      ImageValidationEntryHdr->Offset,
-      ImageValidationEntryHdr->ValidationType
-      ));
 
     // All validation has been updated to reference the original image.  PeCoffLoaderRevertRelocateImage will
     // touch up various parts of the image that will include some pointers causing parts of the TargetImage to
@@ -928,7 +931,9 @@ PeCoffImageDiffValidation (
         break;
       default:
         Status = EFI_INVALID_PARAMETER;
-        // Does not support unknown validation type
+        // Does not support unknown validation type, the size of this entry is unknown so the
+        // location of the next entry cannot be computed.
+        NextImageValidationEntryHdr = NULL;
         DEBUG ((
           DEBUG_ERROR,
           "%a: Entry validation type not supported 0x%x\n",
@@ -939,25 +944,45 @@ PeCoffImageDiffValidation (
     }
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "Validation Error! Dumping Info...\n"));
-      DEBUG ((DEBUG_ERROR, "  MsegBase = \"0x%p\"\n", MsegBase));
-      DEBUG ((DEBUG_ERROR, "  MsegSize = \"0x%x\"\n", MsegSize));
-      DEBUG ((DEBUG_ERROR, "  MmSupervisorBase = \"0x%x\"\n", OriginalImageLoadAddress));
-      DEBUG ((DEBUG_ERROR, "  MmSupervisor:\n"));
-      DUMP_HEX (DEBUG_ERROR, 0, OriginalImageBaseAddress, TargetImageSize, "    ");
-      break;
-    }
+      ViolationCount++;
+      if (!EFI_ERROR (FinalStatus)) {
+        FinalStatus = Status;
+      }
 
-    // We should not do this when the above validation fails
-    if (ImageValidationEntryHdr->OffsetToDefault == MAX_UINT32) {
-      // If OffsetToDefault is MAX_UINT32, then zero the memory rather that copy
-      ZeroMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryHdr->Size);
+      DEBUG ((
+        DEBUG_ERROR,
+        "Validation Error #%d! Entry index: 0x%x offset: 0x%x rule type: 0x%x - %r\n",
+        ViolationCount,
+        Index,
+        ImageValidationEntryHdr->Offset,
+        ImageValidationEntryHdr->ValidationType,
+        Status
+        ));
+
+      if (NextImageValidationEntryHdr == NULL) {
+        break;
+      }
     } else {
-      CopyMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, (UINT8 *)ImageValidationHdr + ImageValidationEntryHdr->OffsetToDefault, ImageValidationEntryHdr->Size);
+      // We should not do this when the above validation fails
+      if (ImageValidationEntryHdr->OffsetToDefault == MAX_UINT32) {
+        // If OffsetToDefault is MAX_UINT32, then zero the memory rather that copy
+        ZeroMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, ImageValidationEntryHdr->Size);
+      } else {
+        CopyMem ((UINT8 *)TargetImage + ImageValidationEntryHdr->Offset, (UINT8 *)ImageValidationHdr + ImageValidationEntryHdr->OffsetToDefault, ImageValidationEntryHdr->Size);
+      }
     }
 
     ImageValidationEntryHdr = NextImageValidationEntryHdr;
   }
 
-  return Status;
+  if (EFI_ERROR (FinalStatus)) {
+    DEBUG ((DEBUG_ERROR, "Validation Error! %d violation(s) detected. Dumping Info...\n", ViolationCount));
+    DEBUG ((DEBUG_ERROR, "  MsegBase = \"0x%p\"\n", MsegBase));
+    DEBUG ((DEBUG_ERROR, "  MsegSize = \"0x%x\"\n", MsegSize));
+    DEBUG ((DEBUG_ERROR, "  MmSupervisorBase = \"0x%x\"\n", OriginalImageLoadAddress));
+    DEBUG ((DEBUG_ERROR, "  MmSupervisor:\n"));
+    DUMP_HEX (DEBUG_ERROR, 0, OriginalImageBaseAddress, TargetImageSize, "    ");
+  }
+
+  return FinalStatus;
 }

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.c
@@ -35,6 +35,7 @@
 #include <Library/SafeIntLib.h>
 #include <Library/PeCoffValidationLib.h>
 #include <Library/PeCoffLibNegative.h>
+#include <Library/PcdLib.h>
 #include <IndustryStandard/PeImage.h>
 #include <Register/Intel/ArchitecturalMsr.h>
 #include <Register/Intel/Cpuid.h>
@@ -816,7 +817,7 @@ PeCoffImageDiffValidation (
   IMAGE_VALIDATION_ENTRY_HEADER  *NextImageValidationEntryHdr;
   UINTN                          Index;
   EFI_STATUS                     Status;
-  EFI_STATUS                     FinalStatus;
+  EFI_STATUS                     FirstErrorStatus;
   UINTN                          ViolationCount;
   EFI_PHYSICAL_ADDRESS           MsegBase;
   UINTN                          MsegSize;
@@ -865,7 +866,7 @@ PeCoffImageDiffValidation (
     return Status;
   }
 
-  FinalStatus              = EFI_SUCCESS;
+  FirstErrorStatus         = EFI_SUCCESS;
   ViolationCount           = 0;
   ImageValidationEntryHdr  = (IMAGE_VALIDATION_ENTRY_HEADER *)((UINTN)ImageValidationHdr + ImageValidationHdr->OffsetToFirstEntry);
   OriginalImageLoadAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)(UINT8 *)OriginalImageBaseAddress;
@@ -874,7 +875,10 @@ PeCoffImageDiffValidation (
     if ((UINT8 *)(ImageValidationEntryHdr) >= ((UINT8 *)ImageValidationHdr + ImageValidationHdr->Size)) {
       DEBUG ((DEBUG_ERROR, "%a: Current header 0x%p exceeds the reference data limit 0x%x\n", __func__, ImageValidationEntryHdr, (UINT8 *)ImageValidationHdr + ImageValidationHdr->Size));
       ViolationCount++;
-      FinalStatus = EFI_COMPROMISED_DATA;
+      if (!EFI_ERROR (FirstErrorStatus)) {
+        FirstErrorStatus = EFI_COMPROMISED_DATA;
+      }
+
       // The entry stream cannot be parsed any further.
       break;
     }
@@ -882,7 +886,10 @@ PeCoffImageDiffValidation (
     if (ImageValidationEntryHdr->Offset + ImageValidationEntryHdr->Size > TargetImageSize) {
       DEBUG ((DEBUG_ERROR, "%a: Current entry range 0x%x exceeds target image limit 0x%x\n", __func__, ImageValidationEntryHdr->Offset + ImageValidationEntryHdr->Size, TargetImageSize));
       ViolationCount++;
-      FinalStatus = EFI_INVALID_PARAMETER;
+      if (!EFI_ERROR (FirstErrorStatus)) {
+        FirstErrorStatus = EFI_INVALID_PARAMETER;
+      }
+
       break;
     }
 
@@ -897,9 +904,20 @@ PeCoffImageDiffValidation (
         ImageValidationHdr->Size
         ));
       ViolationCount++;
-      FinalStatus = EFI_COMPROMISED_DATA;
+      if (!EFI_ERROR (FirstErrorStatus)) {
+        FirstErrorStatus = EFI_COMPROMISED_DATA;
+      }
+
       break;
     }
+
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "%a: Evaluating symbol at offset: 0x%x in the target image with rule type: 0x%x\n",
+      __func__,
+      ImageValidationEntryHdr->Offset,
+      ImageValidationEntryHdr->ValidationType
+      ));
 
     // All validation has been updated to reference the original image.  PeCoffLoaderRevertRelocateImage will
     // touch up various parts of the image that will include some pointers causing parts of the TargetImage to
@@ -945,13 +963,13 @@ PeCoffImageDiffValidation (
 
     if (EFI_ERROR (Status)) {
       ViolationCount++;
-      if (!EFI_ERROR (FinalStatus)) {
-        FinalStatus = Status;
+      if (!EFI_ERROR (FirstErrorStatus)) {
+        FirstErrorStatus = Status;
       }
 
       DEBUG ((
         DEBUG_ERROR,
-        "Validation Error #%d! Entry index: 0x%x offset: 0x%x rule type: 0x%x - %r\n",
+        "Validation Error #%Ld! Entry index: 0x%Lx offset: 0x%x rule type: 0x%x - %r\n",
         ViolationCount,
         Index,
         ImageValidationEntryHdr->Offset,
@@ -960,6 +978,10 @@ PeCoffImageDiffValidation (
         ));
 
       if (NextImageValidationEntryHdr == NULL) {
+        break;
+      }
+
+      if (FeaturePcdGet (PcdImageValidationFailFast)) {
         break;
       }
     } else {
@@ -975,8 +997,8 @@ PeCoffImageDiffValidation (
     ImageValidationEntryHdr = NextImageValidationEntryHdr;
   }
 
-  if (EFI_ERROR (FinalStatus)) {
-    DEBUG ((DEBUG_ERROR, "Validation Error! %d violation(s) detected. Dumping Info...\n", ViolationCount));
+  if (EFI_ERROR (FirstErrorStatus)) {
+    DEBUG ((DEBUG_ERROR, "Validation Error! %Ld violation(s) detected. Dumping Info...\n", ViolationCount));
     DEBUG ((DEBUG_ERROR, "  MsegBase = \"0x%p\"\n", MsegBase));
     DEBUG ((DEBUG_ERROR, "  MsegSize = \"0x%x\"\n", MsegSize));
     DEBUG ((DEBUG_ERROR, "  MmSupervisorBase = \"0x%x\"\n", OriginalImageLoadAddress));
@@ -984,5 +1006,5 @@ PeCoffImageDiffValidation (
     DUMP_HEX (DEBUG_ERROR, 0, OriginalImageBaseAddress, TargetImageSize, "    ");
   }
 
-  return FinalStatus;
+  return FirstErrorStatus;
 }

--- a/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf
+++ b/SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf
@@ -53,4 +53,8 @@
   PeCoffExtraActionLib
   PeCoffValidationLib
   BaseMemoryLib
+  PcdLib
+
+[FeaturePcd]
+  gEfiSeaPkgTokenSpaceGuid.PcdImageValidationFailFast   ## CONSUMES
 

--- a/SeaPkg/SeaPkg.dec
+++ b/SeaPkg/SeaPkg.dec
@@ -57,6 +57,15 @@
   # The SHA256 hash of the MM supervisor core EFI binary file
   gEfiSeaPkgTokenSpaceGuid.PcdMmSupervisorCoreHash|{0x0}|VOID*|0x00000004
 
+[PcdsFeatureFlag]
+  # Controls how image validation reacts to a failing rule.
+  #
+  # When TRUE, validation stops at the first violation, which is the behavior
+  # wanted in production. When FALSE, validation keeps walking the remaining
+  # rules so that a single boot reports every violation, which is only useful
+  # while authoring or repairing an auxiliary file.
+  gEfiSeaPkgTokenSpaceGuid.PcdImageValidationFailFast|TRUE|BOOLEAN|0x00000005
+
 [Ppis]
   ## MSEG Identified PPI
   #


### PR DESCRIPTION
## Description

`PeCoffImageDiffValidation` stopped at the first failing entry, which requires
revising a new sea package and a new boot cycle to discover each subsequent
violation. This is especially tedious to do for memory attribute failures (which
cannot be validated by offline tool).  Accumulate the failures instead: log
every violating entry with its index, offset and rule type, keep walking the
entry list, and emit the MSEG info and image hex dump once at the end. Parsing
still stops early on an unknown rule type or a structural bounds failure since
the next entry location cannot be computed.

Based on the feedback, Added a `PcdImageValidationFailFast` to make this behavior 
an opt in for Debug builds by the consumer. For release builds and the default being
TRUE for the PCD, the first error will bailout from further validations.

Other minor typo related to `SAFE_DEBUG` macro where it is not defined for the `#else` case. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated on hardware platform

## Integration Instructions

NA