### PR TITLE
[Rebase & FF] MmSupervisorPkg: Update override hash from latest mu_basecore release/202511

### DIFF
--- a/MmSupervisorPkg/Core/Dispatcher/Dependency.c
+++ b/MmSupervisorPkg/Core/Dispatcher/Dependency.c
@@ -182,12 +182,10 @@ MmIsSchedulable (
 
   if (DriverEntry->Depex == NULL) {
     //
-    // A NULL Depex means that the MM driver is not built correctly.
-    // All MM drivers must have a valid depex expression.
+    // If there is no DEPEX, assume the module can be executed
     //
-    DEBUG ((DEBUG_DISPATCH, "  RESULT = FALSE (Depex is empty)\n"));
-    ASSERT (FALSE);
-    return FALSE;
+    DEBUG ((DEBUG_DISPATCH, "  RESULT = TRUE (No DEPEX)\n"));
+    return TRUE;
   }
 
   //
@@ -222,6 +220,7 @@ MmIsSchedulable (
         //
         DEBUG ((DEBUG_DISPATCH, "  RESULT = FALSE (Unexpected BEFORE or AFTER opcode)\n"));
         ASSERT (FALSE);
+        return FALSE;
 
       case EFI_DEP_PUSH:
         //

--- a/MmSupervisorPkg/Core/Dispatcher/Dispatcher.c
+++ b/MmSupervisorPkg/Core/Dispatcher/Dispatcher.c
@@ -375,9 +375,6 @@ MmGetDepexSectionAndPreProccess (
       //
       DriverEntry->DepexProtocolError = TRUE;
     } else {
-      //
-      // If no Depex assume depend on all architectural protocols
-      //
       DriverEntry->Depex              = NULL;
       DriverEntry->Dependent          = TRUE;
       DriverEntry->DepexProtocolError = FALSE;
@@ -787,8 +784,14 @@ MmAddToDriverList (
   DriverEntry->Pe32DataSize = Pe32DataSize;
   DriverEntry->DepexSize    = DepexSize;
 
-  DriverEntry->Depex = AllocateCopyPool (DepexSize, Depex);
-  ASSERT (DriverEntry->Depex != NULL);
+  //
+  // Depex is NULL for a module without an MM DEPEX section. AllocateZeroPool
+  // above already left DriverEntry->Depex NULL for that case.
+  //
+  if (Depex != NULL) {
+    DriverEntry->Depex = AllocateCopyPool (DepexSize, Depex);
+    ASSERT (DriverEntry->Depex != NULL);
+  }
 
   MmGetDepexSectionAndPreProccess (DriverEntry);
 

--- a/MmSupervisorPkg/Core/FwVol/FwVol.c
+++ b/MmSupervisorPkg/Core/FwVol/FwVol.c
@@ -145,7 +145,13 @@ Returns:
       Status          = FfsFindSectionData (EFI_SECTION_PE32, InnerFileHeader, &Pe32Data, &Pe32DataSize);
       DEBUG ((DEBUG_INFO, "Find PE data - 0x%x\n", Pe32Data));
       DepexStatus = FfsFindSectionData (EFI_SECTION_MM_DEPEX, InnerFileHeader, &Depex, &DepexSize);
-      if (!EFI_ERROR (DepexStatus)) {
+      if (DepexStatus == EFI_NOT_FOUND) {
+        // FfsFindSectionData does not set DepexSize when the section is absent.
+        Depex     = NULL;
+        DepexSize = 0;
+      }
+
+      if (!EFI_ERROR (Status)) {
         // Set the FV header to be NULL here since the original header will not be available anyway.
         MmAddToDriverList (NULL, Pe32Data, Pe32DataSize, Depex, DepexSize, &InnerFileHeader->Name);
       }

--- a/MmSupervisorPkg/Core/MmSupervisorCore.inf
+++ b/MmSupervisorPkg/Core/MmSupervisorCore.inf
@@ -11,9 +11,9 @@
 ##
 
 # release/202511 (Non Secure)
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 567c67d760b57fc036b0dae53c77f700 | 2026-08-22T00-06-08 | ad2e52e130d77544d9461913ce69983b22410559
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 3956b3bf91e0fb0acbb39e88df240816 | 2026-09-02T19-27-12 | a5197f87e628b31215ef10a64b9cc1962169ad35
 # release/202511 (Secure)
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 567c67d760b57fc036b0dae53c77f700 | 2026-08-22T00-24-26 | 65fa6f67751c273bc8312513dfb223f296e558ed
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 3956b3bf91e0fb0acbb39e88df240816 | 2026-09-02T19-24-35 | 765de7129b9ca8672842900da24aec20ce6bb93c
 
 # release/202502 (Non Secure)
 #Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | c80945fbcea5c11226d4f179c83292f2 | 2026-03-23T19-21-41 | 40548b12d821a8bce209f8b5559c3b230b226d50

--- a/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
+++ b/MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
@@ -11,9 +11,9 @@
 # This module contains an instance of protocol/handle from StandaloneMmCore and pool memory + guard management from PiSmmCore.
 
 # release/202511 (Non Secure)
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 567c67d760b57fc036b0dae53c77f700 | 2026-08-22T00-06-08 | ad2e52e130d77544d9461913ce69983b22410559
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 3956b3bf91e0fb0acbb39e88df240816 | 2026-09-02T19-27-12 | a5197f87e628b31215ef10a64b9cc1962169ad35
 # release/202511 (Secure)
-#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 567c67d760b57fc036b0dae53c77f700 | 2026-08-22T00-24-26 | 65fa6f67751c273bc8312513dfb223f296e558ed
+#Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | 3956b3bf91e0fb0acbb39e88df240816 | 2026-09-02T19-24-35 | 765de7129b9ca8672842900da24aec20ce6bb93c
 
 # release/202502 (Non Secure)
 #Track : 00000002 | StandaloneMmPkg/Core/StandaloneMmCore.inf | c80945fbcea5c11226d4f179c83292f2 | 2026-03-23T19-21-41 | 40548b12d821a8bce209f8b5559c3b230b226d50


### PR DESCRIPTION
## Description

MmSupervisorCore: Update override hash from latest mu_basecore release/202511

Upstream StanadloneMmPkg changes:
```
749910060f48 StandaloneMmPkg Core: Check PE section finding status
04afff14ebbd StandaloneMmPkg Core: Treat no DEPEX as TRUE
12f8ff0fac4d StandaloneMmPkg/Core: Return when processing malformed DEPEX [Trivial]
```
Additional fix for 1, due to 2 with a NULL Depex now reachable,
MmAddToDriverList no longer calls AllocateCopyPool unconditionally.

Track tags for StandaloneMmCore.inf are refreshed to the release/202511.
This is needed for CI build to pass on main and https://github.com/microsoft/mu_feature_mm_supv/pull/684. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted on physical platform. Level 30 validation needs few rules related change in the sea releases.

## Integration Instructions

NA