### PR TITLE
MmSupervisorPkg: Zero relocated mailbox status pages before publishing

### DIFF
--- a/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
+++ b/MmSupervisorPkg/Drivers/MmPeiLaunchers/MmDxeSupport.c
@@ -468,6 +468,9 @@ UpdateDxeCommunicateBuffer (
     goto Done;
   }
 
+  ZeroMem (NewMmCommSupvBufferStatus, sizeof (MM_COMM_BUFFER_STATUS));
+  ZeroMem (NewMmCommUserBufferStatus, sizeof (MM_COMM_BUFFER_STATUS));
+
   mCommunicateHeader = (EFI_SMM_COMMUNICATE_HEADER *)mMmSupvCommonBuffer;
 
   // The size of supervisor communication buffer should be much larger than this value below


### PR DESCRIPTION
## Description

MmSupervisorPkg: Zero relocated mailbox status pages before publishing

UpdateDxeCommunicateBuffer() allocates the new supervisor and user status
pages with AllocateAlignedRuntimePages(), which does not zero memory, then
hands their addresses to MM in the COMM_UPDATE request while they still
hold indeterminate data.

Nothing initializes the new user page: ProcessUpdateCommBufferRequest()
only repoints the mailbox pointers, and MmEntryPoint() cleanup writes just
the supervisor page since the relocation SMI arrives on that channel.

IsCommBufferValid is a BOOLEAN, so any nonzero byte reads true, and
MmEntryPoint() tests the user channel first. A garbage byte therefore
routes the next supervisor request into the user path, where the
uninitialized user buffer yields a bogus MessageLength and trips the size
guard:

  Using Supervisor Communicate Buffer - 950CB000, 950CB000, 40
  MmEntryPoint Input buffer size is larger than maximal allowed user buffer size...
  ASSERT MmSupervisorCore.c(604)

A 0x40-byte supervisor send cannot exceed the user buffer limit, so the
user path was entered spuriously.

Zero both status structures after the allocation NULL checks and before
publishing their addresses. The supervisor page is included because it is
currently initialized only as a side effect of the cleanup branch taken.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated on TGL

## Integration Instructions

NA